### PR TITLE
Add Church history, Apostles, May 3 Gospel commentary, and reworked Church Divisions

### DIFF
--- a/src/app/commentary/page.tsx
+++ b/src/app/commentary/page.tsx
@@ -22,6 +22,85 @@ interface GospelEntry {
 
 const gospelEntries: GospelEntry[] = [
   {
+    id: '2026-05-03',
+    date: 'May 3, 2026',
+    sundayName: '5th Sunday of Easter — The New Commandment',
+    liturgicalYear: 'Year C',
+    gospelRef: 'John 13:31-33a, 34-35',
+    gospelText: `When Judas had left them, Jesus said, "Now is the Son of Man glorified, and God is glorified in him. If God is glorified in him, God will also glorify him in himself, and God will glorify him at once. My children, I will be with you only a little while longer.
+
+I give you a new commandment: love one another. As I have loved you, so you also should love one another. This is how all will know that you are my disciples, if you have love for one another."`,
+    firstReading: `Acts 14:21-27 — Paul and Barnabas return to Antioch, reporting how God "had opened the door of faith to the Gentiles."`,
+    psalm: `Psalm 145 — "I will praise your name forever, my king and my God."`,
+    secondReading: `Revelation 21:1-5a — "Behold, I make all things new." A new heaven and a new earth; the heavenly Jerusalem coming down from God.`,
+    context: `Today's Gospel takes us back to the night before Jesus died. The Fifth Sunday of Easter pivots from the Resurrection appearances of the previous weeks to the Last Supper Farewell Discourse (John 13-17), the long, intimate teaching Jesus gave his disciples on the eve of his Passion. The Church places this discourse in the Easter season because the new commandment, the promise of the Spirit, and the prayer for unity are all the lived fruit of the Resurrection — the way the Risen Christ continues to dwell in his disciples.
+
+The setting is heavy with foreboding. Judas has just left the upper room (John 13:30) to set the betrayal in motion, and John pointedly remarks, "And it was night." It is precisely at that moment, with the door closing on Judas and the cross now in motion, that Jesus says, "Now is the Son of Man glorified." In John, "glorification" is shorthand for the cross — the lifting up that paradoxically reveals God's love. The new commandment is given inside this hour.
+
+John's account of the Last Supper differs from the Synoptic Gospels in a striking way: John records no institution narrative of the Eucharist (the bread and cup) but instead describes the foot-washing (John 13:1-20). Most scholars see these as complementary rather than contradictory — John presupposes the eucharistic tradition his community already knew (cf. John 6) and uses the foot-washing to interpret what the Eucharist means: self-emptying love, the Master who serves. The final form of the Fourth Gospel is generally dated around AD 90-100, but it incorporates earlier eyewitness traditions traceable, as Raymond E. Brown and Richard Bauckham have argued, to the disciple "whom Jesus loved" and the Johannine community's living memory of his teaching.
+
+The historicity of the farewell command of love is well-attested in the earliest Christian memory. Around AD 197, the African apologist Tertullian recorded that pagans observing Christian communities exclaimed, "See how they love one another." That stunned outsider observation is the historical fingerprint of John 13:34-35 already at work in the second-century Church.`,
+    themes: [
+      'The new commandment given on the eve of the Passion',
+      `"As I have loved you" — the cruciform standard that raises the bar above natural reciprocity`,
+      'Love as the visible mark of authentic discipleship',
+      'Agape (self-giving divine love) versus merely natural affection or reciprocity',
+      'The ecclesial dimension of love — given to the gathered Twelve, lived in the Church',
+    ],
+    commentary: `**"As I Have Loved You" — What Makes the Commandment New**
+
+The command to love your neighbor as yourself is not new in itself. It comes straight from Leviticus 19:18, and Jesus elsewhere joins it to Deuteronomy 6:5 as the second of the two greatest commandments (Mark 12:30-31). So when Jesus calls this a "new commandment," what is genuinely new? The novelty is not the verb but the standard: "as I have loved you." The qualifier raises the bar from natural reciprocity to the cruciform love about to be displayed on Calvary. The immediate context (John 13:1-20) is the foot-washing — a slave's task — which prefigures the cross as self-emptying love. To love "as I have loved you" is to love to the end (John 13:1), to lay down one's life (John 15:13), to wash the feet even of the one who will betray you.
+
+**The Last Supper Setting and the Hour of Glory**
+
+Notice when Jesus speaks these words. The moment Judas leaves the room (v. 30), Jesus says: "Now is the Son of Man glorified." In John's vocabulary, "glorified" almost always means lifted up on the cross. The new commandment is not given in a comfortable seminar; it is given in the shadow of the cross, framed by betrayal on one side and Peter's coming denial on the other. It cannot be detached from cruciform self-gift. Christian love that is not willing to suffer for the other has not yet understood the "as I have loved you."
+
+**Pope Benedict XVI on Christian Love (Deus Caritas Est, 2005)**
+
+Benedict XVI's first encyclical, Deus Caritas Est, explored the relationship between agape (self-giving love), eros (the love of desire), and philia (friendship), insisting that they are not opposites but transformed in Christ into a single integrated love. He wrote: "Love is 'divine' because it comes from God and unites us to God; through this unifying process it makes us a 'we' which transcends our divisions and makes us one" (DCE 18). For Benedict, Christian love is never abstract philanthropy or generic kindness. It is participation in God's own outgoing self-gift, a love made possible because we have first received it ourselves — supremely in the Eucharist, which is the sacrament of the very love commanded here.
+
+**Pope Francis on the Concrete Mark of Discipleship**
+
+Pope Francis returns again and again to verse 35: "By this everyone will know that you are my disciples." For Francis, Christian witness is verified by acts of mercy and concrete love, not by slogans, ideological purity, or correct opinions. In his 2016 Wednesday catecheses for the Jubilee Year of Mercy, he walked through the corporal and spiritual works of mercy as the visible, touchable form of John 13:34-35. In Fratelli Tutti (2020) he extended this love to a universal fraternity, insisting that the commandment cannot stop at the boundaries of the in-group. The disciple is recognized, Francis says, by hands that serve, not by tongues that argue.
+
+**How Different Christian Traditions Read This Passage**
+
+- Catholic: The commandment is given to the gathered Twelve — that is, to the Church. It establishes the ecclesial dimension of love: visible witness through visible communion (CCC 1822-1829). The Eucharist, instituted at this same Last Supper according to the Synoptics, is both the school and the source of this love. Following Aquinas, charity is the form of all the virtues (Summa Theologiae II-II q. 23) — it is what gives every other virtue its life.
+
+- Eastern Orthodox: Closely aligned with the Catholic reading, with a strong emphasis on love as theosis. To love as Christ loved is to be transformed into Christ's image and to participate in the divine life. Thinkers from Maximus the Confessor and John of Damascus through modern theologians like Vladimir Lossky stress that the new commandment is not merely a moral demand but a transfiguring participation.
+
+- Lutheran and Reformed: Love is the inevitable fruit of justification by faith, never its cause. Reformed traditions especially emphasize that "love one another" is not a means of earning salvation but the necessary mark of genuine, living faith — what Calvin called the "evidence" of true regeneration.
+
+- Evangelical: Strong emphasis on relational love within the local congregation as the verifying evidence of conversion, often framed as the difference between mere profession and genuine new birth — though typically without the same accent on visible ecclesial communion that Catholics and Orthodox carry.
+
+- Mainline Protestant: Often interpreted in primarily ethical and social terms — service to the neighbor, social justice, peacemaking — with less metaphysical or sacramental framing than the older traditions, but with real seriousness about the public witness of love.
+
+**What the Catholic Church Teaches**
+
+Charity is the theological virtue infused at baptism, ordering us to love God for his own sake and our neighbor for the love of God (CCC 1812-1829). It is inseparable from the love of God (Mark 12:30-31; Matthew 22:37-40) — one cannot exist without the other. The new commandment is the summit of the Christian moral life and the definitional mark of the Church. What is distinctively Catholic is that this love is not left abstract: it is incarnated in the visible communion of the Church, sustained by the sacraments — especially the Eucharist, where the love commanded becomes the love received — and expressed concretely in the corporal and spiritual works of mercy. Love, for the Catholic tradition, is always visible, sacramental, and ecclesial, or it is not yet the love Christ commanded.`,
+    application: `**For reflection this week:**
+
+- **Read John 13:1-35 slowly.** Read the whole movement: the foot-washing, the prediction of betrayal, Judas's departure, and the new commandment. Let the setting interpret the command. The cross is already in the room.
+
+- **Examine your love by the Christ-standard, not the natural-reciprocity standard.** Look at your closest relationships — family, parish, coworkers, your online presence. Where do you love only those who love you back? "As I have loved you" reaches further.
+
+- **Choose one corporal and one spiritual work of mercy this week.** Pick concretely: feed the hungry, visit the sick, instruct the ignorant, comfort the sorrowful. Verse 35 says the world will know us by what we do, not by what we declare.
+
+- **Go to the Eucharist this Sunday remembering this is the school of agape.** The Eucharist is not a private devotion but the sacrament of the love commanded in this Gospel. Receive it as both gift and demand.
+
+- **Pray Romans 8:38-39 daily as the ground of your love.** "Neither death, nor life... will be able to separate us from the love of God in Christ Jesus our Lord." We can only love as he loved because we have first been loved like that.`,
+    sources: [
+      'New American Bible Revised Edition (NABRE) — Lectionary for Mass',
+      'Pope Benedict XVI, *Deus Caritas Est* (2005), §§ 1, 17-18',
+      'Pope Francis, Wednesday Catecheses on the Works of Mercy (2016 Jubilee Year of Mercy)',
+      'Pope Francis, *Fratelli Tutti* (2020) on universal fraternity',
+      'Catechism of the Catholic Church §§ 1812-1829 (theological virtues, charity); 2196 (the great commandment)',
+      'Raymond E. Brown, *The Gospel According to John XIII-XXI* (Anchor Bible Commentary, 1970), pp. 605-616',
+      'Joseph Ratzinger / Benedict XVI, *Jesus of Nazareth, Vol. 2*, ch. 3 ("The Washing of the Feet")',
+      'St. Augustine, *Tractates on the Gospel of John*, Tractate 65 (on John 13:34-35)',
+    ],
+  },
+  {
     id: '2026-04-26',
     date: 'April 26, 2026',
     sundayName: '4th Sunday of Easter — Good Shepherd Sunday',

--- a/src/app/history/apostles/page.tsx
+++ b/src/app/history/apostles/page.tsx
@@ -1,35 +1,1194 @@
 'use client'
 
-import { Users, MapPin, BookOpen, Crown } from 'lucide-react'
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  Anchor,
+  Users,
+  MapPin,
+  Flame,
+  ArrowRight,
+  BookOpen,
+  Globe,
+  Crown,
+  Star,
+  Shield,
+  Heart,
+  Cross,
+  Scroll,
+  Church,
+  Sword,
+  User,
+} from 'lucide-react'
+
+type TabId = 'the-twelve' | 'paul' | 'missions' | 'martyrdom'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'the-twelve', label: 'The Twelve' },
+  { id: 'paul', label: 'St. Paul' },
+  { id: 'missions', label: 'Missions to the World' },
+  { id: 'martyrdom', label: 'Martyrdom & Legacy' },
+]
 
 export default function ApostlesHistoryPage() {
-  const sections = [
-    { icon: Users, title: 'The Twelve', description: 'Peter, Andrew, James, John, Philip, Bartholomew, Matthew, Thomas, James son of Alphaeus, Thaddaeus, Simon the Zealot, and Judas — their calling, their role, and their witness.' },
-    { icon: MapPin, title: 'Missions to the World', description: 'Where the Apostles went after Pentecost — Peter to Rome, Thomas to India, James to Spain, Andrew to Greece, and the spread of the Gospel across the known world.' },
-    { icon: BookOpen, title: 'St. Paul — Apostle to the Gentiles', description: 'The conversion, missionary journeys, letters, and martyrdom of the greatest missionary in Church history.' },
-    { icon: Crown, title: 'Martyrdom & Legacy', description: 'How the Apostles died for their faith — and how their witness established the Church that endures to this day.' },
-  ]
+  const [activeTab, setActiveTab] = useState<TabId>('the-twelve')
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-10">
-        <h1 className="text-3xl sm:text-4xl font-serif font-bold text-gray-900 mb-3">History of the Apostles</h1>
-        <p className="text-lg text-gray-600 leading-relaxed max-w-3xl">
-          The twelve Apostles, chosen by Christ himself, became the foundation stones of the Church. After Pentecost, they carried the Gospel to the ends of the known world — and nearly all of them sealed their testimony with their blood. Their story is the story of how Christianity began.
-        </p>
-      </div>
-      <div className="rounded-xl p-6 mb-10 border-l-4" style={{ backgroundColor: '#FFFBEB', borderColor: '#D4AF37' }}>
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Coming Soon</h2>
-        <p className="text-gray-600">Detailed profiles of each Apostle, their missions, traditions, historical evidence, and martyrdom accounts will be added here.</p>
-      </div>
-      <div className="grid sm:grid-cols-2 gap-6">
-        {sections.map((s) => { const Icon = s.icon; return (
-          <div key={s.title} className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <div className="flex items-center gap-3 mb-3"><div className="p-2 rounded-lg bg-indigo-50"><Icon className="w-5 h-5 text-indigo-700" /></div>
-            <h3 className="font-serif text-lg font-semibold text-gray-900">{s.title}</h3></div>
-            <p className="text-sm text-gray-600 leading-relaxed">{s.description}</p>
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4 font-serif">
+            History of the Apostles
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The twelve Apostles, chosen by Christ himself, became the foundation stones of the Church.
+            After Pentecost, they carried the Gospel to the ends of the known world &mdash; and nearly
+            all of them sealed their testimony with their blood. Their story is the story of how
+            Christianity began.
+          </p>
+        </div>
+
+        {/* Navigation Links */}
+        <div className="flex flex-wrap justify-center gap-4 mb-8">
+          <Link
+            href="/history/christ"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-700 rounded-lg border border-amber-200 hover:bg-amber-100 transition-colors text-sm font-medium"
+          >
+            <Cross className="w-4 h-4" />
+            Lord Jesus Christ
+            <ArrowRight className="w-3.5 h-3.5" />
+          </Link>
+          <Link
+            href="/history/resurrection"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-50 text-blue-700 rounded-lg border border-blue-200 hover:bg-blue-100 transition-colors text-sm font-medium"
+          >
+            <Star className="w-4 h-4" />
+            The Resurrection
+            <ArrowRight className="w-3.5 h-3.5" />
+          </Link>
+          <Link
+            href="/history/church"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-green-50 text-green-700 rounded-lg border border-green-200 hover:bg-green-100 transition-colors text-sm font-medium"
+          >
+            <Church className="w-4 h-4" />
+            Church History
+            <ArrowRight className="w-3.5 h-3.5" />
+          </Link>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
           </div>
-        )})}
+        </div>
+
+        {/* ==================== TAB 1: THE TWELVE ==================== */}
+        {activeTab === 'the-twelve' && (
+          <div className="space-y-8">
+
+            {/* Intro */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">The Twelve Apostles</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Jesus chose twelve men as his closest disciples &mdash; a deliberate echo of the twelve
+                tribes of Israel, signalling that he was reconstituting the people of God. The word
+                &ldquo;apostle&rdquo; (Greek: <em>apostolos</em>) means &ldquo;one who is sent.&rdquo; After
+                the Resurrection and Pentecost, they were sent to the whole world.
+              </p>
+              <p className="text-gray-700 leading-relaxed">
+                After the betrayal and suicide of Judas Iscariot, the Eleven gathered and elected Matthias
+                by lot to restore the number to twelve (Acts 1:15&ndash;26). The Twelve are the foundation
+                stones of the New Jerusalem (Rev 21:14).
+              </p>
+            </div>
+
+            {/* Apostle Cards */}
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+
+              {/* 1. Peter */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-amber-400 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-amber-50">
+                    <Anchor className="w-5 h-5 text-amber-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Simon Peter</h3>
+                    <p className="text-xs text-gray-500">Bethsaida, Galilee &bull; Fisherman</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Brother of Andrew; a fisherman whom Jesus renamed &ldquo;Cephas&rdquo; (Rock). Led the
+                  early Jerusalem Church, delivered the first sermon at Pentecost, and wrote two epistles.
+                  Tradition identifies him as the first Bishop of Rome. Crucified upside down in Rome
+                  c. AD 64&ndash;68; his tomb lies beneath St. Peter&rsquo;s Basilica.
+                </p>
+              </div>
+
+              {/* 2. Andrew */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-amber-400 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-amber-50">
+                    <Anchor className="w-5 h-5 text-amber-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Andrew</h3>
+                    <p className="text-xs text-gray-500">Bethsaida, Galilee &bull; Fisherman</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Peter&rsquo;s brother and the first Apostle called (John 1:40&ndash;42); he immediately
+                  brought his brother to Jesus. The Eastern Church honours him as &ldquo;Protocletos&rdquo;
+                  &mdash; the first-called. Preached in Cappadocia, Scythia, and Greece; martyred by
+                  crucifixion on an X-shaped cross at Patras. Patron saint of Scotland.
+                </p>
+              </div>
+
+              {/* 3. James son of Zebedee */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-amber-400 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-amber-50">
+                    <Crown className="w-5 h-5 text-amber-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">James son of Zebedee</h3>
+                    <p className="text-xs text-gray-500">Capernaum, Galilee &bull; Fisherman</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Brother of John; one of the &ldquo;Sons of Thunder.&rdquo; Part of the inner circle
+                  present at the Transfiguration and Gethsemane. The first Apostle martyred &mdash;
+                  beheaded by Herod Agrippa I c. AD 44, the only apostolic martyrdom recorded in
+                  Scripture (Acts 12:2). Patron of Spain; his shrine at Santiago de Compostela became
+                  the greatest pilgrimage site in medieval Christendom.
+                </p>
+              </div>
+
+              {/* 4. John */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-amber-400 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-amber-50">
+                    <Heart className="w-5 h-5 text-amber-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">John</h3>
+                    <p className="text-xs text-gray-500">Capernaum, Galilee &bull; Fisherman</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  James&rsquo;s brother; &ldquo;the Beloved Disciple.&rdquo; Stood at the foot of the Cross
+                  and was entrusted with Mary (John 19:26&ndash;27). Author of the Gospel of John, three
+                  Letters, and the Book of Revelation. Settled in Ephesus where he lived to old age
+                  &mdash; the only Apostle not killed for his faith, though he suffered exile to Patmos
+                  under Emperor Domitian.
+                </p>
+              </div>
+
+              {/* 5. Philip */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <User className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Philip</h3>
+                    <p className="text-xs text-gray-500">Bethsaida, Galilee</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Brought Nathanael to Jesus with the invitation &ldquo;Come and see&rdquo; (John 1:46).
+                  At the Last Supper, he asked Jesus, &ldquo;Show us the Father&rdquo; (John 14:8),
+                  prompting one of Christ&rsquo;s most direct revelations of his identity. Preached in
+                  Phrygia (modern Turkey) and was martyred by crucifixion at Hierapolis c. AD 80.
+                </p>
+              </div>
+
+              {/* 6. Bartholomew */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <User className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Bartholomew (Nathanael)</h3>
+                    <p className="text-xs text-gray-500">Cana, Galilee</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Identified with Nathanael, whom Jesus called &ldquo;a true Israelite in whom there is
+                  no deceit&rdquo; (John 1:47). Traditionally preached in Armenia and northwest India.
+                  Martyred in Armenia by flaying alive and crucifixion; depicted in Michelangelo&rsquo;s
+                  <em> Last Judgment</em> holding his own flayed skin.
+                </p>
+              </div>
+
+              {/* 7. Matthew */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <Scroll className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Matthew (Levi)</h3>
+                    <p className="text-xs text-gray-500">Capernaum &bull; Tax Collector</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  A tax collector called at his tax booth (Matt 9:9) &mdash; a calling that shocked his
+                  contemporaries, since tax collectors were despised as Roman collaborators. Author of
+                  the Gospel of Matthew. Preached in Judea and later in Ethiopia and Persia. Martyrdom
+                  accounts vary; most traditions hold that he died for the faith.
+                </p>
+              </div>
+
+              {/* 8. Thomas */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <Globe className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Thomas (Didymus)</h3>
+                    <p className="text-xs text-gray-500">Galilee &bull; &ldquo;The Twin&rdquo;</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Famous for doubting the Resurrection (John 20:24&ndash;29), yet he became the first
+                  to make the highest confession: &ldquo;My Lord and my God!&rdquo; (John 20:28). The
+                  greatest missionary Apostle in reach &mdash; travelling to Parthia, Persia, and India.
+                  The Saint Thomas Christian community in Kerala traces its origin directly to his
+                  mission. Martyred at Mylapore (modern Chennai) c. AD 72.{' '}
+                  <Link href="/history/indian-church" className="text-amber-700 underline hover:text-amber-900">
+                    The Church in India &rarr;
+                  </Link>
+                </p>
+              </div>
+
+              {/* 9. James son of Alphaeus */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <User className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">James son of Alphaeus</h3>
+                    <p className="text-xs text-gray-500">&ldquo;James the Less&rdquo;</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Called &ldquo;James the Less&rdquo; (perhaps younger or shorter than James son of
+                  Zebedee). Little is recorded of him in Scripture beyond the lists of the Twelve.
+                  Traditions associate him with mission to Egypt or Persia. His martyrdom accounts vary;
+                  some traditions hold he was stoned or clubbed to death.
+                </p>
+              </div>
+
+              {/* 10. Thaddaeus / Jude */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <BookOpen className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Thaddaeus (Jude)</h3>
+                    <p className="text-xs text-gray-500">&ldquo;Judas, not Iscariot&rdquo; (John 14:22)</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Also called Lebbaeus; the &ldquo;Judas not Iscariot&rdquo; who asked Jesus why he
+                  revealed himself to the disciples and not to the world (John 14:22). Author of the
+                  Letter of Jude. Preached in Syria, Mesopotamia, and Persia alongside Simon the Zealot.
+                  Martyred in Persia; patron of hopeless causes.
+                </p>
+              </div>
+
+              {/* 11. Simon the Zealot */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <Flame className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Simon the Zealot</h3>
+                    <p className="text-xs text-gray-500">Formerly of the Zealot movement</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Identified as &ldquo;the Zealot,&rdquo; suggesting possible former membership in the
+                  Zealot resistance movement against Roman rule &mdash; making his brotherhood in the
+                  Twelve with Matthew the tax collector a remarkable testimony to Christ&rsquo;s unifying
+                  power. Preached in Egypt and Persia; martyred in Persia alongside Thaddaeus.
+                </p>
+              </div>
+
+              {/* 12. Matthias */}
+              <div className="bg-white rounded-xl border border-gray-200 border-l-4 border-l-indigo-200 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="p-2 rounded-lg bg-indigo-50">
+                    <Star className="w-5 h-5 text-indigo-700" />
+                  </div>
+                  <div>
+                    <h3 className="font-serif text-lg font-semibold text-gray-900">Matthias</h3>
+                    <p className="text-xs text-gray-500">Chosen to replace Judas Iscariot</p>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  Chosen by the casting of lots to fill the vacancy left by Judas Iscariot (Acts
+                  1:15&ndash;26). He had been a follower of Jesus from his baptism to the Ascension,
+                  qualifying as a witness to the Resurrection. Preached in Judea and possibly Colchis
+                  (modern Georgia) or Ethiopia; martyrdom traditions vary.
+                </p>
+              </div>
+
+            </div>
+
+            {/* Judas note */}
+            <div className="bg-gray-50 border border-gray-200 rounded-xl p-6">
+              <h3 className="font-serif text-lg font-semibold text-gray-800 mb-2">A Note on Judas Iscariot</h3>
+              <p className="text-sm text-gray-600 leading-relaxed">
+                Judas Iscariot was one of the original Twelve &mdash; called, taught, and trusted with the
+                common purse. He betrayed Jesus to the chief priests for thirty pieces of silver (Matt
+                26:14&ndash;16); his kiss in Gethsemane identified Jesus to the arresting soldiers. Overcome
+                with remorse, he returned the silver and hanged himself (Matt 27:3&ndash;5). Jesus himself
+                referred to him as &ldquo;the son of destruction&rdquo; (John 17:12). His place was taken
+                by Matthias.
+              </p>
+            </div>
+
+            {/* Cross-link */}
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-6">
+              <p className="text-amber-800 text-sm mb-3">
+                The mission of the Apostles did not end with their deaths &mdash; it continues in the Church
+                they founded, sustained by apostolic succession.
+              </p>
+              <Link
+                href="/history/church"
+                className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-900 font-medium text-sm"
+              >
+                <ArrowRight className="w-4 h-4" />
+                The Church &mdash; continuing the Apostolic mission
+              </Link>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: ST. PAUL ==================== */}
+        {activeTab === 'paul' && (
+          <div className="space-y-8">
+
+            {/* Introduction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">The Thirteenth Apostle</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Paul of Tarsus was not one of the original Twelve. He never walked with Jesus during his
+                earthly ministry, and in fact spent the early years of the Church trying to destroy it. Yet
+                he is universally regarded as an Apostle &mdash; not by human appointment but because he
+                was called directly by the risen Christ on the road to Damascus. He describes himself as
+                &ldquo;one abnormally born&rdquo; (1 Cor 15:8) &mdash; an apostle born out of due time,
+                not in the ordinary way.
+              </p>
+              <p className="text-gray-700 leading-relaxed">
+                No single figure did more to carry the Gospel into the Gentile world, to establish the
+                churches of the Mediterranean, or to articulate the theology of grace that forms the
+                intellectual backbone of Christianity. He wrote nearly half the New Testament. He is
+                universally venerated as one of the two great Apostles of Rome, alongside Peter.
+              </p>
+            </div>
+
+            {/* Background */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Background: Saul of Tarsus</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Paul was born c. AD 5 in Tarsus, a prosperous city in Cilicia (modern southern Turkey).
+                His birth name was Saul &mdash; a Hebrew name honouring the tribe of Benjamin, to which
+                he belonged (Phil 3:5). Crucially, he was a Roman citizen by birth (Acts 22:27&ndash;28),
+                a status that would later protect him from summary execution and allow him to appeal to
+                Caesar.
+              </p>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                He was educated in Jerusalem under Gamaliel, one of the most eminent rabbis of the era
+                (Acts 22:3), and became a Pharisee of exceptional zeal. He describes his pre-Christian
+                life thus: &ldquo;I was advancing in Judaism beyond many of my own age among my people,
+                so extremely zealous was I for the traditions of my fathers&rdquo; (Gal 1:14).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Persecutor</h3>
+                <p className="text-blue-800 leading-relaxed mb-3">
+                  Saul considered the claim that the crucified Jesus was the Messiah to be blasphemy of
+                  the worst kind, and he acted accordingly. He was present holding the cloaks of those
+                  who stoned Stephen, the first Christian martyr (Acts 7:58). He then launched a
+                  systematic campaign: &ldquo;Saul was ravaging the church, and entering house after
+                  house, he dragged off men and women and committed them to prison&rdquo; (Acts 8:3).
+                  He obtained letters from the High Priest authorising him to travel to Damascus and
+                  arrest Christians there.
+                </p>
+                <p className="text-blue-800 leading-relaxed">
+                  He never reached that destination as the man he had been.
+                </p>
+              </div>
+            </div>
+
+            {/* Damascus Road */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">The Damascus Road (c. AD 33&ndash;36)</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On the road to Damascus, Saul was suddenly struck down by a blinding light. A voice
+                spoke to him: &ldquo;Saul, Saul, why are you persecuting me?&rdquo; (Acts 9:4). When
+                Saul asked who was speaking, the answer came: &ldquo;I am Jesus, whom you are
+                persecuting.&rdquo; Blinded for three days, he neither ate nor drank. In Damascus he
+                was baptised by Ananias and received his sight back.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">His First Words as a Christian (Acts 9:20)</h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;Immediately he began to proclaim Jesus in the synagogues, saying, &lsquo;He is
+                  the Son of God.&rsquo;&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Acts 9:20</em></p>
+                <p className="text-amber-800 text-sm mt-3 leading-relaxed">
+                  The very first thing Paul did after his baptism was to proclaim the thing he had most
+                  violently denied. This instantaneous reversal &mdash; from Christianity&rsquo;s most
+                  dangerous enemy to its most passionate herald &mdash; is one of the strongest
+                  historical evidences for the reality of the Resurrection.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Paul spent several years in Arabia and Damascus before returning to Jerusalem around
+                AD 35&ndash;36, where he spent fifteen days with Peter and met James, the brother of
+                the Lord (Gal 1:17&ndash;19). It was during this visit that he most likely received
+                the early creed now recorded in 1 Corinthians 15:3&ndash;8, which dates the
+                resurrection tradition to within just a few years of the events.
+              </p>
+            </div>
+
+            {/* Missionary Journeys */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Three Missionary Journeys</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Beginning around AD 46, Paul undertook three great missionary journeys that planted
+                churches from Cyprus to Greece and established the Christian presence across the
+                eastern Mediterranean. He travelled by ship and on foot, preaching in synagogues
+                and marketplaces, founding communities, appointing elders, and returning to
+                strengthen them.
+              </p>
+
+              <div className="space-y-4">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="text-lg font-semibold text-green-900 mb-2">First Journey (c. AD 46&ndash;48)</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    With Barnabas: <strong>Cyprus</strong> &rarr; <strong>Pisidian Antioch</strong> (first
+                    synagogue sermon to Gentiles) &rarr; <strong>Iconium</strong> &rarr; <strong>Lystra</strong>
+                    (stoned and left for dead) &rarr; <strong>Derbe</strong>, then the return route
+                    strengthening the churches. The Jerusalem Council (Acts 15, c. AD 49) confirmed the
+                    Gentile mission at the end of this phase.
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="text-lg font-semibold text-green-900 mb-2">Second Journey (c. AD 49&ndash;52)</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    With Silas: Through <strong>Syria and Asia Minor</strong> &rarr; a divine vision
+                    calling them to <strong>Macedonia</strong> &rarr; <strong>Philippi</strong>
+                    (imprisonment and miraculous release) &rarr; <strong>Thessalonica</strong> &rarr;
+                    <strong>Berea</strong> &rarr; <strong>Athens</strong> (the Areopagus speech, Acts 17,
+                    arguing for the one God from the altar to the Unknown God) &rarr; <strong>Corinth</strong>
+                    (18 months; wrote 1 &amp; 2 Thessalonians here).
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="text-lg font-semibold text-green-900 mb-2">Third Journey (c. AD 53&ndash;57)</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    <strong>Ephesus</strong> (three years; wrote 1 Corinthians; the silversmiths&rsquo;
+                    riot) &rarr; <strong>Macedonia and Corinth</strong> (wrote Galatians, Romans, 2
+                    Corinthians) &rarr; <strong>Jerusalem</strong> with the collection for the poor saints,
+                    where his arrest would end his free mission.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Arrest and Imprisonment */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-indigo-100 rounded-full flex items-center justify-center">
+                  <Shield className="w-6 h-6 text-indigo-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Arrest, Trials, and Rome (AD 57&ndash;62)</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                In Jerusalem, a riot in the Temple led to Paul&rsquo;s arrest by Roman soldiers (Acts
+                21:30&ndash;33). Transferred to Caesarea, he stood trial before the governors Felix and
+                Festus and before King Agrippa II. Facing a potentially unfair outcome, he exercised
+                his Roman citizenship and appealed to Caesar (Acts 25:11), triggering a voyage to Rome
+                that included a famous shipwreck on Malta (Acts 27).
+              </p>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                In Rome he spent at least two years under house arrest (Acts 28:30&ndash;31), freely
+                preaching and writing letters &mdash; including Ephesians, Philippians, Colossians,
+                and Philemon. Tradition holds that he was released, possibly travelled to Spain and
+                the eastern Mediterranean again, and was then rearrested under Nero and executed
+                c. AD 67.
+              </p>
+            </div>
+
+            {/* The Letters */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scroll className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">The Pauline Letters</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Thirteen letters in the New Testament bear Paul&rsquo;s name. They were written to
+                address specific problems in real communities and are among the most theologically
+                rich documents ever produced. They cover the full sweep of Christian life: justification
+                by faith, the nature of the Church, the resurrection of the body, the ethics of love,
+                the sovereignty of grace, and the cosmic lordship of Christ.
+              </p>
+              <div className="bg-gray-50 rounded-lg p-5 mb-4">
+                <p className="text-sm text-gray-700 leading-relaxed">
+                  <strong>The thirteen letters:</strong> Romans &bull; 1 &amp; 2 Corinthians &bull;
+                  Galatians &bull; Ephesians &bull; Philippians &bull; Colossians &bull; 1 &amp; 2
+                  Thessalonians &bull; 1 &amp; 2 Timothy &bull; Titus &bull; Philemon
+                </p>
+              </div>
+
+              {/* Key quotes */}
+              <div className="space-y-4">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <p className="text-amber-800 italic mb-1">
+                    &ldquo;I have been crucified with Christ and I no longer live, but Christ lives in
+                    me. The life I now live in the body, I live by faith in the Son of God, who loved me
+                    and gave himself for me.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-sm">&mdash; <em>Galatians 2:20</em></p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <p className="text-amber-800 italic mb-1">
+                    &ldquo;I can do all this through him who gives me strength.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-sm">&mdash; <em>Philippians 4:13</em></p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <p className="text-amber-800 italic mb-1">
+                    &ldquo;For I am convinced that neither death nor life, neither angels nor demons,
+                    neither the present nor the future, nor any powers, neither height nor depth, nor
+                    anything else in all creation, will be able to separate us from the love of God that
+                    is in Christ Jesus our Lord.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-sm">&mdash; <em>Romans 8:38&ndash;39</em></p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <p className="text-amber-800 italic mb-1">
+                    &ldquo;For what I received I passed on to you as of first importance: that Christ
+                    died for our sins according to the Scriptures, that he was buried, that he was raised
+                    on the third day according to the Scriptures, and that he appeared to Cephas, and then
+                    to the Twelve&hellip;&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-sm">&mdash; <em>1 Corinthians 15:3&ndash;5</em> (the earliest written resurrection creed)</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Martyrdom */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Crown className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Martyrdom at Rome (c. AD 67)</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Paul was beheaded &mdash; the method of execution reserved for Roman citizens, considered
+                more dignified than crucifixion &mdash; at a place outside Rome called Tre Fontane
+                (Three Fountains), c. AD 67, during the persecution of Nero. The Basilica of St. Paul
+                Outside the Walls marks the traditional site of his burial on the Via Ostiensis.
+              </p>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Clement of Rome, writing c. AD 96 within living memory of the events, attests that Paul
+                &ldquo;bore chains seven times, was banished, was stoned, became a herald in East and
+                West, and won the noble renown which was the reward of his faith, having taught
+                righteousness to the whole world and having reached the farthest limits of the West;
+                and when he had borne his testimony before the rulers, he thus departed from the world
+                and went to the holy place, having become an outstanding example of patient
+                endurance&rdquo; (1 Clement 5).
+              </p>
+              <div className="bg-amber-50 p-5 rounded-lg">
+                <p className="text-amber-800 italic mb-1">
+                  &ldquo;For to me, to live is Christ and to die is gain.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Philippians 1:21</em></p>
+              </div>
+            </div>
+
+            {/* Cross-link */}
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-6">
+              <p className="text-amber-800 text-sm mb-3">
+                Paul&rsquo;s entire mission was built on the one foundation: the risen Christ who
+                appeared to him on the Damascus road.
+              </p>
+              <Link
+                href="/history/christ"
+                className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-900 font-medium text-sm"
+              >
+                <ArrowRight className="w-4 h-4" />
+                Learn about Jesus himself
+              </Link>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: MISSIONS ==================== */}
+        {activeTab === 'missions' && (
+          <div className="space-y-8">
+
+            {/* Great Commission */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">The Great Commission</h2>
+              </div>
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic mb-2 text-lg leading-relaxed">
+                  &ldquo;Go therefore and make disciples of all nations, baptising them in the name of
+                  the Father and of the Son and of the Holy Spirit, teaching them to observe all that I
+                  have commanded you. And behold, I am with you always, to the end of the age.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Matthew 28:19&ndash;20</em></p>
+              </div>
+              <p className="text-gray-700 leading-relaxed">
+                These words, spoken by the Risen Christ to his disciples on a mountain in Galilee, set
+                in motion one of the most extraordinary episodes of religious expansion in human history.
+                Within a generation, the Gospel had spread from Jerusalem to Rome; within three centuries,
+                it had reached from Ireland to India. What follows is a record of where each Apostle went.
+              </p>
+            </div>
+
+            {/* Mission Table */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Where the Apostles Went</h2>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b-2 border-gray-200">
+                      <th className="text-left py-3 px-4 font-semibold text-gray-700 bg-gray-50 rounded-tl-lg">Apostle</th>
+                      <th className="text-left py-3 px-4 font-semibold text-gray-700 bg-gray-50">Primary Territory</th>
+                      <th className="text-left py-3 px-4 font-semibold text-gray-700 bg-gray-50 rounded-tr-lg">Key Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Peter</td>
+                      <td className="py-3 px-4 text-gray-700">Jerusalem &rarr; Antioch &rarr; Rome</td>
+                      <td className="py-3 px-4 text-gray-600">Founded the Roman Church; first Bishop of Rome; crucified upside down c. AD 64&ndash;68</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Andrew</td>
+                      <td className="py-3 px-4 text-gray-700">Cappadocia, Galatia, Bithynia &rarr; Scythia &rarr; Greece (Patras)</td>
+                      <td className="py-3 px-4 text-gray-600">&ldquo;Protocletos&rdquo; (first-called) in Eastern tradition; patron of Scotland; martyred on an X-shaped cross</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">James son of Zebedee</td>
+                      <td className="py-3 px-4 text-gray-700">Judea; Spain (tradition)</td>
+                      <td className="py-3 px-4 text-gray-600">Martyred early (c. AD 44) before extensive missions; shrine at Santiago de Compostela in Spain</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">John</td>
+                      <td className="py-3 px-4 text-gray-700">Jerusalem (decades) &rarr; Ephesus; Patmos (exile)</td>
+                      <td className="py-3 px-4 text-gray-600">Wrote Gospel, three Letters, and Revelation; died naturally at Ephesus c. AD 100</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Philip</td>
+                      <td className="py-3 px-4 text-gray-700">Phrygia &amp; Asia Minor (Hierapolis); some traditions add Ethiopia</td>
+                      <td className="py-3 px-4 text-gray-600">Martyred at Hierapolis c. AD 80</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Bartholomew</td>
+                      <td className="py-3 px-4 text-gray-700">Armenia; northwest India tradition; possibly Persia</td>
+                      <td className="py-3 px-4 text-gray-600">A separate Indian tradition from Thomas; martyred in Armenia by flaying</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Matthew</td>
+                      <td className="py-3 px-4 text-gray-700">Judea &rarr; Ethiopia and/or Persia</td>
+                      <td className="py-3 px-4 text-gray-600">Author of the First Gospel; martyrdom accounts vary</td>
+                    </tr>
+                    <tr className="hover:bg-green-50 transition-colors border-l-4 border-green-400">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Thomas</td>
+                      <td className="py-3 px-4 text-gray-700">Parthia &rarr; Persia &rarr; India (Kerala, Malabar coast)</td>
+                      <td className="py-3 px-4 text-gray-600">
+                        Founded the Saint Thomas Christian (Nasrani) community in Kerala; martyred at Mylapore (Chennai) c. AD 72.
+                        Attested by Eusebius, Jerome, and the unbroken Syro-Malabar tradition.{' '}
+                        <Link href="/history/indian-church" className="text-green-700 underline hover:text-green-900 font-medium">
+                          The Church in India &rarr;
+                        </Link>
+                      </td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">James son of Alphaeus</td>
+                      <td className="py-3 px-4 text-gray-700">Various traditions; possibly Egypt</td>
+                      <td className="py-3 px-4 text-gray-600">Little scriptural record; traditions vary</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Thaddaeus / Jude</td>
+                      <td className="py-3 px-4 text-gray-700">Syria &rarr; Mesopotamia &rarr; Persia (with Simon)</td>
+                      <td className="py-3 px-4 text-gray-600">Author of the Letter of Jude; martyred in Persia</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Simon the Zealot</td>
+                      <td className="py-3 px-4 text-gray-700">Egypt, Persia; some traditions include Britain</td>
+                      <td className="py-3 px-4 text-gray-600">Martyred in Persia alongside Thaddaeus</td>
+                    </tr>
+                    <tr className="hover:bg-amber-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Paul</td>
+                      <td className="py-3 px-4 text-gray-700">Cyprus &rarr; Asia Minor &rarr; Macedonia &rarr; Greece &rarr; Rome &rarr; possibly Spain</td>
+                      <td className="py-3 px-4 text-gray-600">Three missionary journeys; 13 letters; beheaded at Rome c. AD 67</td>
+                    </tr>
+                    <tr className="hover:bg-blue-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Mark <span className="text-xs font-normal text-gray-500">(not of the Twelve)</span></td>
+                      <td className="py-3 px-4 text-gray-700">Egypt, Alexandria</td>
+                      <td className="py-3 px-4 text-gray-600">Companion of Peter; author of the Second Gospel; founded the Coptic Church in Alexandria</td>
+                    </tr>
+                    <tr className="hover:bg-blue-50 transition-colors">
+                      <td className="py-3 px-4 font-semibold text-gray-900">Luke <span className="text-xs font-normal text-gray-500">(not of the Twelve)</span></td>
+                      <td className="py-3 px-4 text-gray-700">Accompanied Paul throughout his journeys</td>
+                      <td className="py-3 px-4 text-gray-600">Author of the Gospel of Luke and the Acts of the Apostles; the historian of the early Church</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Thomas note */}
+            <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+              <h3 className="font-serif text-lg font-semibold text-green-900 mb-3">Thomas and India: One of the Best-Attested Apostolic Missions</h3>
+              <p className="text-green-800 text-sm leading-relaxed mb-3">
+                The mission of Thomas to India is one of the most historically credible of all the
+                apostolic traditions. Eusebius of Caesarea (c. AD 313) records Thomas&rsquo;s mission
+                to Parthia; St. Jerome (c. AD 393) explicitly names India. The Syriac Acts of Thomas
+                (3rd century) provides a detailed narrative. Most significantly, the Saint Thomas
+                Christian community of Kerala &mdash; the Nasrani, also known as the Syro-Malabar
+                Church &mdash; has maintained an unbroken tradition of Thomasine origin from at least
+                the 3rd century, long before European contact.
+              </p>
+              <p className="text-green-800 text-sm leading-relaxed mb-3">
+                The Santhome Basilica in Chennai (formerly Mylapore) marks Thomas&rsquo;s traditional
+                burial site, confirmed by excavations conducted in the 16th century by Portuguese
+                missionaries who found the tomb and relics.
+              </p>
+              <Link
+                href="/history/indian-church"
+                className="inline-flex items-center gap-2 text-green-700 hover:text-green-900 font-medium text-sm"
+              >
+                <ArrowRight className="w-4 h-4" />
+                The Church in India &mdash; Thomas&rsquo;s Legacy
+              </Link>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: MARTYRDOM & LEGACY ==================== */}
+        {activeTab === 'martyrdom' && (
+          <div className="space-y-8">
+
+            {/* Tertullian quote */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Crown className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">The Blood of Martyrs</h2>
+              </div>
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic text-lg mb-2">
+                  &ldquo;The blood of martyrs is the seed of the Church.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Tertullian, Apologeticus, c. AD 197</em></p>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Tertullian&rsquo;s famous observation captures a paradox that puzzled Rome: the more the
+                Empire persecuted the Christians, the faster the Church grew. The willingness of the
+                Apostles and their followers to die rather than deny Christ was not weakness &mdash; it
+                was the most powerful possible testimony to what they believed they had witnessed.
+              </p>
+              <p className="text-gray-700 leading-relaxed">
+                No conspiracy theory or collective delusion adequately explains men choosing prolonged
+                suffering and death for an event they themselves could have exposed as false. The
+                Apostles were not dying for a faith they had received from others; they were dying
+                for events they personally claimed to have seen. Their willingness to face death is
+                among the strongest historical arguments for the truth of the Resurrection.
+              </p>
+            </div>
+
+            {/* How they died */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Sword className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">How the Apostles Died</h2>
+              </div>
+
+              <div className="bg-red-50 rounded-xl p-6 mb-2">
+                <div className="space-y-5">
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Peter &mdash; Crucified upside down (c. AD 64&ndash;68), Rome</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Crucified on Vatican Hill during Nero&rsquo;s persecution. He asked to be
+                          crucified upside down, declaring he was unworthy to die in the same manner as
+                          his Lord. His tomb beneath St. Peter&rsquo;s Basilica was identified in
+                          excavations conducted 1939&ndash;1949.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Paul &mdash; Beheaded (c. AD 67), Rome</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          As a Roman citizen, Paul was entitled to a more dignified death than crucifixion.
+                          Beheaded at Tre Fontane (Three Fountains) outside Rome, also under Nero. The
+                          Basilica of St. Paul Outside the Walls marks his burial site on the Via Ostiensis.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Andrew &mdash; Crucified on an X-shaped cross (c. AD 60), Patras, Greece</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          The <em>Crux decussata</em> &mdash; the X-shaped cross &mdash; bears his name
+                          (St. Andrew&rsquo;s Cross) and appears on the Saltire flag of Scotland, of which
+                          Andrew is patron. Tradition records he was bound rather than nailed, prolonging
+                          his suffering, and preached from the cross for two days.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">James son of Zebedee &mdash; Beheaded (c. AD 44), Jerusalem</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          The only Apostle whose martyrdom is explicitly recorded in the New Testament:
+                          &ldquo;He killed James the brother of John with the sword&rdquo; (Acts 12:2).
+                          Herod Agrippa I ordered his execution to please the Jewish leadership. He was the
+                          first of the Twelve to die for the faith.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Philip &mdash; Crucified (c. AD 80), Hierapolis, Asia Minor</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          After decades of ministry in Phrygia, Philip was arrested during a
+                          confrontation with pagan priests at Hierapolis. He was crucified upside down.
+                          Excavations at Hierapolis have uncovered a martyrium (memorial shrine) believed
+                          to mark the site.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Bartholomew &mdash; Flayed alive and crucified, Armenia</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Tradition records one of the most gruesome of the apostolic martyrdoms: he was
+                          flayed (skinned) alive and then crucified or beheaded in Armenia. Michelangelo
+                          depicted him in the <em>Last Judgment</em> in the Sistine Chapel holding his
+                          own skin &mdash; the skin bearing Michelangelo&rsquo;s own face in a moment of
+                          dark self-reflection.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Matthew &mdash; Martyrdom accounts vary; Ethiopia or Persia</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Sources differ on the manner and location of Matthew&rsquo;s death &mdash;
+                          some traditions say he was killed by the sword in Ethiopia, others by spear in
+                          Persia. Some early sources suggest he may have died a natural death. The
+                          uncertainty itself reflects the limits of early tradition.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Thomas &mdash; Speared (c. AD 72), Mylapore, India</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Thomas was martyred by spear on a hill outside Mylapore (modern Chennai,
+                          Tamil Nadu, India). The Santhome Basilica &mdash; built originally by the
+                          Portuguese in 1523 over earlier structures, and elevated to a basilica in 1956
+                          &mdash; marks his traditional burial place. He is one of only three Apostles
+                          (with Peter and James) whose tomb site has a continuous devotional tradition
+                          traceable to antiquity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">James son of Alphaeus &mdash; Stoned or clubbed; accounts vary</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Traditions place his martyrdom in Egypt or Persia; some accounts say he was
+                          stoned, others that he was beaten to death with a fuller&rsquo;s club &mdash;
+                          a wooden implement used for preparing cloth &mdash; which became his artistic
+                          symbol.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Thaddaeus / Jude &mdash; Clubbed and/or speared, Persia</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Martyred in Persia alongside Simon the Zealot. His artistic symbol is a club
+                          or axe. As the patron of hopeless causes, his intercessory reputation has made
+                          him one of the most popular saints in popular Catholic devotion.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Simon the Zealot &mdash; Martyred in Persia (with Thaddaeus)</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          Tradition consistently pairs Simon with Thaddaeus in Persia. Some accounts
+                          describe him as sawn in two, others as crucified. A minority British tradition
+                          (largely legendary) holds that he reached Britain.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-b border-red-100 pb-4">
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-red-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">Matthias &mdash; Stoned and beheaded; traditions vary</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          The tradition most commonly cited records him stoned and then beheaded in
+                          Colchis (modern Georgia) or in Judea. His feast day is 14 May in the Roman Rite.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="flex items-start gap-3">
+                      <div className="w-2 h-2 rounded-full bg-blue-400 mt-2 flex-shrink-0"></div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900">John &mdash; Died naturally at Ephesus (c. AD 100)</h3>
+                        <p className="text-sm text-gray-600 mt-1 leading-relaxed">
+                          John alone among the Twelve is believed to have died of old age &mdash; though
+                          not without suffering. He was banished to the island of Patmos by Emperor
+                          Domitian, where he received the visions of the Book of Revelation. Tradition
+                          records that he was also briefly thrown into boiling oil in Rome, from which he
+                          emerged unharmed. He returned to Ephesus and lived to extreme old age, his last
+                          words said to be: &ldquo;Little children, love one another.&rdquo;
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+
+            {/* Apologetic argument */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Shield className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Why This Matters: The Apologetic Argument</h2>
+              </div>
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 leading-relaxed mb-4">
+                  People will die for beliefs they sincerely hold &mdash; members of many religions have
+                  done so throughout history. This in itself proves nothing about the truth of those
+                  beliefs. What is historically unique about the Apostles is different: they were not
+                  dying for a theological system they had received from others. They were dying for
+                  specific, concrete, empirical events that they personally claimed to have witnessed
+                  &mdash; above all, the bodily resurrection of Jesus from the dead.
+                </p>
+                <p className="text-blue-800 leading-relaxed mb-4">
+                  The Apostles were in a unique epistemic position. They knew whether the resurrection
+                  had happened or not. If it had not happened &mdash; if the tomb was not empty, if the
+                  appearances were fabricated &mdash; they would have known it was a lie. Men and women
+                  sometimes die for beliefs they think are true but which are false. But no coherent
+                  psychological or sociological explanation accounts for a group of people who knew their
+                  central claim was false, yet chose torture and death rather than renounce it, with
+                  nothing to gain and everything to lose.
+                </p>
+                <p className="text-blue-800 leading-relaxed">
+                  Not one of the Apostles recanted. Not one, under threat of death, said: &ldquo;It was
+                  a deception.&rdquo; The martyrdom of the Apostles is not proof of the Resurrection in
+                  the strict logical sense, but it is among the strongest circumstantial arguments that
+                  what they proclaimed was what they genuinely believed they had seen &mdash; and that
+                  they had very good reason for that belief.
+                </p>
+              </div>
+              <Link
+                href="/history/resurrection"
+                className="inline-flex items-center gap-2 text-blue-700 hover:text-blue-900 font-medium"
+              >
+                <ArrowRight className="w-4 h-4" />
+                Explore the full historical case for the Resurrection
+              </Link>
+            </div>
+
+            {/* Apostolic Succession */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800 font-serif">Apostolic Succession</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Before the Apostles died, they passed on their authority by the laying on of hands
+                &mdash; ordaining bishops to lead the communities they had founded. This transmission
+                of authority in an unbroken chain from the Apostles to the bishops of today is called
+                Apostolic Succession. The Catholic Church holds that this succession is essential to
+                the identity and authority of the Church.
+              </p>
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Catechism of the Catholic Church</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;In order that the mission entrusted to them might be continued after their death,
+                  [the Apostles] consigned, by will and testament, as it were, to their immediate
+                  collaborators the duty of completing and consolidating the work they had begun,
+                  urging them to tend to the whole flock, in which the Holy Spirit had appointed them
+                  to shepherd the Church of God.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>CCC 861</em></p>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The earliest evidence for apostolic succession comes from within a generation of the
+                Apostles themselves. Clement of Rome (c. AD 96) already speaks of the authority passed
+                from Christ to the Apostles, and from the Apostles to their appointed successors. The
+                unbroken chain of episcopal ordinations means that every validly ordained bishop in
+                the Catholic Church today can trace his ordination lineage &mdash; through the laying
+                on of hands &mdash; back to the Apostles themselves.
+              </p>
+              <div className="bg-gray-50 rounded-lg p-5">
+                <p className="text-sm text-gray-600">
+                  <strong>CCC References:</strong> 857&ndash;865 on the Apostles and their successors;
+                  861&ndash;862 specifically on apostolic succession and the college of bishops.
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-gray-50 rounded-lg p-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4">Sources &amp; Further Reading</h3>
+              <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+                <li>Eusebius of Caesarea, <em>Ecclesiastical History</em> (c. AD 313) &mdash; the primary ancient source for apostolic traditions</li>
+                <li>Clement of Rome, <em>1 Clement</em> (c. AD 96), chapters 4&ndash;6 &mdash; the earliest extra-biblical witness to the deaths of Peter and Paul</li>
+                <li>Ignatius of Antioch, seven letters (c. AD 107), especially <em>To the Romans</em></li>
+                <li>Sean McDowell, <em>The Fate of the Apostles: Examining the Martyrdom Accounts of the Closest Followers of Jesus</em> (Routledge, 2015) &mdash; the most thorough modern scholarly treatment</li>
+                <li>F.F. Bruce, <em>The Spreading Flame</em> (Paternoster, 1958)</li>
+                <li>Margherita Guarducci, <em>The Tomb of St. Peter</em> (Hawthorn Books, 1960) &mdash; on the Vatican excavations of 1939&ndash;1949 and the identification of Peter&apos;s relics</li>
+                <li>A. Mathias Mundadan, <em>History of Christianity in India, Vol. 1: From the Beginnings up to the Middle of the Sixteenth Century</em> (Bangalore, 1989) &mdash; on the Saint Thomas tradition in Kerala</li>
+                <li><em>New Catholic Encyclopedia</em>, &ldquo;Apostles&rdquo; entries (2nd ed., Gale)</li>
+                <li><em>Catechism of the Catholic Church</em>, CCC 857&ndash;865 (The Apostles and their Successors)</li>
+              </ol>
+            </div>
+
+          </div>
+        )}
+
       </div>
     </div>
   )

--- a/src/app/history/church-divisions/page.tsx
+++ b/src/app/history/church-divisions/page.tsx
@@ -1250,6 +1250,57 @@ const DIVISIONS: Division[] = [
       'Catholic Encyclopedia, "Old Catholics"',
     ],
   },
+  {
+    id: 'church-of-south-india',
+    name: 'Church of South India (CSI)',
+    alternateNames: ['CSI'],
+    category: 'post-reformation',
+    era: 'Modern (1800-Present)',
+    yearStart: 1947,
+    region: 'South India (Tamil Nadu, Kerala, Karnataka, Andhra Pradesh, Telangana); diaspora worldwide',
+    status: 'active',
+    estimatedFollowers: '~4-5 million members; second-largest Christian church in India',
+    founder: 'Union of Anglican, Methodist, and Reformed/Congregational bodies (no single founder)',
+    shortDescription:
+      'A 1947 union of Anglican, Methodist, Congregational, and Presbyterian/Reformed churches in South India — the first major union worldwide to bring together episcopal and non-episcopal Protestant traditions into a single body. Notable as a partial reversal of post-Reformation Protestant fragmentation, though not in communion with Rome.',
+    causes: {
+      theological: [
+        'Conviction that the divisions inherited from European Protestantism had no missionary or theological justification on Indian soil',
+        'Acceptance of the historic episcopate as a uniting structure (without judging its absence in non-episcopal traditions as invalid)',
+        'Mutual recognition of ministries through a process called "extension of episcopacy"',
+      ],
+      cultural: [
+        'Indian Christian leadership\'s rejection of European denominational labels',
+        'Post-independence India: forging an indigenous Christian identity beyond colonial inheritance',
+      ],
+      political: ['Independence movement context: 1947 union came just six weeks after Indian independence (15 August 1947)'],
+    },
+    keyFigures: [
+      'Bishop V. S. Azariah (early advocate before his death in 1945)',
+      'Bishop Lesslie Newbigin (one of the first CSI bishops; later Bishop of Madras)',
+      'Bishop A. J. Appasamy',
+      'Bishop Stephen Neill',
+    ],
+    keyEvents: [
+      { year: '1919', event: 'Tranquebar Manifesto: Indian Christian leaders call for organic union' },
+      { year: '1908', event: 'South India United Church formed (Congregational + Presbyterian/Reformed)' },
+      { year: '1919-1947', event: 'Decades of negotiation between Anglican, Methodist, and SIUC bodies' },
+      { year: '1947', event: 'Church of South India inaugurated 27 September 1947 in St. George\'s Cathedral, Madras' },
+      { year: '1972', event: 'Church of North India (CNI) parallel union formed' },
+      { year: '1978', event: 'CSI-CNI-Mar Thoma Joint Council establishes mutual eucharistic hospitality' },
+    ],
+    resolution: 'A united Protestant body that has continued for 75+ years; member of Anglican Communion, World Methodist Council, World Communion of Reformed Churches, and World Council of Churches.',
+    fullDescription:
+      'The Church of South India was inaugurated on 27 September 1947 at St. George\'s Cathedral, Madras (now Chennai), just six weeks after Indian independence. It brought together four ecclesial families — the Anglican dioceses of South India, the South India province of the Methodist Church, and the South India United Church (which itself was an earlier 1908 union of Congregational, Presbyterian, and Dutch Reformed bodies) — into a single church under a unified episcopal structure. This was the first major union worldwide to combine episcopal (Anglican) and non-episcopal (Methodist, Reformed, Congregational) Protestant traditions, and it was watched closely by ecumenists everywhere. The CSI accepted the historic episcopate as a uniting structure while explicitly declining to declare non-episcopal ministries invalid; over a thirty-year transitional period, all CSI ministers came under episcopal ordination through a process called the "extension of episcopacy." The CSI is unusual in this list of "divisions" because it represents the inverse: a partial reversal of post-Reformation fragmentation. It does not, however, restore communion with the Catholic Church, the Eastern Orthodox, or the Oriental Orthodox bodies (including the ancient Saint Thomas Christians of Kerala). The CSI today numbers around 4-5 million members across 24 dioceses and is the second-largest Christian body in India after the Catholic Church.',
+    catholicResponse: 'The Catholic Church recognizes the CSI as a Christian ecclesial community arising from the Reformation traditions. CSI is engaged in dialogue with Catholic dioceses in South India through the National Council of Churches in India and the Catholic Bishops\' Conference of India.',
+    currentRelations: 'Full communion with the Anglican Communion, the Mar Thoma Syrian Church (since 1978), the Church of North India, and other united churches. In dialogue with Catholic and Orthodox bodies through the National Council of Churches of India.',
+    sources: [
+      'Bengt Sundkler, Church of South India: The Movement Towards Union 1900-1947',
+      'Lesslie Newbigin, A South India Diary; The Reunion of the Church',
+      'CSI Constitution (1947, with subsequent amendments)',
+      'Robert Eric Frykenberg, Christianity in India: From Beginnings to the Present (Oxford, 2008)',
+    ],
+  },
 
   // -------------------- Modern Movements --------------------
   {
@@ -1297,6 +1348,51 @@ const DIVISIONS: Division[] = [
       'Allan Anderson, An Introduction to Pentecostalism (Cambridge, 2nd ed. 2014)',
       'Catholic-Pentecostal International Dialogue, official reports (1972-present)',
       'Vinson Synan, The Century of the Holy Spirit (Thomas Nelson, 2001)',
+    ],
+  },
+  {
+    id: 'new-life-fellowship',
+    name: 'New Life Fellowship Church (Mumbai/India)',
+    alternateNames: ['NLFC', 'New Life Fellowship Association', 'New Life Churches'],
+    category: 'modern',
+    era: 'Modern (1800-Present)',
+    yearStart: 1968,
+    region: 'Originating Mumbai (Bombay), India; spread across India and into the Indian diaspora',
+    status: 'active',
+    estimatedFollowers: 'Estimates vary widely; tens of thousands of small house-church congregations across India and several hundred thousand adherents',
+    founder: 'Pastor Jose Joseph and family (with associates)',
+    parentId: 'pentecostalism',
+    shortDescription:
+      'An indigenous Indian Neo-Pentecostal / independent Charismatic church-planting movement founded in Mumbai around 1968. Doctrinally Pentecostal in spirituality, but organizationally distinct from classical Pentecostal denominations such as Assemblies of God. Notable for its house-church model and rapid expansion across India.',
+    causes: {
+      theological: [
+        'Pentecostal/charismatic emphasis: baptism in the Spirit, speaking in tongues, divine healing, prophecy',
+        'Restorationist self-understanding: returning to a "New Testament" pattern of believer\'s baptism, lay leadership, simple worship',
+        'Strong evangelistic and missional focus, especially toward unreached Indian populations',
+      ],
+      cultural: [
+        'Indigenous Indian Christian leadership independent of Western missionary structures',
+        'Adoption of the house-church model suited to urban Indian settings (rented rooms, homes, small halls)',
+        'Use of vernacular Indian languages for worship and discipleship',
+      ],
+    },
+    keyFigures: ['Jose Joseph (founding pastor)', 'Other founding family members (Joseph brothers)', 'Various senior pastors of constituent churches across India'],
+    keyEvents: [
+      { year: 'c. 1968', event: 'Beginnings in Mumbai under Pastor Jose Joseph; small fellowship gatherings' },
+      { year: '1970s-80s', event: 'Expansion of the house-church model across Mumbai and into other Indian cities' },
+      { year: '1990s-2000s', event: 'Significant church-planting wave reaching multiple Indian states' },
+      { year: '2000s-present', event: 'Continued growth; multiple New Life networks and affiliated bodies operating across India and abroad' },
+    ],
+    resolution: 'An ongoing Protestant Neo-Pentecostal movement, organizationally independent and varied in governance from city to city.',
+    fullDescription:
+      'New Life Fellowship Church (NLFC) is an indigenous Indian Neo-Pentecostal / independent Charismatic movement that emerged in Mumbai in the late 1960s under Pastor Jose Joseph and his associates. Theologically it stands within the broader Pentecostal tradition — affirming baptism in the Holy Spirit, speaking in tongues, divine healing, and the contemporary operation of the gifts of 1 Corinthians 12 — but it is organizationally distinct from classical Pentecostal denominations such as the Assemblies of God or the Church of God in Christ. NLFC pioneered a distinctive house-church model in urban India: small congregations meeting in rented rooms, homes, or simple halls under indigenous leadership, with rapid multiplication and disciple-making as a strategic priority. The movement has grown to thousands of small congregations across India, with affiliated networks among the Indian diaspora.\n\nIMPORTANT NOTE ON DISAMBIGUATION: There are several unrelated churches around the world named "New Life Fellowship" (most prominently a separate church in Queens, New York founded by Pete Scazzero, with no connection to the Indian movement). This entry refers specifically to the Mumbai/India NLFC.\n\nNLFC is doctrinally Protestant: it does not recognize the seven sacraments, papal authority, Marian dogmas, the intercession of saints, or apostolic succession in the Catholic-Orthodox sense. It practices believer\'s baptism by immersion and a memorial view of the Lord\'s Supper.',
+    catholicResponse: 'No formal dialogue. The Catholic Church in India relates to NLFC at the local level through the National Council of Churches in India and through informal cooperation in matters of religious freedom, social action, and (where appropriate) charitable work.',
+    currentRelations: 'Independent of formal ecumenical structures; some local cooperation with other Indian Protestant bodies. Limited direct engagement with the Catholic Bishops\' Conference of India.',
+    sources: [
+      'Roger E. Hedlund (ed.), Christianity is Indian: The Emergence of an Indigenous Community (MIIS / ISPCK, 2nd ed. 2004)',
+      'Allan Anderson, An Introduction to Pentecostalism (Cambridge, 2nd ed. 2014) — chapters on Indian Pentecostalism',
+      'Michael Bergunder, The South Indian Pentecostal Movement in the Twentieth Century (Eerdmans, 2008)',
+      'Local NLFC publications and church-planting reports',
     ],
   },
 

--- a/src/app/history/church-divisions/page.tsx
+++ b/src/app/history/church-divisions/page.tsx
@@ -1,7 +1,25 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { ChevronRight, ChevronDown, Calendar, Users, AlertTriangle, BookOpen } from 'lucide-react'
+import { useState, useEffect, useMemo } from 'react'
+import Link from 'next/link'
+import {
+  ChevronRight,
+  ChevronDown,
+  Calendar,
+  Users,
+  AlertTriangle,
+  BookOpen,
+  Search,
+  MapPin,
+  User,
+  List,
+  Network,
+  ExternalLink,
+} from 'lucide-react'
+
+// ============================================================================
+// OLD VIEW TYPES (existing DB-backed shape)
+// ============================================================================
 
 interface ChurchDivision {
   id: string
@@ -16,7 +34,2035 @@ interface ChurchDivision {
   relatedPopes: any[]
 }
 
-export default function ChurchDivisionsPage() {
+// ============================================================================
+// NEW VIEW TYPES
+// ============================================================================
+
+type Category =
+  | 'early-heresy'
+  | 'christological'
+  | 'great-schism'
+  | 'medieval'
+  | 'reformation'
+  | 'post-reformation'
+  | 'modern'
+  | 'restorationist'
+  | 'eastern-catholic'
+  | 'traditionalist'
+
+type Status = 'active' | 'extinct' | 'reconciled' | 'partial-communion'
+
+interface Division {
+  id: string
+  name: string
+  alternateNames?: string[]
+  category: Category
+  era: string
+  yearStart: number
+  yearEnd?: number
+  founder?: string
+  region: string
+  status: Status
+  estimatedFollowers?: string
+  parentId?: string
+  shortDescription: string
+  causes: {
+    theological?: string[]
+    political?: string[]
+    cultural?: string[]
+  }
+  keyFigures: string[]
+  keyEvents: { year: string; event: string }[]
+  resolution?: string
+  fullDescription: string
+  catholicResponse?: string
+  currentRelations?: string
+  sources: string[]
+}
+
+const CATEGORY_META: Record<Category, { label: string; description: string; color: string; order: number }> = {
+  'early-heresy': {
+    label: 'Early Heresies (pre-Nicaea)',
+    description: '1st-4th century movements that broke from apostolic teaching before the first ecumenical council.',
+    color: 'bg-red-100 text-red-800 border-red-200',
+    order: 1,
+  },
+  'christological': {
+    label: 'Christological & Trinitarian Controversies',
+    description: 'Disputes over the nature of Christ and the Trinity, addressed by the early ecumenical councils.',
+    color: 'bg-orange-100 text-orange-800 border-orange-200',
+    order: 2,
+  },
+  'great-schism': {
+    label: 'The Great Schism (East-West)',
+    description: 'The 1054 break between Rome and Constantinople, and the Eastern Orthodox communion that followed.',
+    color: 'bg-purple-100 text-purple-800 border-purple-200',
+    order: 3,
+  },
+  'medieval': {
+    label: 'Medieval Movements',
+    description: 'High and late medieval reform movements, dissenters, and dualist sects.',
+    color: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+    order: 4,
+  },
+  'reformation': {
+    label: 'Protestant Reformation',
+    description: '16th-century breaks from Rome: Lutheran, Reformed, Anglican, and Anabaptist traditions.',
+    color: 'bg-blue-100 text-blue-800 border-blue-200',
+    order: 5,
+  },
+  'post-reformation': {
+    label: 'Post-Reformation (17th-19th c.)',
+    description: 'Later Protestant offshoots including Baptists, Methodists, Quakers, and Old Catholics.',
+    color: 'bg-cyan-100 text-cyan-800 border-cyan-200',
+    order: 6,
+  },
+  'modern': {
+    label: 'Modern Movements (19th-20th c.)',
+    description: 'Pentecostal, Adventist, and other modern revival movements.',
+    color: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+    order: 7,
+  },
+  'restorationist': {
+    label: 'Restorationist (outside historic Christianity)',
+    description: 'New religious movements that claim to restore primitive Christianity but depart from historic orthodoxy.',
+    color: 'bg-pink-100 text-pink-800 border-pink-200',
+    order: 8,
+  },
+  'eastern-catholic': {
+    label: 'Eastern Catholic Churches',
+    description: 'Eastern churches in full communion with Rome while preserving their own liturgy and tradition.',
+    color: 'bg-amber-100 text-amber-800 border-amber-200',
+    order: 9,
+  },
+  'traditionalist': {
+    label: 'Traditionalist Catholic',
+    description: 'Post-Vatican II groups that reject or partially reject the council\'s reforms.',
+    color: 'bg-stone-100 text-stone-800 border-stone-200',
+    order: 10,
+  },
+}
+
+// ============================================================================
+// DIVISIONS DATASET
+// Add new divisions here. Each entry follows the Division interface.
+// ============================================================================
+
+const DIVISIONS: Division[] = [
+  // -------------------- Early Heresies --------------------
+  {
+    id: 'marcionism',
+    name: 'Marcionism',
+    alternateNames: ['Marcionite Church'],
+    category: 'early-heresy',
+    era: 'Early Church (33-313)',
+    yearStart: 144,
+    yearEnd: 500,
+    founder: 'Marcion of Sinope',
+    region: 'Roman Empire (originated Asia Minor, spread to Rome)',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct (significant 2nd-4th c.)',
+    shortDescription:
+      'A 2nd-century movement that rejected the Old Testament and most of the New Testament, teaching that the God of Israel was a different, lesser deity than the Father of Jesus Christ.',
+    causes: {
+      theological: [
+        'Radical dualism between the wrathful "Demiurge" of the Old Testament and the merciful Father revealed by Jesus',
+        'Rejection of the Hebrew Scriptures and Jewish heritage of Christianity',
+        'Docetic tendencies regarding the humanity of Christ',
+      ],
+      cultural: [
+        'Anti-Jewish sentiment in parts of the Greco-Roman world',
+        'Influence of philosophical dualism',
+      ],
+    },
+    keyFigures: ['Marcion of Sinope', 'Apelles (disciple)', 'Tertullian (opponent)', 'Irenaeus of Lyons (opponent)'],
+    keyEvents: [
+      { year: 'c. 144', event: 'Marcion expelled from the Roman Christian community; founds his own church' },
+      { year: 'c. 144', event: 'Marcion publishes his "canon": an edited Luke and ten Pauline epistles' },
+      { year: 'c. 207', event: 'Tertullian writes Adversus Marcionem in five books' },
+      { year: '4th-5th c.', event: 'Marcionite communities gradually absorbed by Manichaeism or mainstream Church' },
+    ],
+    resolution:
+      'Suppressed by sustained refutation from Church Fathers and the formation of the orthodox New Testament canon as a direct response to Marcion\'s truncated scriptures.',
+    fullDescription:
+      'Marcion of Sinope, a wealthy shipowner and son of a bishop, arrived in Rome around 140 AD and proposed a radical reinterpretation of the Christian message. He argued that the God revealed in Jesus Christ was utterly distinct from the Creator God of the Hebrew Bible, whom he characterized as harsh, ignorant, and vengeful. To support this, Marcion produced what is often called the first attempted Christian canon: a heavily edited version of Luke\'s Gospel and ten Pauline letters, with all positive references to the Old Testament removed. The Roman church returned his substantial donation and excommunicated him around 144 AD. Marcionism spread rapidly throughout the empire and was, for a time, one of the most serious rivals to apostolic Christianity. The orthodox response was decisive: figures like Justin Martyr, Irenaeus, and Tertullian wrote extensively against him, and the Church\'s growing consensus on a fourfold Gospel canon and the unity of the Old and New Testaments was accelerated by the need to refute Marcionism. The movement persisted until the fifth century before being absorbed into Manichaeism or returning to mainstream Christianity.',
+    catholicResponse:
+      'The Church Fathers, especially Irenaeus (Against Heresies) and Tertullian (Against Marcion), defended the unity of the two Testaments and the goodness of creation. The development of the New Testament canon and the rule of faith were sharpened in direct opposition to Marcion.',
+    currentRelations: 'Extinct; no modern adherents.',
+    sources: [
+      'Tertullian, Adversus Marcionem',
+      'Irenaeus, Adversus Haereses',
+      'Eusebius, Ecclesiastical History',
+      'Catholic Encyclopedia, "Marcionites"',
+    ],
+  },
+  {
+    id: 'montanism',
+    name: 'Montanism',
+    alternateNames: ['New Prophecy', 'Cataphrygian heresy'],
+    category: 'early-heresy',
+    era: 'Early Church (33-313)',
+    yearStart: 156,
+    yearEnd: 800,
+    founder: 'Montanus',
+    region: 'Phrygia (Asia Minor), spreading to North Africa and Rome',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct (notable 2nd-6th c.)',
+    shortDescription:
+      'An ecstatic prophetic movement claiming a "New Prophecy" superseding the apostolic age. Tertullian famously joined the movement in his later years.',
+    causes: {
+      theological: [
+        'Claim of new, ongoing revelation through ecstatic prophecy',
+        'Imminent expectation of the New Jerusalem descending in Pepuza, Phrygia',
+        'Rigorist morality: forbidding remarriage, encouraging martyrdom, strict fasting',
+      ],
+      cultural: [
+        'Reaction against perceived laxity in the developing institutional Church',
+        'Charismatic religious traditions of Phrygia',
+      ],
+    },
+    keyFigures: ['Montanus', 'Prisca (Priscilla)', 'Maximilla', 'Tertullian (later joined)', 'Pope Zephyrinus'],
+    keyEvents: [
+      { year: 'c. 156-172', event: 'Montanus begins prophesying in Phrygia; joined by Prisca and Maximilla' },
+      { year: 'c. 177', event: 'Bishops of Asia Minor begin condemning the movement' },
+      { year: 'c. 207', event: 'Tertullian of Carthage embraces Montanism' },
+      { year: '6th c.', event: 'Justinian I orders suppression; remnants survive into the 8th century' },
+    ],
+    resolution:
+      'Condemned by local synods in Asia Minor and rejected by the Roman bishops; gradually suppressed by imperial action under Justinian.',
+    fullDescription:
+      'Around the middle of the second century, Montanus, a recent convert in Phrygia, began to prophesy in ecstatic states, soon joined by two women, Prisca and Maximilla. They proclaimed a "New Prophecy" announcing the imminent descent of the heavenly Jerusalem at Pepuza and Tymion in Phrygia. The movement combined apocalyptic urgency with rigorous asceticism: it forbade second marriages, demanded strict fasts, and exalted martyrdom. While Montanists held orthodox views on the Trinity and Christ, their claim that the Paraclete spoke through their prophets in a way that supplemented apostolic teaching was decisively rejected by the wider Church. The movement gained a remarkable convert in the great Latin theologian Tertullian, whose later writings reflect Montanist sympathies. Bishops of Asia Minor convened synods to condemn the movement, and Rome eventually followed. Montanism persisted in pockets, particularly in Phrygia, until Justinian I ordered the destruction of their shrines in the sixth century; the last remnants disappeared by the eighth century.',
+    catholicResponse:
+      'Local synods in Asia Minor condemned the movement; Rome (under disputed circumstances) eventually agreed. The episode helped clarify the Church\'s position that public revelation closed with the apostles.',
+    currentRelations: 'Extinct; influenced later charismatic and prophetic movements indirectly.',
+    sources: [
+      'Eusebius, Ecclesiastical History V.16-19',
+      'Epiphanius, Panarion 48',
+      'Tertullian, De Pudicitia',
+      'Catholic Encyclopedia, "Montanists"',
+    ],
+  },
+  {
+    id: 'gnosticism',
+    name: 'Gnosticism',
+    alternateNames: ['Valentinianism', 'Sethian Gnosticism', 'Basilideans'],
+    category: 'early-heresy',
+    era: 'Early Church (33-313)',
+    yearStart: 100,
+    yearEnd: 500,
+    founder: 'Diverse (Valentinus, Basilides, others)',
+    region: 'Egypt, Syria, Rome, Asia Minor',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct (peaked 2nd c.)',
+    shortDescription:
+      'A diverse 2nd-century movement teaching salvation through secret knowledge (gnosis), often involving elaborate cosmic mythologies and a sharp dualism between spirit and matter.',
+    causes: {
+      theological: [
+        'Belief that matter is evil and the material world was created by a lesser deity (Demiurge)',
+        'Salvation through esoteric knowledge available only to initiates',
+        'Docetism: denial that Christ truly took human flesh',
+      ],
+      cultural: [
+        'Syncretism with Platonic philosophy, Jewish apocalyptic, and Eastern religious ideas',
+        'Appeal of esoteric, initiatory religion in the Hellenistic world',
+      ],
+    },
+    keyFigures: ['Valentinus', 'Basilides', 'Marcion (related)', 'Irenaeus of Lyons (opponent)', 'Hippolytus (opponent)', 'Clement of Alexandria (opponent)'],
+    keyEvents: [
+      { year: 'c. 130-160', event: 'Valentinus teaches in Rome; Basilides in Alexandria' },
+      { year: 'c. 180', event: 'Irenaeus writes Adversus Haereses, the major refutation of Gnosticism' },
+      { year: '4th c.', event: 'Decline as the Church gains imperial support' },
+      { year: '1945', event: 'Discovery of the Nag Hammadi library in Egypt revolutionizes scholarly understanding' },
+    ],
+    resolution:
+      'Refuted by Church Fathers, marginalized by the establishment of the apostolic canon and creeds, and finally suppressed under Christian Roman emperors.',
+    fullDescription:
+      'Gnosticism is not a single church but a diverse family of religious movements that flourished in the second century, all sharing a conviction that salvation comes through possessing a secret, saving knowledge (gnosis) about the true nature of God, the cosmos, and the self. Most Gnostic systems included a sharp dualism between an unknown true God and a lesser, often hostile, creator (the Demiurge), frequently identified with the God of the Hebrew Bible. The material world was viewed as a prison from which the divine spark within the elect must be liberated. Christ was understood not as a true incarnation but as a heavenly emissary appearing to bring saving knowledge. Major teachers included Valentinus, who attracted a sophisticated following in Rome, and Basilides in Alexandria. The orthodox response was led by Irenaeus of Lyons, whose five-book Adversus Haereses (c. 180) systematically catalogued and refuted Gnostic teachings while articulating the apostolic rule of faith, the unity of Scripture, the goodness of creation, and the reality of the Incarnation. The 1945 discovery of the Nag Hammadi codices in Egypt provided modern scholars with primary Gnostic texts, including the Gospel of Thomas, transforming our understanding of this movement.',
+    catholicResponse:
+      'Irenaeus, Tertullian, Hippolytus, Clement of Alexandria, and Origen wrote major refutations. The Church\'s emphasis on the apostolic succession of bishops, the public rule of faith, and the four-Gospel canon all crystallized partly in response to Gnostic claims of secret tradition.',
+    currentRelations: 'Extinct as an organized religion; some new religious movements claim Gnostic inspiration but have no historical continuity.',
+    sources: [
+      'Irenaeus, Adversus Haereses',
+      'The Nag Hammadi Library (1945 discovery)',
+      'Hippolytus, Refutation of All Heresies',
+      'Catholic Encyclopedia, "Gnosticism"',
+    ],
+  },
+  {
+    id: 'manichaeism',
+    name: 'Manichaeism',
+    alternateNames: ['Manichaean religion'],
+    category: 'early-heresy',
+    era: 'Early Church (33-313)',
+    yearStart: 240,
+    yearEnd: 1400,
+    founder: 'Mani (216-274 AD)',
+    region: 'Persia, Roman Empire, Central Asia, China',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct (major 3rd-7th c. in West; survived in China to 14th c.)',
+    shortDescription:
+      'A dualistic religion founded by the Persian prophet Mani, blending Christian, Zoroastrian, and Buddhist elements. St. Augustine spent nine years as a Manichaean before his conversion.',
+    causes: {
+      theological: [
+        'Cosmic dualism: eternal opposition between Light (good, spiritual) and Darkness (evil, material)',
+        'View of Mani as the final prophet completing Jesus, Buddha, and Zoroaster',
+        'Strict asceticism for the "Elect"; lesser obligations for the "Hearers"',
+      ],
+      political: [
+        'Initially favored, then persecuted by the Sassanid Persian dynasty',
+        'Outlawed by Diocletian (302) and later Christian emperors',
+      ],
+    },
+    keyFigures: ['Mani', 'Augustine of Hippo (former Manichaean)', 'Faustus of Mileve', 'Diocletian (persecutor)'],
+    keyEvents: [
+      { year: '240', event: 'Mani begins preaching in the Sassanid Persian Empire' },
+      { year: '274', event: 'Mani executed by Sassanid authorities' },
+      { year: '302', event: 'Diocletian issues an edict against Manichaeans in the Roman Empire' },
+      { year: '373-382', event: 'Augustine of Hippo is a Manichaean Hearer' },
+      { year: '1370s', event: 'Last Manichaean communities suppressed in China under the Ming dynasty' },
+    ],
+    resolution:
+      'Suppressed by Christian, Zoroastrian, and later Islamic and Confucian authorities. Augustine\'s anti-Manichaean writings shaped Western theology of evil, free will, and grace.',
+    fullDescription:
+      'Manichaeism was founded in the third century by the Persian prophet Mani, who claimed to be the final Paraclete completing the partial revelations of Jesus, Buddha, and Zoroaster. At its core was an absolute cosmic dualism: two eternal principles, Light and Darkness, locked in a primordial conflict, with the material world as the battlefield in which particles of Light are imprisoned in matter. Salvation consisted in the liberation of these Light particles through ascetic practice. The faithful were divided into the "Elect," who lived in extreme asceticism and celibacy, and the "Hearers," who supported the Elect and lived under lighter rules. Manichaeism spread astonishingly quickly, reaching from North Africa to China. Its impact on Christianity is most famously seen in Augustine of Hippo, who spent nine years (373-382) as a Manichaean Hearer before his conversion to Catholicism. Augustine\'s subsequent writings against the Manichaeans, defending the goodness of creation, free will, and the unity of God, shaped the entire trajectory of Western theology. In Europe, Manichaean ideas may have influenced later dualist movements such as the Bogomils and Cathars, though direct historical continuity is debated.',
+    catholicResponse:
+      'Augustine\'s anti-Manichaean works (Contra Faustum, De Genesi contra Manichaeos, etc.) established the Catholic doctrine of evil as privation of good, the goodness of creation, and the responsibility of free will.',
+    currentRelations: 'Extinct.',
+    sources: [
+      'Augustine, Confessions; Contra Faustum Manichaeum',
+      'The Cologne Mani Codex',
+      'S.N.C. Lieu, Manichaeism in the Later Roman Empire and Medieval China',
+      'Catholic Encyclopedia, "Manichaeism"',
+    ],
+  },
+  {
+    id: 'donatism',
+    name: 'Donatism',
+    alternateNames: ['Donatist Church'],
+    category: 'early-heresy',
+    era: 'Early Church (33-313)',
+    yearStart: 311,
+    yearEnd: 700,
+    founder: 'Donatus Magnus',
+    region: 'Roman North Africa (modern Algeria, Tunisia)',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct (major 4th-5th c. in North Africa)',
+    shortDescription:
+      'A North African schism over whether bishops who had handed over scriptures during the Diocletian persecution could validly ordain or administer sacraments. Augustine\'s major pastoral and theological opponent.',
+    causes: {
+      theological: [
+        'Claim that sacraments administered by "traditores" (those who had handed over scriptures) were invalid',
+        'Belief that the Church must consist of the morally pure',
+        'Demand for rebaptism of those baptized by lapsed clergy',
+      ],
+      political: [
+        'Resentment of Roman imperial authority in North Africa',
+        'Appeal to indigenous Berber religious sentiment',
+      ],
+      cultural: [
+        'North African tradition of rigorous discipline (Tertullian, Cyprian)',
+        'Memory of recent persecution and the cult of martyrs',
+      ],
+    },
+    keyFigures: ['Donatus Magnus', 'Caecilian of Carthage (opponent)', 'Augustine of Hippo (opponent)', 'Optatus of Milevis (opponent)'],
+    keyEvents: [
+      { year: '311', event: 'Disputed election of Caecilian of Carthage triggers the schism' },
+      { year: '313-316', event: 'Council of Rome and Council of Arles rule against the Donatists' },
+      { year: '411', event: 'Conference of Carthage; imperial decision against the Donatists' },
+      { year: '430', event: 'Death of Augustine; Vandal invasion soon after disrupts both communities' },
+      { year: '7th c.', event: 'Islamic conquest ends Christianity in North Africa, including Donatism' },
+    ],
+    resolution:
+      'Suppressed by imperial coercion after 411 and finally extinguished by the Islamic conquest of North Africa in the seventh century. Augustine\'s theology of the sacraments (validity ex opere operato) became foundational Catholic doctrine.',
+    fullDescription:
+      'The Donatist controversy arose from the question of how the Church should treat clergy who, during the Great Persecution under Diocletian (303-311), had handed over sacred books to Roman authorities. When Caecilian was elected bishop of Carthage in 311, his consecrator was alleged to have been a traditor, and a rival group elected Majorinus, soon succeeded by Donatus, whose name the schism bears. The Donatists held that the holiness of the Church depended on the personal holiness of its ministers, and that sacraments performed by lapsed clergy were void. They rebaptized those who came to them from the catholic communion. Their movement appealed to North African religious rigor and Berber identity, drawing on the legacy of Tertullian and Cyprian. The dispute went to Constantine, who referred it to councils at Rome (313) and Arles (314), both of which ruled against the Donatists. Despite imperial measures, the schism flourished for over a century and at times rivaled the catholic Church in North Africa. Augustine of Hippo became its most formidable opponent, developing the doctrine that sacraments derive their efficacy from Christ rather than the minister, and articulating the visible Church as a "mixed body" of saints and sinners until the final judgment. The Conference of Carthage in 411 produced a decisive imperial ruling against the Donatists, and they declined steadily until the Vandal invasions and finally the Islamic conquest extinguished organized Christianity in the region.',
+    catholicResponse:
+      'Augustine\'s anti-Donatist writings established the principles ex opere operato (sacraments are valid by virtue of Christ\'s action, not the minister\'s holiness) and the Church as corpus permixtum. These remain foundational to Catholic sacramental theology.',
+    currentRelations: 'Extinct.',
+    sources: [
+      'Augustine, Contra Litteras Petiliani; De Baptismo',
+      'Optatus of Milevis, Against the Donatists',
+      'W.H.C. Frend, The Donatist Church',
+      'Catholic Encyclopedia, "Donatists"',
+    ],
+  },
+  // -------------------- Christological / Trinitarian --------------------
+  {
+    id: 'arianism',
+    name: 'Arianism',
+    alternateNames: ['Arian heresy', 'Homoian Arianism'],
+    category: 'christological',
+    era: 'Imperial Church (313-787)',
+    yearStart: 318,
+    yearEnd: 700,
+    founder: 'Arius of Alexandria',
+    region: 'Roman Empire, Germanic kingdoms (Goths, Vandals, Lombards)',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct (dominant in Germanic kingdoms 4th-7th c.)',
+    shortDescription:
+      'The teaching that the Son of God was created by the Father and is therefore not co-eternal or fully divine. Condemned at Nicaea (325) but persisted for centuries among the Germanic peoples.',
+    causes: {
+      theological: [
+        'Strict subordinationism: only the Father is truly God; the Son is the highest creature',
+        'The famous Arian slogan: "There was a time when the Son was not"',
+        'Concern to safeguard divine monarchy and unity',
+      ],
+      political: [
+        'Imperial vacillation: emperors Constantius II and Valens favored Arian or semi-Arian formulas',
+        'Conversion of Germanic peoples by Arian missionaries (Ulfilas)',
+      ],
+    },
+    keyFigures: ['Arius', 'Athanasius of Alexandria', 'Eusebius of Nicomedia', 'Ulfilas (Gothic apostle)', 'Constantine the Great', 'Constantius II'],
+    keyEvents: [
+      { year: '318', event: 'Arius begins teaching his doctrine in Alexandria' },
+      { year: '325', event: 'First Council of Nicaea condemns Arius; Nicene Creed proclaims the Son is "homoousios" (consubstantial) with the Father' },
+      { year: '341-360', event: 'Period of Arian and semi-Arian dominance under Constantius II' },
+      { year: '381', event: 'First Council of Constantinople reaffirms Nicaea and expands the Creed' },
+      { year: '589', event: 'Visigoths in Spain abandon Arianism at the Third Council of Toledo' },
+      { year: '7th c.', event: 'Last Arian Lombard kingdoms convert to Catholicism' },
+    ],
+    resolution:
+      'Defeated theologically at Nicaea (325) and Constantinople (381); finally extinguished as Arian Germanic kingdoms converted to Catholicism between the 6th and 7th centuries.',
+    fullDescription:
+      'Arianism arose in Alexandria around 318 when the priest Arius began teaching that the Son of God, though the firstborn and most exalted of creatures, was nevertheless created and not co-eternal with the Father. His position was crystallized in the famous slogan "there was a time when the Son was not." This struck at the heart of Christian worship of Christ and threatened to reduce the Incarnation to the appearance of a creature. The bishop of Alexandria, Alexander, and his deacon (later bishop) Athanasius opposed Arius vigorously. Emperor Constantine, newly committed to Christianity, summoned the First Council of Nicaea (325), the first ecumenical council, which condemned Arius and confessed the Son as homoousios (of the same substance) with the Father. Yet Arianism persisted for over a century within the empire, often supported by emperors. Athanasius spent much of his life in exile, sustaining the Nicene cause. The Cappadocian Fathers (Basil the Great, Gregory of Nazianzus, Gregory of Nyssa) refined the trinitarian vocabulary, distinguishing one ousia (essence) and three hypostases (persons). The First Council of Constantinople (381) decisively reaffirmed Nicaea. Meanwhile, the Gothic missionary Ulfilas (a moderate Arian) had converted the Goths, who in turn evangelized other Germanic peoples in their own form of the faith. As a result, when the Western Roman Empire collapsed, most of the new Germanic kingdoms (Visigoths, Ostrogoths, Vandals, Lombards, Burgundians) were Arian, in religious tension with their Catholic Roman subjects. The conversion of Clovis of the Franks to Catholicism (496), the Visigoths at the Third Council of Toledo (589), and finally the last Lombards in the seventh century, ended Arianism as an organized force.',
+    catholicResponse:
+      'The Nicene Creed (325) and the Niceno-Constantinopolitan Creed (381) remain the central confession of Catholic, Orthodox, and most Protestant Christians. Athanasius and the Cappadocians shaped Trinitarian orthodoxy.',
+    currentRelations: 'Extinct as an organized church. Modern groups holding Arian-like views (e.g., Jehovah\'s Witnesses) are treated as separate movements.',
+    sources: [
+      'Athanasius, Orationes contra Arianos',
+      'R.P.C. Hanson, The Search for the Christian Doctrine of God',
+      'Council of Nicaea (325) acts and creed',
+      'Catholic Encyclopedia, "Arianism"',
+    ],
+  },
+  {
+    id: 'nestorianism',
+    name: 'Nestorianism',
+    alternateNames: ['Church of the East', 'Assyrian Church of the East', 'East Syriac Church'],
+    category: 'christological',
+    era: 'Imperial Church (313-787)',
+    yearStart: 431,
+    founder: 'Nestorius (Patriarch of Constantinople)',
+    region: 'Originally Syria, Mesopotamia; today Iraq, Syria, India, diaspora',
+    status: 'active',
+    estimatedFollowers: '~400,000 (Assyrian Church of the East and Ancient Church of the East combined)',
+    shortDescription:
+      'A Christological position emphasizing the distinction between Christ\'s divine and human natures so sharply that opponents charged it with teaching two persons. The Assyrian Church of the East descends from this tradition and continues today.',
+    causes: {
+      theological: [
+        'Emphasis on the full reality of both natures, especially the integrity of Christ\'s humanity',
+        'Reluctance to call Mary "Theotokos" (God-bearer); Nestorius preferred "Christotokos" (Christ-bearer)',
+        'Antiochene exegetical tradition vs. Alexandrian',
+      ],
+      political: [
+        'Rivalry between sees of Alexandria and Constantinople',
+        'Sasanian Persian patronage of an East Syriac church distinct from the Roman imperial church',
+      ],
+      cultural: [
+        'Linguistic and theological divide between Syriac East and Greek West',
+      ],
+    },
+    keyFigures: ['Nestorius', 'Cyril of Alexandria (opponent)', 'Theodore of Mopsuestia', 'Pope Celestine I', 'Babai the Great'],
+    keyEvents: [
+      { year: '428', event: 'Nestorius becomes Patriarch of Constantinople and preaches against the title "Theotokos"' },
+      { year: '431', event: 'Council of Ephesus condemns Nestorius and affirms Mary as Theotokos' },
+      { year: '451', event: 'Council of Chalcedon\'s definition of two natures in one person rejected by both Nestorians and Miaphysites' },
+      { year: '486', event: 'Synod of Beth Lapat: Persian church formally adopts a dyophysite Christology' },
+      { year: '7th-13th c.', event: 'Church of the East flourishes from Mesopotamia to China' },
+      { year: '14th c.', event: 'Devastation under Timur reduces the Church of the East to small communities in modern Iraq and Iran' },
+    ],
+    resolution:
+      'The historic break has not been formally healed, but recent Christological dialogues (Common Christological Declaration, 1994) acknowledge that the two churches confess the same faith in Christ in different formulations.',
+    fullDescription:
+      'The Nestorian controversy began when Nestorius, newly appointed Patriarch of Constantinople in 428, criticized the popular Marian title Theotokos ("God-bearer") and preferred Christotokos ("Christ-bearer"), fearing that Theotokos confused the divine and human in Christ. His opponent, Cyril of Alexandria, saw this as a denial of the unity of Christ\'s person. The Council of Ephesus (431) condemned Nestorius and affirmed Theotokos. Nestorius was deposed and eventually exiled. While the imperial Church moved through further refinement at Chalcedon (451), East Syriac Christians, mostly outside the Roman empire under Sasanian Persian rule, increasingly identified with the Antiochene Christological tradition associated with Theodore of Mopsuestia and, to a lesser degree, Nestorius. The Church of the East developed into a distinct communion centered in Mesopotamia, with its own catholicos at Seleucia-Ctesiphon. From the seventh through thirteenth centuries it was one of the largest Christian bodies in the world by geography, sending missions to Central Asia, India (joining the existing Saint Thomas Christians), and as far as Tang-dynasty China (Xi\'an stele, 781). Mongol patronage briefly elevated it, but the conquests of Timur in the late fourteenth century devastated its communities. Modern descendants include the Assyrian Church of the East and the smaller Ancient Church of the East, primarily in Iraq, Syria, and the diaspora; many Saint Thomas Christians of India trace lineage to this tradition, although most are now Catholic (Syro-Malabar) or Oriental Orthodox.',
+    catholicResponse:
+      'The 1994 Common Christological Declaration between Pope John Paul II and Catholicos-Patriarch Mar Dinkha IV affirmed a common faith in Christ. The 2001 admission of Eucharistic sharing in pastoral need was an unprecedented ecumenical step.',
+    currentRelations: 'In active ecumenical dialogue with Rome; agreement on Christology achieved (1994). Many Assyrian Christians of India have entered full communion with Rome as the Chaldean Syrian Church.',
+    sources: [
+      'Acts of the Council of Ephesus (431)',
+      'Common Christological Declaration (1994)',
+      'Sebastian Brock, "The Nestorian Church: A Lamentable Misnomer"',
+      'Wilhelm Baum and Dietmar Winkler, The Church of the East: A Concise History',
+    ],
+  },
+  {
+    id: 'oriental-orthodoxy',
+    name: 'Miaphysitism / Oriental Orthodoxy',
+    alternateNames: ['Non-Chalcedonian Churches', 'Pre-Chalcedonian Churches', 'Monophysitism (older, contested label)'],
+    category: 'christological',
+    era: 'Imperial Church (313-787)',
+    yearStart: 451,
+    founder: 'Various; key theologians include Cyril of Alexandria, Severus of Antioch',
+    region: 'Egypt, Ethiopia, Eritrea, Syria, Armenia, India',
+    status: 'partial-communion',
+    estimatedFollowers: '~60 million across six churches',
+    shortDescription:
+      'Six ancient churches that rejected the Council of Chalcedon (451). Modern dialogue distinguishes their "Miaphysitism" (one united nature, fully divine and fully human) from condemned "Monophysitism" and has produced shared Christological agreements with Rome.',
+    causes: {
+      theological: [
+        'Rejection of Chalcedon\'s formula "in two natures" as compromising the unity of Christ',
+        'Fidelity to Cyril of Alexandria\'s formula "one incarnate nature of God the Word"',
+        'Concern that Chalcedon was a concession to Nestorianism',
+      ],
+      political: [
+        'Resistance to Byzantine imperial coercion',
+        'Regional and ethnic identity (Coptic, Syriac, Armenian) distinct from Greek imperial church',
+      ],
+      cultural: [
+        'Linguistic differences (Coptic, Syriac, Armenian, Ge\'ez vs. Greek)',
+      ],
+    },
+    keyFigures: ['Dioscorus of Alexandria', 'Severus of Antioch', 'Timothy Aelurus', 'Jacob Baradaeus (Syriac)', 'Pope Shenouda III (modern Coptic)'],
+    keyEvents: [
+      { year: '451', event: 'Council of Chalcedon: rejected by the Coptic, Syriac, Armenian, and Ethiopian churches' },
+      { year: '482', event: 'Emperor Zeno\'s Henotikon attempts compromise; ultimately fails' },
+      { year: '6th c.', event: 'Jacob Baradaeus organizes a parallel Syriac hierarchy' },
+      { year: '1442', event: 'Council of Florence: brief reunion of some Coptic and Ethiopian delegates with Rome' },
+      { year: '1973', event: 'Common declaration of Pope Paul VI and Coptic Pope Shenouda III on Christology' },
+      { year: '1990', event: 'Pro Oriente Christological agreements between Catholic and Oriental Orthodox theologians' },
+    ],
+    resolution:
+      'Christological dialogues since 1973 have largely resolved the doctrinal misunderstanding. Full communion has not yet been restored, but the historic charge of heresy has been mutually retracted in joint declarations.',
+    fullDescription:
+      'The Council of Chalcedon (451) defined that Christ is one person "in two natures," divine and human, "without confusion, change, division, or separation." This formula was opposed by a substantial portion of the Eastern Church, particularly in Egypt, Syria, Armenia, and Ethiopia, who saw it as a concession to Nestorianism and a betrayal of Cyril of Alexandria\'s "one incarnate nature of God the Word." Under imperial pressure these churches developed their own hierarchies and have remained distinct ever since. Modern theological scholarship recognizes that most of these "non-Chalcedonian" churches were never strictly Monophysite (the heresy of Eutyches, who held that the human nature was absorbed into the divine), but rather Miaphysite, confessing one united nature of Christ that is fully divine and fully human. The Oriental Orthodox communion today consists of six autocephalous churches: the Coptic Orthodox Church of Alexandria (~10 million, Egypt), the Syriac Orthodox Church (~5 million, originally Antioch), the Armenian Apostolic Church (~9 million, with two catholicosates), the Ethiopian Orthodox Tewahedo Church (~36 million, the largest), the Eritrean Orthodox Tewahedo Church, and the Malankara Orthodox Syrian Church of India (~2.5 million). Each preserves ancient liturgical traditions in its own language. Beginning with the historic Common Declaration of Pope Paul VI and Coptic Pope Shenouda III (1973), the Catholic Church and the Oriental Orthodox have signed a series of agreements affirming the same faith in Christ in different formulas. Ecumenical dialogue continues, and in many regions Catholic and Oriental Orthodox faithful share pastoral cooperation.',
+    catholicResponse:
+      'Catholic teaching upholds Chalcedon\'s definition while acknowledging that the Oriental Orthodox confess the same Christological faith in their own terminology. Joint declarations (1973, 1984, 1990, 1994, 1996) have removed the historic charge of heresy.',
+    currentRelations: 'Partial communion in Christology achieved through a series of joint declarations. The Joint International Commission for Theological Dialogue continues. Eastern Catholic counterparts exist for most Oriental Orthodox churches.',
+    sources: [
+      'Common Declaration of Paul VI and Shenouda III (1973)',
+      'Pro Oriente Vienna Christological Consultations',
+      'Aristeides Papadakis, The Christian East and the Rise of the Papacy',
+      'Catholic Encyclopedia, "Monophysites and Monophysitism"',
+    ],
+  },
+  {
+    id: 'pelagianism',
+    name: 'Pelagianism',
+    alternateNames: ['Semi-Pelagianism (related)', 'Caelestianism'],
+    category: 'christological',
+    era: 'Imperial Church (313-787)',
+    yearStart: 410,
+    yearEnd: 600,
+    founder: 'Pelagius (a British monk in Rome)',
+    region: 'Rome, North Africa, Palestine, Britain, Gaul',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct',
+    shortDescription:
+      'A teaching that human beings, by free will, can take the initial steps toward salvation without the necessity of divine grace; that Adam\'s sin affected only Adam, not his descendants. Augustine\'s lifelong opponent.',
+    causes: {
+      theological: [
+        'Denial of original sin as a transmitted condition',
+        'Affirmation that grace consists primarily in the law and the example of Christ',
+        'Belief that infants are born in the same state as Adam before the Fall',
+      ],
+      cultural: [
+        'Reaction against perceived moral laxity in late Roman Christianity',
+        'Stoic and ascetic ideals of moral self-mastery',
+      ],
+    },
+    keyFigures: ['Pelagius', 'Caelestius (disciple)', 'Julian of Eclanum', 'Augustine of Hippo (opponent)', 'Pope Innocent I', 'Pope Zosimus'],
+    keyEvents: [
+      { year: 'c. 405', event: 'Pelagius reacts against Augustine\'s prayer "Give what you command, and command what you will"' },
+      { year: '411', event: 'Council of Carthage condemns Caelestius' },
+      { year: '418', event: 'Council of Carthage and Pope Zosimus\'s Tractoria condemn Pelagianism' },
+      { year: '431', event: 'Council of Ephesus reaffirms condemnation' },
+      { year: '529', event: 'Second Council of Orange condemns Semi-Pelagianism and affirms Augustine\'s doctrine of grace' },
+    ],
+    resolution:
+      'Definitively condemned at Carthage (418), Ephesus (431), and Orange (529). Augustine\'s doctrine of original sin and prevenient grace became normative for the Latin West.',
+    fullDescription:
+      'Pelagius was a British or Irish ascetic teacher who came to Rome around 380 and gained a reputation for moral seriousness. He was scandalized by Augustine\'s phrase in the Confessions, "Give what you command, and command what you will," which seemed to him to undermine human responsibility. Pelagius taught that God would not command what humans cannot do, and therefore that human beings retain the natural capacity to choose the good and live without sin if they will it. Adam\'s sin was a bad example, not a transmitted condition; infants are born in the same state Adam was before the Fall; grace consists in the gift of free will, the moral law, and the example of Christ, all of which assist but do not enable a fundamentally healthy human nature. His disciple Caelestius pushed these implications further. Augustine of Hippo became the chief opponent, developing the doctrine of original sin, the necessity of prevenient grace, and the absolute gratuity of salvation. After complex political and theological maneuvering between Rome, Carthage, and Palestine, Pelagianism was condemned at the Council of Carthage (418), endorsed by Pope Zosimus, and again at Ephesus (431). A milder form, Semi-Pelagianism, taught that the initial movement of faith comes from human free will and grace then assists; this was condemned at the Second Council of Orange (529), which became the definitive statement of Augustinian grace for the medieval Latin Church.',
+    catholicResponse:
+      'Augustine\'s anti-Pelagian writings (De Natura et Gratia, De Gratia Christi, De Peccato Originali, etc.) and the canons of Orange II became the foundation of Catholic teaching on grace, original sin, and free will, reaffirmed at the Council of Trent.',
+    currentRelations: 'Extinct as an organized movement. "Pelagian" remains a theological label for over-emphasis on human capacity for self-salvation.',
+    sources: [
+      'Augustine, Anti-Pelagian writings',
+      'Canons of the Second Council of Orange (529)',
+      'Catechism of the Catholic Church 405-406',
+      'Catholic Encyclopedia, "Pelagius and Pelagianism"',
+    ],
+  },
+  {
+    id: 'iconoclasm',
+    name: 'Iconoclasm',
+    alternateNames: ['Byzantine Iconoclasm', 'Image-breakers'],
+    category: 'christological',
+    era: 'Imperial Church (313-787)',
+    yearStart: 726,
+    yearEnd: 843,
+    founder: 'Emperor Leo III (initiator)',
+    region: 'Byzantine Empire',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct as a movement',
+    shortDescription:
+      'A Byzantine imperial movement (726-843) that condemned the veneration of icons as idolatry. Defeated by the Second Council of Nicaea (787) and definitively reversed in the "Triumph of Orthodoxy" (843).',
+    causes: {
+      theological: [
+        'Concern that veneration of icons amounted to idolatry',
+        'Christological argument: only Christ\'s humanity can be depicted, but his humanity cannot be separated from his divinity',
+        'Influence of Old Testament prohibitions on images',
+      ],
+      political: [
+        'Imperial desire to centralize authority and limit monastic influence',
+        'Possible influence from Islamic and Jewish iconoclastic critique of Christian images',
+      ],
+    },
+    keyFigures: ['Emperor Leo III', 'Constantine V', 'John of Damascus (defender)', 'Theodore the Studite (defender)', 'Empress Irene', 'Empress Theodora'],
+    keyEvents: [
+      { year: '726', event: 'Leo III orders the removal of the icon of Christ from the Chalke Gate of the Imperial Palace' },
+      { year: '754', event: 'Iconoclast Council of Hieria condemns icon veneration' },
+      { year: '787', event: 'Second Council of Nicaea (Seventh Ecumenical Council) restores icon veneration' },
+      { year: '815-843', event: 'Second wave of iconoclasm under emperors Leo V, Michael II, and Theophilus' },
+      { year: '843', event: 'Empress Theodora restores icons; the "Triumph of Orthodoxy" celebrated annually on the first Sunday of Lent' },
+    ],
+    resolution:
+      'Definitively rejected at Nicaea II (787) and again in 843. The veneration of icons remains central to Eastern Orthodox and Catholic spirituality.',
+    fullDescription:
+      'In 726 the Byzantine emperor Leo III, possibly motivated by a combination of theological concern, political calculation, and a desire to harden the empire after Arab military pressure, ordered the removal of the prominent icon of Christ over the Chalke Gate of the imperial palace in Constantinople. This inaugurated a century-long crisis. Iconoclasts ("image-breakers") argued that veneration of images of Christ and the saints amounted to idolatry forbidden by the Decalogue, and that Christ\'s divinity could not be circumscribed in matter. Their opponents, the iconodules, argued that the Incarnation made the depiction of Christ legitimate: God himself had taken on visible flesh, and to deny the icon was implicitly to deny the reality of the Incarnation. The two greatest defenders were John of Damascus, writing safely under Muslim rule outside imperial reach, and Theodore the Studite, an abbot in Constantinople who endured exile and torture. The iconoclast Council of Hieria (754) was answered by the Second Council of Nicaea (787), the Seventh Ecumenical Council, which carefully distinguished veneration (proskynesis) due to icons from the worship (latreia) due to God alone. A second wave of iconoclasm followed, finally ended by Empress Theodora\'s restoration of icons in 843, commemorated ever since in the Eastern churches as the Feast of Orthodoxy on the first Sunday of Lent. The Latin West also affirmed icon veneration, though with some confusion in the early reception of Nicaea II in Carolingian theology.',
+    catholicResponse:
+      'The Catholic Church accepts the Second Council of Nicaea (787) as the seventh ecumenical council and affirms the legitimate veneration of icons and sacred images, while reserving worship to God alone (Catechism 2129-2132).',
+    currentRelations: 'Iconoclasm is extinct as a Christian movement. The shared affirmation of Nicaea II is a point of unity between Catholic and Orthodox Christians.',
+    sources: [
+      'Acts of the Second Council of Nicaea (787)',
+      'John of Damascus, On the Divine Images (three treatises)',
+      'Theodore the Studite, On the Holy Icons',
+      'Catechism of the Catholic Church 2129-2132',
+    ],
+  },
+  // -------------------- Great Schism --------------------
+  {
+    id: 'photian-schism',
+    name: 'Photian Schism',
+    alternateNames: ['First Photian Schism'],
+    category: 'great-schism',
+    era: 'Imperial Church (313-787)',
+    yearStart: 863,
+    yearEnd: 879,
+    founder: 'Patriarch Photius of Constantinople',
+    region: 'Constantinople and Rome',
+    status: 'reconciled',
+    estimatedFollowers: 'Reconciled (precursor to 1054)',
+    shortDescription:
+      'A 9th-century rupture between Constantinople and Rome over the deposition of Patriarch Ignatius and the elevation of Photius. A precursor to the Great Schism, eventually healed.',
+    causes: {
+      theological: [
+        'Dispute over the filioque clause in the Western Creed',
+        'Different views on papal jurisdiction',
+      ],
+      political: [
+        'Imperial Byzantine politics over the Patriarchate',
+        'Competing missionary jurisdictions in newly Christian Bulgaria',
+      ],
+    },
+    keyFigures: ['Photius', 'Patriarch Ignatius', 'Pope Nicholas I', 'Pope John VIII', 'Emperor Michael III', 'Emperor Basil I'],
+    keyEvents: [
+      { year: '858', event: 'Photius elevated to the Patriarchate after the deposition of Ignatius' },
+      { year: '863', event: 'Pope Nicholas I declares Photius\'s elevation invalid' },
+      { year: '867', event: 'Photius excommunicates Pope Nicholas I; condemns the filioque' },
+      { year: '869-870', event: 'Council of Constantinople (counted as ecumenical in the West) deposes Photius' },
+      { year: '879-880', event: 'Council of Constantinople under Pope John VIII rehabilitates Photius and restores communion' },
+    ],
+    resolution:
+      'Reconciled by the council of 879-880, which restored Photius and communion with Rome. Considered by many Orthodox as a model of legitimate reunion.',
+    fullDescription:
+      'The Photian Schism arose from a contested patriarchal succession in Constantinople. Patriarch Ignatius was deposed for political reasons in 858, and the brilliant lay scholar Photius was rapidly ordained through the canonical orders to take his place. Pope Nicholas I, when consulted, declared the deposition uncanonical. The dispute escalated when Bulgarian missionary jurisdiction came into conflict between Rome and Constantinople, and Photius issued an encyclical (867) attacking the Latin filioque addition to the Creed. After Emperor Michael III\'s assassination, Photius was deposed and Ignatius restored; a council in Constantinople in 869-870 (counted as ecumenical in the West, not in the East) confirmed this. After Ignatius\'s death, however, Photius returned to the patriarchate, and a fresh council in 879-880 under Pope John VIII\'s legates restored full communion, with Rome accepting Photius and Photius accepting communion with Rome. The episode foreshadowed many of the issues that would resurface decisively in 1054: papal jurisdiction, the filioque, and competing ecclesial cultures.',
+    catholicResponse:
+      'Pope John VIII accepted the reconciliation. The Catholic Church recognizes the council of 869-870 as ecumenical (Constantinople IV), while Orthodox count the 879-880 council as ecumenical in its place.',
+    currentRelations: 'Resolved historically. Photius is venerated as a saint in the Eastern Orthodox Church.',
+    sources: [
+      'Francis Dvornik, The Photian Schism: History and Legend',
+      'Acts of the Councils of Constantinople (869-870 and 879-880)',
+      'Catholic Encyclopedia, "Photius of Constantinople"',
+    ],
+  },
+  {
+    id: 'east-west-schism',
+    name: 'East-West Schism (1054)',
+    alternateNames: ['Great Schism', 'Schism of 1054'],
+    category: 'great-schism',
+    era: 'High Middle Ages (1054-1300)',
+    yearStart: 1054,
+    region: 'Christian East and West',
+    status: 'partial-communion',
+    estimatedFollowers: '~220 million Eastern Orthodox today',
+    shortDescription:
+      'The mutual excommunications of 1054 between Cardinal Humbert and Patriarch Cerularius, traditionally marking the formal break between the Catholic Church of Rome and the Eastern Orthodox Churches. The break was the culmination of centuries of estrangement.',
+    causes: {
+      theological: [
+        'The filioque clause: Western addition of "and the Son" to the Creed regarding the procession of the Holy Spirit',
+        'Papal primacy: Roman claim to universal jurisdiction vs. Eastern conciliar/pentarchic ecclesiology',
+        'Use of unleavened bread (azymes) in the Latin Eucharist',
+        'Clerical celibacy in the West vs. married priesthood in the East',
+        'Practices of fasting, the Saturday observance, and minor liturgical differences',
+      ],
+      political: [
+        'Coronation of Charlemagne (800) and the Carolingian Empire as a Western rival to Byzantine imperial claims',
+        'Competing Norman, Byzantine, and Roman jurisdictions in southern Italy',
+        'Sack of Constantinople by the Fourth Crusade (1204) sealed the popular break',
+      ],
+      cultural: [
+        'Linguistic divide: Greek East vs. Latin West',
+        'Different liturgical and spiritual traditions',
+        'Centuries of growing mutual ignorance after the loss of bilingualism',
+      ],
+    },
+    keyFigures: ['Cardinal Humbert of Silva Candida', 'Patriarch Michael Cerularius', 'Pope Leo IX', 'Emperor Constantine IX Monomachos'],
+    keyEvents: [
+      { year: '800', event: 'Coronation of Charlemagne; political division of Christendom deepens' },
+      { year: '1054', event: 'Cardinal Humbert and Patriarch Cerularius issue mutual excommunications' },
+      { year: '1204', event: 'Fourth Crusade sacks Constantinople, sealing the popular break' },
+      { year: '1274', event: 'Council of Lyon II: short-lived reunion' },
+      { year: '1438-1445', event: 'Council of Florence: another short-lived reunion, repudiated in the East' },
+      { year: '1965', event: 'Pope Paul VI and Patriarch Athenagoras I lift the mutual excommunications of 1054' },
+    ],
+    resolution:
+      'Not yet fully resolved. The 1965 mutual lifting of the excommunications removed a symbol of separation but did not restore full communion. Theological dialogue continues.',
+    fullDescription:
+      'The East-West Schism is conventionally dated to 1054, when the papal legate Cardinal Humbert laid a bull of excommunication on the altar of Hagia Sophia against Patriarch Michael Cerularius, who responded in kind. The bull itself was procedurally questionable (Pope Leo IX had died before it was delivered) and the personal excommunications of two officials did not by themselves separate two churches. In reality the break was a long process of estrangement spanning centuries. Theological issues included the filioque, the Latin addition of "and the Son" to the article of the Creed concerning the procession of the Holy Spirit, made initially in Spain in the 6th century and gradually spreading through the West; the growing claims of the Roman see to universal immediate jurisdiction; the Western use of unleavened bread (azymes) in the Eucharist; clerical celibacy; and various liturgical, fasting, and disciplinary differences. Political and cultural factors aggravated all of these: the rise of the Carolingian and later Holy Roman Empire as a Latin Christian rival to Byzantium; the Norman conquest of Byzantine southern Italy; the loss of bilingualism in both halves of Christendom; and decisively the Fourth Crusade (1204), which captured and brutally sacked Constantinople, leaving a lasting Greek bitterness against the Latins. Attempts at reunion at the councils of Lyon II (1274) and Florence (1438-1445) were imposed by emperors under political pressure and rejected by the Eastern faithful. In 1965, Pope Paul VI and Ecumenical Patriarch Athenagoras I jointly lifted the 1054 excommunications, an important symbolic act, and the Joint International Commission for Theological Dialogue began work in 1980 and continues today.',
+    catholicResponse:
+      'Vatican II affirmed that "particular Churches" of the East are "true Churches" possessing valid sacraments and apostolic succession (Unitatis Redintegratio 13-18). Pope Paul VI called the East and West "sister churches." Recent popes have repeatedly described unity with Orthodoxy as a priority.',
+    currentRelations: 'Sacraments mutually recognized as valid. Joint dialogues continue (notably the Ravenna Document 2007 on conciliarity and primacy). No restoration of full communion yet, especially because of the papal primacy and the post-1054 dogmatic developments in the Catholic Church.',
+    sources: [
+      'Steven Runciman, The Eastern Schism',
+      'Aristeides Papadakis, The Christian East and the Rise of the Papacy',
+      'Joint Catholic-Orthodox Declaration of Paul VI and Athenagoras I (1965)',
+      'Unitatis Redintegratio, Vatican II',
+    ],
+  },
+  {
+    id: 'eastern-orthodoxy',
+    name: 'Eastern Orthodox Communion',
+    alternateNames: ['Orthodox Church', 'Greek Orthodox', 'Russian Orthodox', 'The Orthodox Catholic Church'],
+    category: 'great-schism',
+    era: 'Modern',
+    yearStart: 1054,
+    region: 'Greece, Russia, Eastern Europe, Middle East, global diaspora',
+    status: 'partial-communion',
+    estimatedFollowers: '~220 million across 14-16 autocephalous churches',
+    parentId: 'east-west-schism',
+    shortDescription:
+      'The communion of autocephalous churches descending from the Christian East after 1054, including Constantinople, Russia, Greece, Romania, Serbia, and others. Sacraments mutually recognized with Rome; full communion not yet restored.',
+    causes: {
+      theological: [
+        'Continuation of the East-West Schism issues',
+        'Rejection of post-1054 Latin dogmatic developments (papal infallibility, Immaculate Conception as defined dogma)',
+      ],
+      cultural: [
+        'National and ethnic churches deeply tied to Byzantine, Slavic, and Middle Eastern identities',
+      ],
+    },
+    keyFigures: ['Photius', 'Cerularius', 'Mark of Ephesus', 'Patriarch Tikhon of Russia', 'Ecumenical Patriarch Bartholomew I'],
+    keyEvents: [
+      { year: '1054', event: 'Conventional date of the schism' },
+      { year: '988', event: 'Baptism of Rus\' under Vladimir of Kiev' },
+      { year: '1448-1589', event: 'Russian Orthodox Church becomes autocephalous and then a patriarchate' },
+      { year: '1872', event: 'Synod of Constantinople condemns "phyletism" (ethnic nationalism in the Church)' },
+      { year: '1965', event: 'Mutual lifting of the 1054 excommunications' },
+      { year: '2018-19', event: 'Granting of autocephaly to the Orthodox Church of Ukraine; rupture between Constantinople and Moscow' },
+    ],
+    resolution:
+      'Not in full communion with Rome. Internal tensions (especially between Constantinople and Moscow) have grown since 2018.',
+    fullDescription:
+      'Today the Eastern Orthodox Communion comprises 14 to 16 autocephalous (self-governing) churches, depending on how disputed jurisdictions are counted. The historic apostolic patriarchates are Constantinople (~3.5 million in the patriarchate proper, with much wider influence), Alexandria, Antioch, and Jerusalem. The largest by far is the Russian Orthodox Church (~100 million claimed), followed by the Romanian Orthodox Church, the Church of Greece, the Serbian Orthodox Church, the Bulgarian Orthodox Church, and the Georgian Orthodox Church. Smaller autocephalous churches include those of Cyprus, Albania, Poland, the Czech Lands and Slovakia, and the Orthodox Church in America (whose status is disputed). The newly autocephalous Orthodox Church of Ukraine (granted by Constantinople in 2019) has become the focal point of a serious rupture within the communion: the Moscow Patriarchate has broken communion with Constantinople and the churches recognizing Ukrainian autocephaly. Orthodox ecclesiology emphasizes the conciliar equality of bishops, the primacy of honor (rather than universal jurisdiction) of the Ecumenical Patriarch of Constantinople, and the importance of national/local churches. The Orthodox have their own monastic, liturgical, and theological traditions, including the central practice of icon veneration, the Divine Liturgy of St. John Chrysostom, the Jesus Prayer and hesychasm, and a strong patristic theological orientation.',
+    catholicResponse:
+      'The Catholic Church regards the Eastern Orthodox as true particular Churches with valid sacraments, apostolic succession, and the Eucharist. Catholic-Orthodox dialogue is central to the ecumenical movement.',
+    currentRelations: 'Sacraments mutually recognized in principle. Pastoral arrangements vary. Pope Francis has met repeatedly with Patriarch Bartholomew and other Orthodox leaders. The Joint International Commission continues to work on primacy and conciliarity.',
+    sources: [
+      'Timothy (Kallistos) Ware, The Orthodox Church',
+      'Code of Canons of the Eastern Churches (Catholic counterpart)',
+      'Unitatis Redintegratio 13-18',
+      'Joint International Commission documents (Ravenna 2007, Chieti 2016)',
+    ],
+  },
+  // -------------------- Medieval Movements --------------------
+  {
+    id: 'cathars',
+    name: 'Cathars / Albigensians',
+    alternateNames: ['Albigenses', 'Pure Ones'],
+    category: 'medieval',
+    era: 'High Middle Ages (1054-1300)',
+    yearStart: 1140,
+    yearEnd: 1325,
+    founder: 'Diverse; influenced by Bogomils',
+    region: 'Languedoc (southern France), northern Italy',
+    status: 'extinct',
+    estimatedFollowers: 'Extinct',
+    shortDescription:
+      'A 12th-13th century dualist movement in southern France teaching two gods (good spirit, evil matter) and rejecting most sacraments. Suppressed by the Albigensian Crusade and the medieval inquisition.',
+    causes: {
+      theological: [
+        'Cosmic dualism: a good God of spirit and an evil God of matter',
+        'Rejection of the Incarnation, the Eucharist, and most sacraments',
+        'Belief in reincarnation; only the consolamentum (a single spiritual baptism) saves',
+      ],
+      cultural: [
+        'Discontent with the wealth and corruption of clergy in 12th-c. France',
+        'Influence of Bogomil missionaries from the Balkans',
+      ],
+    },
+    keyFigures: ['Dominic de Guzman (founder of Dominicans, sent to preach against Cathars)', 'Innocent III', 'Simon de Montfort'],
+    keyEvents: [
+      { year: 'c. 1140', event: 'Cathar communities documented in the Rhineland and Languedoc' },
+      { year: '1208', event: 'Murder of papal legate Pierre de Castelnau triggers the Albigensian Crusade' },
+      { year: '1209-1229', event: 'Albigensian Crusade devastates Languedoc' },
+      { year: '1233', event: 'Pope Gregory IX establishes papal inquisitors (often Dominicans) to investigate Cathar communities' },
+      { year: '1244', event: 'Fall of Montsegur; mass execution of Cathar Perfecti' },
+      { year: 'c. 1325', event: 'Last known Cathar Perfectus, Guillaume Belibaste, burned' },
+    ],
+    resolution:
+      'Suppressed by crusade and inquisition over the 13th-14th centuries. The Dominican order was founded in part for preaching against the Cathars.',
+    fullDescription:
+      'Catharism arose in the twelfth century in southern France and northern Italy as a strict dualist movement, probably influenced by Bogomil missionaries from the Balkans. Cathars taught that the visible material world had been created by an evil principle (often identified with the God of the Old Testament), while a good God presided over an invisible spiritual realm. Human souls were fallen spirits trapped in matter; salvation came through extreme asceticism and the consolamentum, a once-in-a-lifetime spiritual baptism normally received on the deathbed. The Cathar elite were called Perfecti and lived in strict celibacy, vegetarianism, and pacifism; ordinary believers, the Credentes, lived ordinary lives and aspired to receive the consolamentum at death. The movement spread rapidly in Languedoc, where local nobles tolerated and sometimes embraced it. After the murder of papal legate Pierre de Castelnau in 1208, Pope Innocent III called the Albigensian Crusade (1209-1229), which combined religious motivation with the political ambition of northern French barons. The crusade was extraordinarily violent, including the notorious sack of Beziers (1209). After the Treaty of Paris (1229) brought Languedoc under royal control, the inquisition (formalized in 1233) systematically investigated and punished surviving Cathars. The fall of the mountain stronghold Montsegur in 1244 ended organized resistance; the last known Perfectus was burned in 1321. The Dominicans, founded by St. Dominic precisely to preach against the Cathars, became the principal order of inquisitors and theologians in the centuries following.',
+    catholicResponse:
+      'Doctrinal refutation, preaching missions (especially by St. Dominic), the Fourth Lateran Council (1215) clarifying Eucharistic and Christological doctrine, and the inquisition. The crusade itself remains a controversial chapter, criticized in modern Catholic reflection.',
+    currentRelations: 'Extinct. Modern romantic and esoteric "Neo-Cathar" movements have no historical continuity.',
+    sources: [
+      'Malcolm Lambert, The Cathars',
+      'Acts of the Fourth Lateran Council (1215)',
+      'Emmanuel Le Roy Ladurie, Montaillou',
+      'Catholic Encyclopedia, "Albigenses"',
+    ],
+  },
+  {
+    id: 'waldensians',
+    name: 'Waldensians',
+    alternateNames: ['Vaudois', 'Poor of Lyon'],
+    category: 'medieval',
+    era: 'High Middle Ages (1054-1300)',
+    yearStart: 1173,
+    region: 'Originally Lyon; survived in Alpine valleys of Italy and France; today Italy and global mission',
+    status: 'active',
+    estimatedFollowers: '~30,000 (Italy); ~3 million counting affiliated South American and missionary churches',
+    founder: 'Peter Waldo (Pierre Vaudes) of Lyon',
+    shortDescription:
+      'A 12th-century lay preaching movement begun by Peter Waldo of Lyon. Persecuted as heretics, the Waldensians survived in Alpine valleys and merged partly with the Reformed tradition in the 16th century. They are arguably the oldest continuously existing dissenting movement in Western Christianity.',
+    causes: {
+      theological: [
+        'Lay preaching without ecclesiastical authorization',
+        'Vernacular translation and circulation of Scripture',
+        'Rejection of purgatory, indulgences, oaths, and capital punishment',
+        'Apostolic poverty as the central Christian virtue',
+      ],
+      cultural: [
+        'Reaction against perceived clerical wealth and corruption',
+        'Rise of urban lay piety in the 12th c.',
+      ],
+    },
+    keyFigures: ['Peter Waldo', 'Pope Alexander III', 'William Farel', 'Olivetan (Bible translator)'],
+    keyEvents: [
+      { year: 'c. 1173', event: 'Peter Waldo gives away his wealth to follow Christ in apostolic poverty' },
+      { year: '1179', event: 'Waldo presents his vernacular Bible at the Third Lateran Council; partial approval, then revoked' },
+      { year: '1184', event: 'Council of Verona condemns the Waldensians as heretics' },
+      { year: '15th-16th c.', event: 'Persecutions in Piedmont; survival in Alpine valleys' },
+      { year: '1532', event: 'Synod of Chanforan: Waldensians align with the Reformed (Calvinist) tradition' },
+      { year: '1655', event: 'The "Piedmont Easter" massacre, immortalized in Milton\'s sonnet' },
+      { year: '1848', event: 'Edict of Emancipation grants Waldensians civil rights in the Kingdom of Sardinia' },
+      { year: '2015', event: 'Pope Francis visits the Waldensian temple in Turin and asks forgiveness for past Catholic persecution' },
+    ],
+    resolution:
+      'Not in full communion with Rome, but reconciled in tone. Pope Francis\'s 2015 request for forgiveness was a major moment of healing.',
+    fullDescription:
+      'In the 1170s, Peter Waldo, a wealthy merchant of Lyon, was so moved by the gospel that he renounced his property and began to preach in the streets. He gathered companions, the "Poor of Lyon," who lived by begging and itinerant preaching, and commissioned the first known vernacular translation of large parts of the Bible into Old French. When Waldo and his followers presented themselves at the Third Lateran Council (1179), Pope Alexander III approved their poverty but, distrustful of unauthorized lay preaching, restricted them to preaching only at the invitation of clergy. Waldo refused, citing "We must obey God rather than men." The movement was condemned at the Council of Verona (1184). Despite persecution, Waldensian communities persisted in southern France, northern Italy, and central Europe. By the late Middle Ages they were concentrated in Alpine valleys of Piedmont and Provence. In 1532, at the Synod of Chanforan, they aligned with the Swiss Reformation, becoming in effect the oldest "Protestant" church. They suffered terrible persecutions, including the 1655 massacres in Piedmont that prompted Cromwell\'s diplomacy and Milton\'s famous sonnet "Avenge, O Lord, thy slaughtered saints." Granted civil rights in 1848, they expanded with missions to South America (especially Uruguay and Argentina). In 2015, Pope Francis became the first pope to visit a Waldensian temple, asking forgiveness for the historic persecution.',
+    catholicResponse:
+      'Historic condemnation followed by significant reconciliation in modern times. Pope Francis\'s 2015 visit and request for forgiveness was a watershed.',
+    currentRelations: 'In dialogue with the Catholic Church and other Reformation churches. The Waldensian Church of Italy is in communion with the Methodist Church of Italy.',
+    sources: [
+      'Gabriel Audisio, The Waldensian Dissent',
+      'Euan Cameron, Waldenses: Rejections of Holy Church in Medieval Europe',
+      'Catholic Encyclopedia, "Waldenses"',
+      'Pope Francis\'s addresses, June 2015',
+    ],
+  },
+  {
+    id: 'hussites',
+    name: 'Hussites / Bohemian Brethren',
+    alternateNames: ['Utraquists', 'Moravian Brethren', 'Unitas Fratrum'],
+    category: 'medieval',
+    era: 'Late Middle Ages (1300-1500)',
+    yearStart: 1415,
+    region: 'Bohemia, Moravia; modern Czech Republic and global Moravian missions',
+    status: 'active',
+    estimatedFollowers: 'Moravian Church ~1 million worldwide',
+    founder: 'Jan Hus (martyred 1415)',
+    shortDescription:
+      'A reform movement begun by the Czech priest Jan Hus, condemned and burned at the Council of Constance in 1415. The Hussite movement gave rise to the Bohemian/Moravian Brethren, a precursor of the Reformation, still active today as the Moravian Church.',
+    causes: {
+      theological: [
+        'Influence of Wycliffe: Scripture as supreme authority; criticism of indulgences and papal authority',
+        'Demand for the chalice for the laity (Utraquism)',
+        'Critique of clerical wealth and immorality',
+      ],
+      political: [
+        'Czech national identity vs. German imperial power and Roman authority',
+        'University of Prague as a center of reform',
+      ],
+    },
+    keyFigures: ['Jan Hus', 'Jerome of Prague', 'Jan Žižka', 'Petr Chelčický', 'Count Zinzendorf (later Moravian leader)'],
+    keyEvents: [
+      { year: '1402', event: 'Hus begins preaching in the Bethlehem Chapel, Prague' },
+      { year: '1415', event: 'Council of Constance condemns Hus; he is burned at the stake' },
+      { year: '1419-1434', event: 'Hussite Wars; the Czech kingdom becomes effectively independent in religion' },
+      { year: '1457', event: 'Founding of the Unitas Fratrum (Bohemian Brethren)' },
+      { year: '1620', event: 'Battle of White Mountain ends Czech Protestant independence; Brethren go into hiding or exile' },
+      { year: '1722', event: 'Brethren refugees settle on Count Zinzendorf\'s estate; Moravian Church renewed' },
+      { year: '1999', event: 'Joint Catholic-Lutheran-Moravian dialogues; Hus rehabilitated in modern Catholic discourse' },
+    ],
+    resolution:
+      'Czech Hussite tradition fragmented into the Catholic-Hussite Utraquists (eventually re-Catholicized after 1620), the Bohemian/Moravian Brethren (surviving in exile), and modern Czechoslovak Hussite Church.',
+    fullDescription:
+      'Jan Hus was a Czech priest, theologian, and rector of the University of Prague who, influenced by the writings of John Wycliffe, criticized clerical immorality, the sale of indulgences, and the abuse of papal authority. He demanded that the laity receive the chalice as well as the host at communion, and preached in Czech rather than Latin. Summoned under safe-conduct to the Council of Constance (1414-1418), he was nevertheless arrested, condemned, and burned at the stake on 6 July 1415. His martyrdom, and that of Jerome of Prague the next year, ignited the Hussite Wars (1419-1434), in which Czech armies under brilliant commanders such as Jan Žižka repeatedly defeated Catholic crusader forces. The Council of Basel (1436) granted the Czechs the Compactata, allowing communion in both kinds, in effect creating a self-governing national church (the Utraquists). A more radical strand under Petr Chelčický led to the founding in 1457 of the Unitas Fratrum, the Bohemian Brethren, who emphasized pacifism, simplicity, and lay biblical piety, and produced the Kralice Bible, a milestone of Czech literature. The defeat of the Czech Protestants at the Battle of White Mountain (1620) led to the suppression of the Brethren; survivors went into hiding or exile, including the famous Comenius. In 1722, refugees settled on the estate of Count Zinzendorf in Saxony, where they refounded the Moravian Church, which became one of the great Protestant missionary movements of the 18th century. In modern times Pope John Paul II expressed regret for Hus\'s death, and ecumenical study commissions have rehabilitated his memory.',
+    catholicResponse:
+      'Modern popes (especially John Paul II in 1999) have expressed regret for Hus\'s execution. Ecumenical dialogue with the Czech Hussite Church and the Moravian Church continues.',
+    currentRelations: 'The Moravian Church is in dialogue with Catholic, Lutheran, and Anglican bodies. The Czechoslovak Hussite Church is a separate, more recent body.',
+    sources: [
+      'Thomas A. Fudge, Jan Hus: Religious Reform and Social Revolution in Bohemia',
+      'Acts of the Council of Constance (1415)',
+      'Joint Commission documents on Hus (1990s)',
+      'Catholic Encyclopedia, "Hus, John"',
+    ],
+  },
+
+  // -------------------- Protestant Reformation --------------------
+  {
+    id: 'lutheranism',
+    name: 'Lutheranism',
+    alternateNames: ['Evangelical Lutheran Church', 'Lutheran World Federation'],
+    category: 'reformation',
+    era: 'Reformation (1500-1700)',
+    yearStart: 1517,
+    founder: 'Martin Luther (1483-1546)',
+    region: 'Originating Saxony; today global with strongholds in Germany, Scandinavia, USA, Africa',
+    status: 'active',
+    estimatedFollowers: '~80 million worldwide',
+    shortDescription:
+      'The first and most influential Protestant tradition, founded when Martin Luther posted his 95 Theses in 1517 protesting indulgences. Sola fide, sola scriptura, sola gratia.',
+    causes: {
+      theological: [
+        'Justification by faith alone (sola fide) vs. faith working through love',
+        'Scripture alone (sola scriptura) as the supreme rule of faith',
+        'Rejection of indulgences, purgatory as treasury of merits, papal authority',
+        'Two sacraments (baptism, Eucharist) instead of seven; rejection of transubstantiation in favor of "consubstantiation" or sacramental union',
+      ],
+      political: [
+        'German princes\' resistance to Imperial and papal taxation',
+        'Frederick the Wise of Saxony\'s protection of Luther',
+      ],
+      cultural: [
+        'Renaissance humanism\'s return to original sources',
+        'The printing press: Luther\'s 95 Theses spread across Germany within weeks',
+      ],
+    },
+    keyFigures: ['Martin Luther', 'Philip Melanchthon', 'Johann Bugenhagen', 'Frederick the Wise'],
+    keyEvents: [
+      { year: '1517', event: '95 Theses posted at Wittenberg' },
+      { year: '1521', event: 'Diet of Worms — "Here I stand"' },
+      { year: '1530', event: 'Augsburg Confession — definitive Lutheran statement of faith' },
+      { year: '1546', event: 'Death of Luther' },
+      { year: '1577', event: 'Formula of Concord unifies Lutheran churches' },
+      { year: '1999', event: 'Joint Declaration on the Doctrine of Justification with the Catholic Church' },
+    ],
+    resolution:
+      'Permanent denominational separation, but the 1999 Joint Declaration on Justification represents one of the great ecumenical convergences of modern times. Many historic Lutheran objections have been substantially addressed.',
+    fullDescription:
+      'Martin Luther, an Augustinian friar and professor at Wittenberg, posted ninety-five theses against the abuse of indulgences on the eve of All Saints\' Day, 1517. What began as an academic protest rapidly became a continental movement, fueled by the new printing press and by genuine theological insight: Luther\'s "discovery" that the righteousness of God in Romans 1:17 is not God\'s wrath but the gift by which he justifies sinners. Excommunicated by Pope Leo X in 1521 and outlawed by the Emperor at Worms, Luther was sheltered by Frederick the Wise and translated the New Testament into German in less than three months. Lutheranism became the established religion of much of northern Germany and all of Scandinavia. The Augsburg Confession (1530), drafted by Philip Melanchthon, remains the foundational doctrinal text. Modern Lutheranism includes the Lutheran World Federation (representing most Lutherans worldwide), the more conservative Lutheran Church-Missouri Synod, and the Wisconsin Evangelical Lutheran Synod. The 1999 Joint Declaration on the Doctrine of Justification, signed by the Lutheran World Federation and the Vatican, declared that the historic mutual condemnations on justification do not apply to the teaching of either body today.',
+    catholicResponse:
+      'Council of Trent (1545-63) clarified Catholic teaching on justification, sacraments, scripture, and tradition. Modern dialogue (especially the 1999 Joint Declaration) has substantially closed the historic gap on the central Reformation issue.',
+    currentRelations:
+      'Lutheran-Catholic dialogue is among the most fruitful ecumenical engagements. Joint commemoration of the Reformation\'s 500th anniversary (2017) at Lund Cathedral by Pope Francis and the LWF.',
+    sources: [
+      'The Augsburg Confession (1530)',
+      'Luther\'s 95 Theses; Bondage of the Will',
+      'Joint Declaration on the Doctrine of Justification (1999)',
+      'Diarmaid MacCulloch, The Reformation: A History',
+    ],
+  },
+  {
+    id: 'reformed',
+    name: 'Reformed / Calvinist Tradition',
+    alternateNames: ['Presbyterian', 'Reformed Church', 'Continental Reformed', 'Dutch Reformed'],
+    category: 'reformation',
+    era: 'Reformation (1500-1700)',
+    yearStart: 1519,
+    founder: 'Huldrych Zwingli (1484-1531) and John Calvin (1509-1564)',
+    region: 'Originating Switzerland; today strong in Netherlands, Scotland, USA, South Korea, sub-Saharan Africa',
+    status: 'active',
+    estimatedFollowers: '~75 million worldwide',
+    shortDescription:
+      'The second major Protestant tradition, originating with Zwingli in Zurich (1519) and systematized by John Calvin in Geneva. Emphasizes God\'s sovereignty, predestination, and the regulative principle of worship.',
+    causes: {
+      theological: [
+        'Even more radical break with medieval sacramental theology than Lutheranism',
+        'Predestination and election as central doctrines',
+        'Symbolic or "spiritual presence" view of the Eucharist (vs. Luther\'s real presence)',
+        'Regulative principle: worship is permitted only what is commanded in Scripture',
+        'Strict iconoclasm — removal of statues, images, organs',
+      ],
+      political: [
+        'Calvin\'s Geneva as a model "godly city"',
+        'Influence on Dutch revolt against Spain, Scottish Reformation, English Puritanism',
+      ],
+    },
+    keyFigures: ['Huldrych Zwingli', 'John Calvin', 'Theodore Beza', 'John Knox', 'Heinrich Bullinger'],
+    keyEvents: [
+      { year: '1519', event: 'Zwingli begins reform in Zurich' },
+      { year: '1536', event: 'Calvin publishes Institutes of the Christian Religion (first edition)' },
+      { year: '1541', event: 'Calvin returns to Geneva; reformed church order established' },
+      { year: '1560', event: 'Scottish Reformation under John Knox; Scottish Confession' },
+      { year: '1618-19', event: 'Synod of Dort: defines Five Points of Calvinism (TULIP)' },
+      { year: '1646-47', event: 'Westminster Confession of Faith' },
+    ],
+    resolution: 'Permanent denominational separation; the Reformed family remains diverse and globally significant.',
+    fullDescription:
+      'The Reformed tradition emerged in Zurich under Huldrych Zwingli almost simultaneously with Luther\'s movement, but pushed further: rejecting any physical presence of Christ in the Eucharist, removing all images from churches, and insisting on the regulative principle of worship. Zwingli died in battle in 1531; the tradition\'s great systematizer was the French exile John Calvin, whose Institutes of the Christian Religion (final edition 1559) became the most influential Protestant theological work after Luther\'s catechisms. Calvin\'s Geneva was an experiment in confessional governance that influenced the Dutch Republic, Scotland (under John Knox), Hungary, and the English Puritans who would shape American Protestantism. The Reformed family today includes Presbyterian, Reformed, Congregational, and Dutch Reformed bodies. The doctrinal distinctives of unconditional election, limited atonement, and irresistible grace ("TULIP") were sharpened at the Synod of Dort (1618-19) against Arminian theology.',
+    catholicResponse:
+      'Catholic-Reformed dialogue has been less fruitful than Catholic-Lutheran, partly because of greater theological distance on sacraments and ecclesiology. Recent dialogues continue under the Pontifical Council for Promoting Christian Unity.',
+    currentRelations:
+      'World Communion of Reformed Churches has dialogues with Catholics; signed an "Association" with the Joint Declaration on Justification in 2017.',
+    sources: [
+      'John Calvin, Institutes of the Christian Religion',
+      'Westminster Confession of Faith (1647)',
+      'Synod of Dort, Canons (1619)',
+      'Bruce Gordon, Calvin (Yale, 2009)',
+    ],
+  },
+  {
+    id: 'anglicanism',
+    name: 'Anglicanism',
+    alternateNames: ['Church of England', 'Episcopal Church', 'Anglican Communion'],
+    category: 'reformation',
+    era: 'Reformation (1500-1700)',
+    yearStart: 1534,
+    founder: 'King Henry VIII (formal break); Thomas Cranmer (theology and liturgy)',
+    region: 'Originating England; today global Anglican Communion with 39 provinces',
+    status: 'active',
+    estimatedFollowers: '~85 million worldwide',
+    shortDescription:
+      'The Church of England formally separated from Rome in 1534 over Henry VIII\'s desired annulment of his marriage to Catherine of Aragon — a split rooted in royal politics rather than primarily in doctrine, leading to a unique "via media" between Catholic and Protestant.',
+    causes: {
+      theological: [
+        'Initially minimal — Henry VIII rejected Lutheran teaching ("Defender of the Faith")',
+        'Under Edward VI: clearly Reformed direction (1549, 1552 Books of Common Prayer)',
+        'Under Elizabeth I: the "Elizabethan Settlement" — Catholic structure with Reformed theology',
+      ],
+      political: [
+        'Henry VIII\'s desire for an annulment denied by Pope Clement VII',
+        'Royal supremacy over the Church (Act of Supremacy, 1534)',
+        'Confiscation of monastic lands enriched the crown and gentry',
+      ],
+      cultural: [
+        'English national identity and resistance to foreign jurisdiction',
+        'Cranmer\'s liturgical genius shaped English religious sensibility for centuries',
+      ],
+    },
+    keyFigures: ['Henry VIII', 'Thomas Cranmer', 'Elizabeth I', 'Richard Hooker', 'John Henry Newman (later Catholic)'],
+    keyEvents: [
+      { year: '1534', event: 'Act of Supremacy: Henry VIII Supreme Head of the Church of England' },
+      { year: '1549', event: 'First Book of Common Prayer (Cranmer)' },
+      { year: '1559', event: 'Elizabethan Settlement; 39 Articles of Religion' },
+      { year: '1662', event: 'Definitive Book of Common Prayer' },
+      { year: '1833', event: 'Oxford Movement begins; recovery of Catholic identity' },
+      { year: '1992', event: 'Church of England ordains women priests' },
+      { year: '2009', event: 'Pope Benedict XVI establishes Anglican Ordinariates' },
+    ],
+    resolution:
+      'Permanent denominational separation, with significant ongoing dialogue (ARCIC). Pope Benedict XVI created Personal Ordinariates (2009) for groups of Anglicans entering Catholic communion while preserving liturgical patrimony.',
+    fullDescription:
+      'The English Reformation was driven by King Henry VIII\'s desire to annul his marriage to Catherine of Aragon, refused by Pope Clement VII. Through Acts of Parliament (1532-34), Henry severed legal ties with Rome and made himself Supreme Head of the Church of England. Doctrinally, however, Henry remained largely Catholic — he had previously written against Luther and earned the title "Defender of the Faith." It was under his son Edward VI, with Archbishop Thomas Cranmer, that English worship became decidedly Reformed (1552 Book of Common Prayer). After Mary I\'s brief Catholic restoration, Elizabeth I established the "Elizabethan Settlement": Catholic structure (bishops, cathedrals, ancient liturgical year) with Reformed theology (39 Articles). Anglicans regard their tradition as a "via media" between Rome and Geneva. The 19th-century Oxford Movement, led by John Henry Newman (who himself later became Catholic and was canonized in 2019), recovered Catholic identity within the Church of England. The Anglican Communion today is the third-largest Christian body after the Catholic and Orthodox communions. Catholic-Anglican relations have been particularly close: ARCIC (Anglican-Roman Catholic International Commission) has produced major agreed statements on the Eucharist, ministry, and authority. The ordination of women (Church of England, 1992) and same-sex blessings have created tensions both internally and ecumenically.',
+    catholicResponse:
+      'Pope Leo XIII\'s Apostolicae Curae (1896) declared Anglican orders "absolutely null and utterly void." ARCIC dialogues since 1970 have substantially closed many gaps. Pope Benedict XVI\'s Anglicanorum Coetibus (2009) created the Personal Ordinariates as a structure for Anglican groups entering full Catholic communion.',
+    currentRelations:
+      'ARCIC remains active. The Anglican Ordinariates — Our Lady of Walsingham (UK), the Chair of Saint Peter (USA), Our Lady of the Southern Cross (Australia) — preserve Anglican liturgical patrimony in full Catholic communion.',
+    sources: [
+      'Eamon Duffy, The Stripping of the Altars',
+      'Diarmaid MacCulloch, Thomas Cranmer: A Life',
+      'ARCIC Agreed Statements',
+      'Apostolicae Curae (1896); Anglicanorum Coetibus (2009)',
+    ],
+  },
+  {
+    id: 'anabaptists',
+    name: 'Anabaptists',
+    alternateNames: ['Mennonites', 'Amish', 'Hutterites', 'Schwarzenau Brethren'],
+    category: 'reformation',
+    era: 'Reformation (1500-1700)',
+    yearStart: 1525,
+    founder: 'Conrad Grebel, Felix Manz, George Blaurock (Swiss Brethren)',
+    region: 'Originating Switzerland; today strong in Netherlands, Germany, USA (Pennsylvania), Paraguay',
+    status: 'active',
+    estimatedFollowers: '~2.1 million worldwide',
+    shortDescription:
+      'The "radical Reformation" — those who rejected infant baptism, insisted on a believers\' church, and pursued strict separation from civil authority. Persecuted by Catholics, Lutherans, and Reformed alike.',
+    causes: {
+      theological: [
+        'Believers\' baptism: only adult professing believers should be baptized',
+        'Pacifism and refusal to swear oaths',
+        'Strict separation of church and state',
+        'Pure church discipline (the "ban") to maintain holiness',
+      ],
+      cultural: ['Distrust of magisterial Reformation\'s alliance with civil power'],
+    },
+    keyFigures: ['Conrad Grebel', 'Felix Manz', 'Menno Simons', 'Jakob Hutter', 'Michael Sattler'],
+    keyEvents: [
+      { year: '1525', event: 'First adult baptisms in Zurich; movement begins' },
+      { year: '1527', event: 'Schleitheim Confession — defining Anabaptist articles' },
+      { year: '1535', event: 'Münster Rebellion discredits Anabaptism in mainstream Reformation' },
+      { year: '1540s', event: 'Menno Simons consolidates peaceful Dutch Anabaptism (Mennonites)' },
+      { year: '1693', event: 'Amish split from Mennonites (Jakob Ammann)' },
+    ],
+    resolution: 'Permanent separation, but historically harshly persecuted. Modern Mennonite-Catholic dialogue began in 1998.',
+    fullDescription:
+      'The Anabaptists emerged in 1525 when a group of Zwingli\'s disciples, frustrated with what they saw as the slow pace of reform, baptized one another as adults — a capital offense under Imperial law. Persecuted by Catholics, Lutherans, and Reformed alike, they spread underground across Europe. The disastrous Münster Rebellion (1534-35), where radicals briefly established a violent theocratic kingdom, gave Anabaptism a reputation for fanaticism that took centuries to overcome. Menno Simons, a Dutch former priest, consolidated peaceful Anabaptism into what became Mennonite tradition. The Amish split off in 1693 over the strict application of the ban. Today Anabaptists include Mennonites, Amish, Hutterites, and Schwarzenau Brethren. They have produced an outsized contribution to peace theology, voluntary service, and disaster relief.',
+    catholicResponse:
+      'Heavy persecution in the 16th century. Modern Catholic-Mennonite dialogue began in 1998; the report "Called Together to Be Peacemakers" (2003) marked a major reconciliation, with mutual healing of historical memories.',
+    currentRelations:
+      'Mennonite World Conference engages in ongoing dialogue with Catholics and Lutherans. 2010 Lutheran World Federation apology to Mennonites for Reformation-era persecutions.',
+    sources: [
+      'Schleitheim Confession (1527)',
+      '"Called Together to Be Peacemakers" — Catholic-Mennonite Report (2003)',
+      'C. Arnold Snyder, Anabaptist History and Theology',
+    ],
+  },
+
+  // -------------------- Post-Reformation --------------------
+  {
+    id: 'baptists',
+    name: 'Baptists',
+    alternateNames: ['Particular Baptists', 'General Baptists', 'Southern Baptist Convention', 'American Baptist Churches'],
+    category: 'post-reformation',
+    era: 'Early Modern (1600-1800)',
+    yearStart: 1609,
+    founder: 'John Smyth and Thomas Helwys (English separatists)',
+    region: 'Originating England/Holland; today globally strong with USA as largest concentration',
+    status: 'active',
+    estimatedFollowers: '~100 million worldwide; the largest non-Catholic Christian tradition in the United States',
+    shortDescription:
+      'A 17th-century English Separatist movement that adopted believer\'s baptism by full immersion. Emphasizes congregational autonomy, soul liberty, and the priesthood of all believers.',
+    causes: {
+      theological: [
+        'Believers\' baptism by full immersion (later distinctive)',
+        'Congregational church government — each local congregation autonomous',
+        'Soul liberty: every person\'s right and duty to interpret Scripture',
+        'Separation of church and state (early advocates)',
+      ],
+      cultural: ['English Separatist movement and persecuted dissent'],
+    },
+    keyFigures: ['John Smyth', 'Thomas Helwys', 'Roger Williams', 'Charles Spurgeon', 'Billy Graham', 'Martin Luther King Jr.'],
+    keyEvents: [
+      { year: '1609', event: 'John Smyth in Amsterdam baptizes himself and his congregation; first Baptists' },
+      { year: '1638', event: 'Roger Williams founds the first Baptist church in America (Providence)' },
+      { year: '1814', event: 'Triennial Convention — first major Baptist body in USA' },
+      { year: '1845', event: 'Southern Baptist Convention founded (split over slavery)' },
+      { year: '1905', event: 'Baptist World Alliance' },
+    ],
+    resolution: 'Permanent denominational separation; Baptists remain extraordinarily diverse, from Reformed Particular Baptists to charismatic-leaning megachurches.',
+    fullDescription:
+      'Baptists emerged from English Separatism in 1609 when John Smyth, exiled in Amsterdam, repudiated his infant baptism and baptized himself and his small congregation. The movement spread rapidly in 17th-century England and was carried to America by Roger Williams (founder of Providence, Rhode Island, 1636) and others. Baptists\' insistence on religious liberty and church-state separation profoundly shaped the American constitutional tradition. The 19th and 20th centuries saw extraordinary missionary expansion, particularly through the Southern Baptist Convention (founded 1845) and African American Baptist traditions, which produced figures like Martin Luther King Jr. and provided the spiritual backbone of the civil rights movement. Modern Baptists range from theologically conservative inerrantists to progressive social-gospel traditions, united more by polity (congregational autonomy) and ordinance (believers\' baptism) than by doctrinal uniformity.',
+    catholicResponse:
+      'Catholic-Baptist dialogue began in 1984. The convergence document "The Word of God in the Life of the Church" (2010-2015) addressed Scripture, Tradition, and authority.',
+    currentRelations: 'Baptist World Alliance engages in ongoing dialogue with Catholics. Significant theological distance remains, especially on baptism and ecclesiology.',
+    sources: [
+      'Bill J. Leonard, Baptists in America (Columbia, 2005)',
+      'Baptist Faith and Message (Southern Baptist Convention)',
+      'Catholic-Baptist International Conversations Reports',
+    ],
+  },
+  {
+    id: 'methodism',
+    name: 'Methodism',
+    alternateNames: ['United Methodist Church', 'African Methodist Episcopal Church', 'Wesleyan Church'],
+    category: 'post-reformation',
+    era: 'Early Modern (1600-1800)',
+    yearStart: 1738,
+    founder: 'John Wesley (1703-1791) and Charles Wesley (1707-1788)',
+    region: 'Originating England; today globally significant in USA, Africa (especially Nigeria, Zimbabwe), Korea',
+    status: 'active',
+    estimatedFollowers: '~80 million worldwide',
+    shortDescription:
+      'A revival movement begun within the Church of England by John Wesley after his 1738 "heart strangely warmed" conversion experience. Emphasizes personal holiness, evangelistic preaching, and social engagement. Formally separated from the Anglican Church in 1784.',
+    causes: {
+      theological: [
+        'Arminian (vs. Calvinist) view of free grace',
+        '"Christian perfection" — sanctification as growth toward perfect love',
+        'Strong emphasis on personal experience of God ("assurance")',
+        'Open-air preaching and small-group accountability',
+      ],
+      cultural: ['Industrial Revolution\'s spiritual vacuum; Methodism reached working classes'],
+    },
+    keyFigures: ['John Wesley', 'Charles Wesley (great hymnodist)', 'George Whitefield (Calvinist Methodist)', 'Francis Asbury'],
+    keyEvents: [
+      { year: '1738', event: 'Wesley\'s Aldersgate experience: "I felt my heart strangely warmed"' },
+      { year: '1784', event: 'Methodist Episcopal Church organized in America (formal separation from Anglicans)' },
+      { year: '1816', event: 'African Methodist Episcopal Church founded (Richard Allen)' },
+      { year: '1968', event: 'Formation of the United Methodist Church (USA)' },
+      { year: '2024', event: 'Major split as Global Methodist Church separates from UMC over LGBTQ issues' },
+    ],
+    resolution: 'Originally a movement within Anglicanism that separated; today a major global Protestant family with multiple bodies.',
+    fullDescription:
+      'John Wesley, an Anglican priest, experienced a profound conversion at a Moravian gathering on Aldersgate Street, London, in 1738. He and his brother Charles, along with George Whitefield, began open-air preaching to coal miners, factory workers, and the rural poor. "Methodist" was originally a derisive nickname for the methodical spiritual practices of the Wesleys\' Oxford "Holy Club." Wesley insisted on remaining within the Church of England throughout his life, but the practical realities of the American mission (with no Anglican bishops to ordain) led him to ordain ministers himself in 1784, marking effective separation. Methodism emphasized free grace (vs. Calvinist predestination), Christian perfection, and concrete social action — early Methodists campaigned against slavery, drunkenness, and poverty. Methodism\'s American expansion was extraordinarily rapid through the circuit-rider system. Today Methodism includes the United Methodist Church, the AME and AME Zion churches (African American), Free Methodists, Wesleyans, and many others, plus the Pentecostal and Holiness movements that emerged from Methodist roots.',
+    catholicResponse: 'Methodist-Catholic dialogue began in 1967 after Vatican II. Convergence reports on Eucharist, ministry, and authority.',
+    currentRelations: 'World Methodist Council in active dialogue with Vatican. Methodists associated with the Joint Declaration on Justification in 2006.',
+    sources: [
+      'John Wesley, Sermons and Journal',
+      'Charles Wesley, Hymns',
+      'World Methodist Council, Catholic-Methodist Dialogue Reports',
+    ],
+  },
+  {
+    id: 'old-catholic',
+    name: 'Old Catholic Church',
+    alternateNames: ['Union of Utrecht', 'Old Catholic Churches of the Union of Utrecht'],
+    category: 'post-reformation',
+    era: 'Modern (1800-Present)',
+    yearStart: 1870,
+    founder: 'Bishops who rejected Vatican I; centered on the See of Utrecht',
+    region: 'Netherlands, Germany, Switzerland, Austria, Czech Republic, USA (Polish National Catholic Church)',
+    status: 'active',
+    estimatedFollowers: '~1 million worldwide (declining)',
+    shortDescription:
+      'A communion of national Catholic churches that rejected the dogma of papal infallibility defined at Vatican I (1870), centered on the historic See of Utrecht in the Netherlands.',
+    causes: {
+      theological: [
+        'Rejection of papal infallibility as defined by Vatican I (Pastor Aeternus, 1870)',
+        'Rejection of the Immaculate Conception (defined 1854) as binding dogma',
+        'Eventually adopted modernist positions: women\'s ordination, contraception, same-sex blessings',
+      ],
+      political: [
+        'Earlier Dutch Jansenist controversy provided the See of Utrecht with bishops independent of Rome',
+      ],
+    },
+    keyFigures: ['Ignaz von Döllinger (theologian who rejected infallibility)', 'Eduard Herzog (first Old Catholic bishop in Switzerland)'],
+    keyEvents: [
+      { year: '1723', event: 'Utrecht schism: Dutch See independent of Rome over Jansenist disputes' },
+      { year: '1870', event: 'Vatican I defines papal infallibility' },
+      { year: '1871', event: 'Munich Congress: Old Catholic movement begins' },
+      { year: '1889', event: 'Union of Utrecht: federation of Old Catholic churches' },
+      { year: '1931', event: 'Bonn Agreement: full communion with Anglicans' },
+      { year: '1996+', event: 'Old Catholic churches ordain women; movement away from broader Catholic ecumenism' },
+    ],
+    resolution: 'Permanent separation; partial communion with Anglicans since 1931.',
+    fullDescription:
+      'When Vatican I defined papal infallibility on 18 July 1870, a small group of European Catholic intellectuals and clergy refused to accept the dogma. The most prominent was Ignaz von Döllinger, the great church historian at Munich, who was excommunicated. The new Old Catholic Church drew its episcopal succession from the See of Utrecht, which had been independent of Rome since 1723 over Jansenist controversies. National Old Catholic churches were established in Germany, Switzerland, Austria, and elsewhere, joining in the Union of Utrecht (1889). They preserve a Catholic liturgy and structure but reject papal infallibility, the Immaculate Conception, and the bodily Assumption as binding dogmas. Since 1996 several Old Catholic provinces have ordained women, which has strained their position with Rome but strengthened their Anglican alliance.',
+    catholicResponse: 'No formal communion. Some local pastoral arrangements exist.',
+    currentRelations: 'Full communion with Anglicans (Bonn Agreement, 1931). Limited dialogue with Rome.',
+    sources: [
+      'Bonn Agreement (1931)',
+      'Union of Utrecht Statement of Principles',
+      'Catholic Encyclopedia, "Old Catholics"',
+    ],
+  },
+
+  // -------------------- Modern Movements --------------------
+  {
+    id: 'pentecostalism',
+    name: 'Pentecostalism (Protestant)',
+    alternateNames: ['Classical Pentecostalism', 'Assemblies of God', 'Church of God in Christ', 'Neo-Pentecostalism', 'Independent Charismatic'],
+    category: 'modern',
+    era: 'Modern (1800-Present)',
+    yearStart: 1906,
+    founder: 'Charles Parham (theological precursor); William J. Seymour (Azusa Street Revival)',
+    region: 'Originating Los Angeles; today the fastest-growing Protestant tradition, especially in sub-Saharan Africa, Latin America (Brazil), and East Asia',
+    status: 'active',
+    estimatedFollowers: '~280 million classical Pentecostals across thousands of independent denominations and networks',
+    shortDescription:
+      'A Protestant tradition emerging from the Azusa Street Revival (1906) that emphasizes direct experience of the Holy Spirit — especially baptism in the Spirit evidenced by speaking in tongues, divine healing, and prophecy. Pentecostal churches are typically congregational or denominational Protestant bodies, distinct from the Catholic Charismatic Renewal (which is a movement within the Catholic Church, not a denomination).',
+    causes: {
+      theological: [
+        'Baptism in the Holy Spirit as a distinct "second blessing" after conversion, normally evidenced by speaking in tongues',
+        'Continuation of the supernatural gifts of 1 Corinthians 12 (vs. cessationism)',
+        'Emphasis on direct experience and the testimony of the Spirit',
+        'Generally Protestant theology: sola scriptura, believer\'s baptism (in most bodies), two ordinances rather than seven sacraments',
+      ],
+      cultural: [
+        '19th-century Holiness movement origins; democratization of religious authority',
+        'Multiracial origins at Azusa Street were striking in segregated America',
+        'Strong fit with oral cultures and the Global South',
+      ],
+    },
+    keyFigures: ['Charles Parham', 'William J. Seymour', 'Aimee Semple McPherson', 'David du Plessis (ecumenist)', 'Oral Roberts'],
+    keyEvents: [
+      { year: '1901', event: 'Topeka revival: Agnes Ozman speaks in tongues at Charles Parham\'s Bible school' },
+      { year: '1906', event: 'Azusa Street Revival begins in Los Angeles under William J. Seymour; birth of modern Pentecostalism' },
+      { year: '1914', event: 'Assemblies of God founded — became the largest classical Pentecostal denomination' },
+      { year: '1960', event: 'Dennis Bennett (Episcopal priest) goes public with his Pentecostal experience — beginning of the broader "Charismatic Movement" reaching mainline Protestants' },
+      { year: '1972', event: 'Catholic-Pentecostal International Dialogue begins (continuing) — Catholic Church and Pentecostal leaders enter formal ecumenical conversation' },
+    ],
+    resolution: 'A distinct Protestant tradition with massive global presence. Classical Pentecostal churches remain organizationally and theologically separate from the Catholic Church.',
+    fullDescription:
+      'Pentecostalism is a Protestant Christian tradition that emerged in the early 20th century and is now one of the largest and fastest-growing Christian movements in the world. It traces its theological precursors to the 19th-century Holiness movement and finds its formal birth at the Azusa Street Revival (Los Angeles, 1906), led by the African American preacher William J. Seymour. Pentecostal theology centers on a distinct experience called "baptism in the Holy Spirit," typically evidenced by speaking in tongues, alongside emphases on divine healing, prophecy, and the contemporary operation of the spiritual gifts described in 1 Corinthians 12. Organizationally, Pentecostalism is overwhelmingly Protestant: congregations are typically independent or grouped in denominational bodies (Assemblies of God, Church of God in Christ, Foursquare, the Pentecostal Holiness Church, and thousands of others worldwide). Classical Pentecostalism is doctrinally Protestant — affirming sola scriptura, believer\'s baptism in most bodies, and two ordinances (baptism and the Lord\'s Supper) rather than the seven Catholic sacraments. It does not recognize papal authority, Marian doctrine and devotion, the intercession of saints, or apostolic succession in the Catholic-Orthodox sense. Pentecostalism has had enormous global impact, especially in sub-Saharan Africa, Latin America (above all Brazil), and parts of East Asia.\n\nIMPORTANT DISTINCTION: The Catholic Charismatic Renewal (CCR), which began at Duquesne University in 1967, is sometimes confused with Pentecostalism but is theologically and ecclesiologically distinct. The CCR is not a denomination — it is a movement WITHIN the Catholic Church. Catholic Charismatics retain full Catholic communion: they receive the seven sacraments, recognize papal authority, profess Marian dogmas, honor the saints, and live within their local Catholic parish under their bishop. They have integrated certain Pentecostal-style spiritual experiences (charismatic prayer, healing prayer, prophetic gifts) into a fully Catholic sacramental and ecclesial life. Every pope from Paul VI through Francis has formally embraced and addressed the CCR. A dedicated history of the Catholic Charismatic Renewal will be added to this site as a separate article — it does not belong in a list of "divisions in the Church" because it is not one.',
+    catholicResponse:
+      'Pope Paul VI met with Pentecostal leaders in 1971; the Catholic-Pentecostal International Dialogue began in 1972 and continues. The dialogue has produced reports on baptism, faith, koinonia, and the role of Mary. Catholic teaching distinguishes carefully between (a) classical Protestant Pentecostalism as a separate Christian tradition, and (b) the Catholic Charismatic Renewal as a legitimate movement within Catholic communion that draws on similar spiritual experience while remaining fully Catholic in doctrine and discipline.',
+    currentRelations: 'Active formal dialogue with the Pentecostal World Fellowship. Friendly relations with many independent charismatic networks. Pope Francis has cultivated personal friendships with prominent Pentecostal pastors and has been open about being inspired by certain Pentecostal expressions of evangelism while always re-affirming Catholic ecclesiology.',
+    sources: [
+      'Walter J. Hollenweger, Pentecostalism: Origins and Developments Worldwide (Hendrickson, 1997)',
+      'Allan Anderson, An Introduction to Pentecostalism (Cambridge, 2nd ed. 2014)',
+      'Catholic-Pentecostal International Dialogue, official reports (1972-present)',
+      'Vinson Synan, The Century of the Holy Spirit (Thomas Nelson, 2001)',
+    ],
+  },
+
+  // -------------------- Restorationist (outside historic Christianity) --------------------
+  {
+    id: 'mormonism',
+    name: 'The Church of Jesus Christ of Latter-day Saints',
+    alternateNames: ['Mormons', 'LDS Church'],
+    category: 'restorationist',
+    era: 'Modern (1800-Present)',
+    yearStart: 1830,
+    founder: 'Joseph Smith (1805-1844)',
+    region: 'Originating New York / Utah; global presence',
+    status: 'active',
+    estimatedFollowers: '~17 million worldwide',
+    shortDescription:
+      'A 19th-century American restorationist movement claiming a complete restoration of the original Church through Joseph Smith\'s reception of the Book of Mormon (1830). Mainstream Christian bodies (Catholic, Orthodox, Protestant) do not regard it as Christian due to fundamental doctrinal differences.',
+    causes: {
+      theological: [
+        'Claim of new prophetic revelation (Book of Mormon, Doctrine and Covenants, Pearl of Great Price)',
+        'Materialist God: God the Father has a glorified physical body',
+        'Plurality of gods; humans can become gods (theosis radically reinterpreted)',
+        'Polygamy (officially abandoned 1890 by mainstream LDS)',
+      ],
+      cultural: ['Second Great Awakening on the American frontier; "burned-over district" of New York'],
+    },
+    keyFigures: ['Joseph Smith', 'Brigham Young', 'Modern LDS Presidents'],
+    keyEvents: [
+      { year: '1820', event: 'Joseph Smith\'s "First Vision" claim' },
+      { year: '1830', event: 'Book of Mormon published; Church organized in Fayette, NY' },
+      { year: '1844', event: 'Joseph Smith killed by mob in Carthage, Illinois' },
+      { year: '1847', event: 'Brigham Young leads pioneers to Salt Lake Valley' },
+      { year: '1890', event: 'LDS Church officially renounces polygamy (Manifesto)' },
+      { year: '2001', event: 'Catholic Congregation for the Doctrine of the Faith declares LDS baptism invalid for reception into Catholic Church' },
+    ],
+    resolution: 'A distinct world religion that uses Christian vocabulary but is doctrinally distinct from historic Christianity.',
+    fullDescription:
+      'Joseph Smith, a young man in upstate New York during the Second Great Awakening, claimed in 1820 that God the Father and Jesus Christ appeared to him and told him no existing church was true. He further claimed that an angel named Moroni led him to golden plates, which he translated as the Book of Mormon (1830). The early LDS Church faced violent persecution, fled west, and was led by Brigham Young to Utah after Smith\'s assassination in 1844. The Catholic Church, in the year 2001, declared that LDS baptism is invalid for reception into the Catholic Church because LDS theology holds a fundamentally different doctrine of God (materialist, plural, eternally progressing) than historic Christianity. Mainstream Protestant and Orthodox bodies similarly do not consider the LDS Church Christian in the historic sense, though many LDS members consider themselves Christian.',
+    catholicResponse:
+      'CDF Response (2001): Mormon baptism is not valid Christian baptism. Pastoral approach: LDS members entering the Catholic Church must be baptized.',
+    currentRelations: 'No formal ecumenical dialogue (LDS is not part of the World Council of Churches\' historic Christian dialogue). Cordial cooperation on charitable and humanitarian work.',
+    sources: [
+      'CDF Response on the Validity of Baptism Conferred by the Church of Jesus Christ of Latter-day Saints (2001)',
+      'Richard Bushman, Joseph Smith: Rough Stone Rolling',
+      'Catholic Encyclopedia and Catholic Answers materials on LDS',
+    ],
+  },
+  {
+    id: 'jehovahs-witnesses',
+    name: 'Jehovah\'s Witnesses',
+    alternateNames: ['Watch Tower Society', 'Bible Students'],
+    category: 'restorationist',
+    era: 'Modern (1800-Present)',
+    yearStart: 1879,
+    founder: 'Charles Taze Russell (1852-1916)',
+    region: 'Originating Pennsylvania, USA; global presence (~240 countries)',
+    status: 'active',
+    estimatedFollowers: '~8.7 million active publishers',
+    shortDescription:
+      'A 19th-century American adventist-restorationist movement that rejects the Trinity, the deity of Christ, and the immortality of the soul. Distinguished by intense door-to-door evangelism and refusal of military service and blood transfusions.',
+    causes: {
+      theological: [
+        'Rejection of the Trinity (Jesus is the created Son, Michael the Archangel)',
+        'Soul mortality; "the dead are conscious of nothing"',
+        'No hellfire; only annihilation for the wicked',
+        'Apocalyptic expectation; revised end-time predictions (1914, 1925, 1975)',
+        'Use of their own translation, the New World Translation',
+      ],
+    },
+    keyFigures: ['Charles Taze Russell', 'Joseph Franklin Rutherford', 'Modern Governing Body'],
+    keyEvents: [
+      { year: '1879', event: 'Russell publishes Zion\'s Watch Tower' },
+      { year: '1914', event: 'Predicted second coming; reinterpreted as Christ\'s "invisible presence"' },
+      { year: '1931', event: 'Adopt name "Jehovah\'s Witnesses" under Rutherford' },
+      { year: '1945', event: 'Begin refusing blood transfusions' },
+    ],
+    resolution: 'A distinct world religion using Christian vocabulary but doctrinally distinct from historic Christianity.',
+    fullDescription:
+      'Charles Taze Russell founded what became Jehovah\'s Witnesses in 1879, expecting Christ\'s return in 1914. When the visible return did not occur, the movement reinterpreted 1914 as the date of Christ\'s "invisible" enthronement in heaven. Under Joseph Rutherford the movement adopted its current name and reorganized as a centrally directed body. JW theology rejects the Trinity, the bodily resurrection of Christ, the immortality of the soul, and hellfire; it teaches that 144,000 chosen will reign with Christ in heaven while a "great crowd" will live forever on a renewed earth. Catholic and mainstream Protestant theology rejects JW doctrine as fundamentally non-Christian on the central matters of the Trinity and the deity of Christ.',
+    catholicResponse: 'JW baptism is not regarded as valid Christian baptism. Catholic catechetical materials address common JW objections.',
+    currentRelations: 'No ecumenical dialogue.',
+    sources: ['Catholic Encyclopedia entries', 'Catholic Answers materials', 'Watch Tower Society publications'],
+  },
+
+  // -------------------- Traditionalist Catholic --------------------
+  {
+    id: 'sspx',
+    name: 'Society of St. Pius X',
+    alternateNames: ['SSPX', 'Fraternité Sacerdotale Saint-Pie-X'],
+    category: 'traditionalist',
+    era: 'Modern (1800-Present)',
+    yearStart: 1970,
+    founder: 'Archbishop Marcel Lefebvre (1905-1991)',
+    region: 'Originating Switzerland; chapels worldwide',
+    status: 'partial-communion',
+    estimatedFollowers: '~700,000 attendees, ~700 priests, ~6 bishops',
+    shortDescription:
+      'A traditionalist Catholic society of priests founded by Archbishop Marcel Lefebvre in 1970, opposing many of the liturgical and doctrinal developments of Vatican II. In an irregular canonical situation but seeking regularization with Rome.',
+    causes: {
+      theological: [
+        'Rejection of the Novus Ordo Mass as a rupture with the Tridentine tradition',
+        'Concerns about Vatican II teaching on religious liberty (Dignitatis Humanae)',
+        'Concerns about Vatican II teaching on ecumenism (Unitatis Redintegratio) and other religions (Nostra Aetate)',
+        'Rejection of the post-conciliar "spirit of Vatican II"',
+      ],
+      cultural: ['Post-1965 collapse of vocations and traditional Catholic culture in many Western countries'],
+    },
+    keyFigures: ['Marcel Lefebvre', 'Bernard Fellay', 'Davide Pagliarani'],
+    keyEvents: [
+      { year: '1970', event: 'Foundation of the SSPX in Écône, Switzerland' },
+      { year: '1976', event: 'Lefebvre suspended a divinis after illicit ordinations' },
+      { year: '1988', event: 'Lefebvre consecrates four bishops without papal mandate; automatic excommunications incurred' },
+      { year: '2009', event: 'Pope Benedict XVI lifts excommunications of the four bishops' },
+      { year: '2015', event: 'Pope Francis grants SSPX priests faculty to hear confessions validly during the Year of Mercy (made permanent 2016)' },
+      { year: '2017', event: 'Pope Francis grants validity to SSPX marriages with local ordinary cooperation' },
+    ],
+    resolution: 'In partial, irregular communion. Active negotiations toward a Personal Prelature solution; ongoing pastoral provisions.',
+    fullDescription:
+      'Archbishop Marcel Lefebvre founded the Society of St. Pius X in 1970 with the approval of the bishop of Lausanne, Geneva and Fribourg. By 1975, however, the canonical erection had been withdrawn, and Lefebvre continued to ordain priests without permission. His decision in 1988 to consecrate four bishops without papal mandate triggered automatic excommunication for himself and the four bishops under canon law, although the SSPX argued that the perceived state of necessity in the Church justified the act. Pope Benedict XVI, in a major gesture of reconciliation in 2009, lifted the excommunications of the four still-living bishops (Lefebvre had died in 1991). Doctrinal discussions followed; while these have not produced full agreement, Pope Francis has steadily extended pastoral recognition: faculties for confessions (2015, made permanent 2016) and provisions for the validity of SSPX marriages (2017). The SSPX maintains the 1962 Roman Missal, Catholic moral teaching, and Catholic devotional practice but operates outside the regular jurisdiction of diocesan bishops. The Vatican\'s position is that SSPX Masses are valid but illicit; its sacraments other than baptism and matrimony are valid but generally illicit.',
+    catholicResponse:
+      'A pastoral and patient approach under recent popes — particularly Benedict XVI and Francis — seeking eventual full regularization. The Vatican\'s position is that the SSPX is "not in full communion" but that its members are not formally schismatic.',
+    currentRelations: 'Active doctrinal and canonical negotiations; ongoing pastoral provisions for SSPX faithful. Many traditionalist Catholics attend SSPX chapels for the traditional Mass.',
+    sources: [
+      'Pope Benedict XVI, Letter to Bishops on the Lifting of the Excommunication (2009)',
+      'Pope Francis, Misericordia et Misera (2016) — confessional faculties',
+      'Marcel Lefebvre, Open Letter to Confused Catholics',
+    ],
+  },
+
+  // -------------------- Eastern Catholic Churches --------------------
+  {
+    id: 'maronite',
+    name: 'Maronite Catholic Church',
+    alternateNames: ['Antiochene Syriac Maronite Church'],
+    category: 'eastern-catholic',
+    era: 'Early Christianity through Modern',
+    yearStart: 410,
+    founder: 'St. Maron (4th-5th c. hermit); St. John Maron (first patriarch)',
+    region: 'Lebanon (heartland), Syria, global Maronite diaspora',
+    status: 'active',
+    estimatedFollowers: '~3.5 million worldwide',
+    shortDescription:
+      'An ancient Eastern Catholic Church with roots in 4th-century Syria. Centered in Lebanon, the Maronites maintain that they have always been in communion with Rome — never formally schismatic. Distinctive Antiochene liturgy in Syriac and Arabic.',
+    causes: {
+      theological: ['Maintained Chalcedonian Christology amid surrounding Monophysite controversies'],
+      political: [
+        'Geographic isolation in Mt. Lebanon preserved their identity',
+        'Crusader-era contact (12th century) strengthened ties with Rome',
+      ],
+    },
+    keyFigures: ['St. Maron', 'St. John Maron', 'Patriarch Youssef Estephan', 'Cardinal Béchara Boutros al-Rahi'],
+    keyEvents: [
+      { year: 'c. 410', event: 'Death of St. Maron, Syrian hermit; communities form around his memory' },
+      { year: 'c. 685', event: 'Tradition: St. John Maron, first patriarch' },
+      { year: '1182', event: 'Formal communion with Rome reaffirmed during the Crusader era' },
+      { year: '1736', event: 'Synod of Mt. Lebanon — major reform' },
+      { year: '1944', event: 'Lebanon\'s confessional political system gives Maronites the presidency' },
+    ],
+    resolution: 'Always in communion with Rome (per Maronite tradition). Fully Catholic, sui iuris (self-governing) under their own patriarch.',
+    fullDescription:
+      'The Maronite Catholic Church traces its origin to disciples of St. Maron, a 5th-century Syrian hermit. The community fled Arab persecution in the 7th century to the mountains of Lebanon, where they preserved their faith and Antiochene Syriac liturgy in relative isolation. When Crusaders reached the Levant in the 12th century, the Maronites came back into regular contact with Latin Christianity; from the Maronite perspective, this was a renewal of an unbroken communion with Rome rather than a reunion. The Maronite Patriarch of Antioch and All the East, headquartered at Bkerke, Lebanon, leads the Church. The Maronite liturgy includes ancient prayers in Syriac (the language of Jesus, in its later Western Aramaic form), particularly the words of consecration in the Anaphora of St. Peter the Apostle (the Sharar). Lebanese politics has long been intertwined with Maronite identity; under the unwritten 1943 National Pact, the President of Lebanon must be a Maronite Catholic. Maronites have suffered greatly through Lebanon\'s civil war (1975-1990) and ongoing regional crises, with significant emigration to North and South America and Australia.',
+    catholicResponse: 'Full communion. The Maronite Church is one of the 23 sui iuris churches in the Catholic Church.',
+    currentRelations: 'Maronite Patriarch participates in Roman synods of bishops; Maronite cardinals serve in the College of Cardinals.',
+    sources: [
+      'Pierre Dib, History of the Maronite Church',
+      'Code of Canons of the Eastern Churches (1990)',
+      'Maronite Patriarchal Synod documents',
+    ],
+  },
+  {
+    id: 'ukrainian-greek-catholic',
+    name: 'Ukrainian Greek Catholic Church',
+    alternateNames: ['UGCC', 'Ruthenian Uniate Church (historical)'],
+    category: 'eastern-catholic',
+    era: 'Early Modern (1600-1800)',
+    yearStart: 1596,
+    founder: 'Kievan metropolitans at the Union of Brest (1596)',
+    region: 'Ukraine, especially the western regions; significant diaspora in USA, Canada, Brazil, Australia',
+    status: 'active',
+    estimatedFollowers: '~5.5 million worldwide',
+    shortDescription:
+      'The largest Eastern Catholic Church, formed in 1596 at the Union of Brest when several Orthodox eparchies of the Kievan metropolitanate entered communion with Rome while retaining the Byzantine liturgy and Slavonic language. Suppressed under Soviet rule (1946-1989); now flourishing.',
+    causes: {
+      theological: ['Acceptance of papal primacy and the filioque clause'],
+      political: [
+        'Polish-Lithuanian Commonwealth\'s pressure for ecclesial unity',
+        'Resistance to Russian Orthodox absorption',
+      ],
+      cultural: ['Preserved a distinct Ukrainian/Ruthenian Christian identity'],
+    },
+    keyFigures: ['Metropolitan Mykhailo Rohoza', 'St. Josaphat Kuntsevych (martyr)', 'Major Archbishop Sviatoslav Shevchuk (current)'],
+    keyEvents: [
+      { year: '1596', event: 'Union of Brest: Kievan metropolitans enter Catholic communion' },
+      { year: '1623', event: 'St. Josaphat martyred by anti-Union mob' },
+      { year: '1946', event: 'Stalin orchestrates "Lviv Pseudo-Synod" forcibly suppressing the UGCC and absorbing it into the Russian Orthodox Church' },
+      { year: '1946-1989', event: 'UGCC continues underground as "the largest forbidden Church in the world"' },
+      { year: '1989', event: 'Legal restoration of UGCC under Gorbachev' },
+      { year: '2005', event: 'Patriarchal see relocated from Lviv to Kyiv' },
+      { year: '2022', event: 'During Russia\'s full-scale invasion, the UGCC is at the heart of Ukrainian spiritual identity' },
+    ],
+    resolution: 'In full communion with Rome since 1596; restored 1989 after Soviet suppression.',
+    fullDescription:
+      'The Union of Brest (1595-96) brought most of the Kievan metropolitan see into communion with Rome while preserving Byzantine liturgy, married parish clergy, and Slavonic ecclesiastical language. The new Uniate Church faced fierce resistance, especially from Cossack populations whose religious-national identity was Orthodox; the martyrdom of St. Josaphat Kuntsevych (1623) by an angry mob at Vitebsk became emblematic of the church\'s suffering. The Russian Empire systematically dismantled the UGCC after partitioning Poland (late 18th century), and Stalin\'s 1946 "Lviv Pseudo-Synod" formally liquidated the UGCC, transferring all properties to the Russian Orthodox Church. The UGCC survived underground for forty-three years — celebrating Mass in forests and basements — and re-emerged after 1989 as one of the most vibrant churches in the world. Today the UGCC is a major Christian voice in Ukraine, particularly during the Russian invasion that began in 2022. The UGCC has long sought elevation from Major Archbishopric to a full Patriarchate; this remains a pending question in Rome.',
+    catholicResponse: 'Full communion. Major Archbishop participates in the College of Cardinals.',
+    currentRelations: 'Tense with Russian Orthodox Church due to Ukraine war and historical Soviet suppression; close cooperation with Latin Catholics in Ukraine.',
+    sources: [
+      'Borys Gudziak, Crisis and Reform: The Kyivan Metropolitanate, the Patriarchate of Constantinople, and the Genesis of the Union of Brest',
+      'UGCC Catechism (Christ Our Pascha, 2011)',
+    ],
+  },
+  {
+    id: 'syro-malabar',
+    name: 'Syro-Malabar Catholic Church',
+    alternateNames: ['Saint Thomas Christians (in communion with Rome)', 'Malabar Catholic Church'],
+    category: 'eastern-catholic',
+    era: 'Early Modern (1600-1800)',
+    yearStart: 1599,
+    region: 'Kerala, India; diaspora worldwide',
+    status: 'active',
+    estimatedFollowers: '~4.6 million worldwide',
+    shortDescription:
+      'An ancient Saint Thomas Christian community in Kerala that traces its origin to the Apostle Thomas (AD 52). Brought into Latin-style communion with Rome at the Synod of Diamper (1599); restored to its Eastern (East Syrian) liturgical heritage in the 20th century.',
+    causes: {
+      theological: ['Acceptance of full Catholic communion while preserving East Syrian liturgical tradition'],
+      cultural: ['Portuguese Padroado missionary intervention reshaped — sometimes harshly — local traditions'],
+    },
+    keyFigures: ['Archbishop Aleixo de Menezes (Synod of Diamper)', 'Major Archbishop Cardinal George Alencherry', 'Major Archbishop Raphael Thattil (current)'],
+    keyEvents: [
+      { year: 'AD 52 (tradition)', event: 'St. Thomas the Apostle arrives at Muziris, Kerala' },
+      { year: 'Pre-1599', event: 'Saint Thomas Christians in communion with the Church of the East (Persia)' },
+      { year: '1599', event: 'Synod of Diamper (under Portuguese pressure) Latinizes and brings the community under Padroado' },
+      { year: '1653', event: 'Coonan Cross Oath: many Saint Thomas Christians break from Padroado control' },
+      { year: '1923', event: 'Restoration of Syro-Malabar hierarchy by Pope Pius XI' },
+      { year: '1992', event: 'Major Archiepiscopal sui iuris status granted by John Paul II' },
+      { year: '2017+', event: 'Tensions over uniform liturgy ("ad orientem" issue) divide the church' },
+    ],
+    resolution: 'In full communion with Rome as a sui iuris church.',
+    fullDescription:
+      'The Saint Thomas Christians of Kerala trace their origins to the Apostle Thomas, who according to ancient and continuous tradition arrived at Muziris (modern Kodungallur) in AD 52 and was martyred at Mylapore in AD 72. The community was historically in communion with the Church of the East (often called the "Nestorian" Church), receiving bishops from Mesopotamia. Portuguese arrival in 1498 brought Latin Catholic missionaries who, often heavy-handedly, brought the community under Roman jurisdiction at the Synod of Diamper (1599) and substantially Latinized its liturgy. Resistance erupted in 1653 with the Coonan Cross Oath at Mattancherry, after which a portion of the community broke away and is today represented by the Malankara Orthodox Syrian Church and several other bodies. Those who remained in Catholic communion form the Syro-Malabar Catholic Church. In the 20th century the church recovered its Eastern Christian heritage, restoring the East Syrian Liturgy of Addai and Mari (with Catholic adaptations). Today the Syro-Malabar Church is one of the largest Eastern Catholic Churches and has spread globally with the Indian diaspora.',
+    catholicResponse: 'Full communion. The Major Archbishop of Ernakulam-Angamaly leads the church.',
+    currentRelations: 'Close ties with Rome. Significant ongoing internal tensions about liturgical practice (ad orientem celebration).',
+    sources: [
+      'A. Mathias Mundadan, History of Christianity in India, Vol. 1',
+      'Stephen Neill, A History of Christianity in India',
+      'Code of Canons of the Eastern Churches',
+    ],
+  },
+  {
+    id: 'eastern-catholic-other',
+    name: 'Other Eastern Catholic Churches',
+    alternateNames: ['Sui iuris Eastern Catholic Churches'],
+    category: 'eastern-catholic',
+    era: 'Various (1500s-Present)',
+    yearStart: 1551,
+    region: 'Middle East, Eastern Europe, Africa, India',
+    status: 'active',
+    estimatedFollowers: '~10 million combined (in addition to Maronite, UGCC, Syro-Malabar)',
+    shortDescription:
+      'In addition to the Maronite, Ukrainian Greek Catholic, and Syro-Malabar churches, the Catholic Communion includes 19 other sui iuris Eastern Catholic Churches preserving Alexandrian, Antiochene, Armenian, Byzantine, and East Syrian liturgical traditions.',
+    causes: {
+      theological: ['Each church entered communion with Rome in different historical circumstances while preserving its liturgical heritage'],
+    },
+    keyFigures: ['Various patriarchs and major archbishops'],
+    keyEvents: [
+      { year: '1551', event: 'Chaldean Catholic Church (East Syrian, Iraq)' },
+      { year: '1646', event: 'Romanian Greek Catholic Church (Byzantine)' },
+      { year: '1724', event: 'Melkite Greek Catholic Church (Byzantine, Antiochene)' },
+      { year: '1741', event: 'Coptic Catholic Church (Alexandrian)' },
+      { year: '1781', event: 'Armenian Catholic Church' },
+      { year: '1846', event: 'Ethiopian Catholic Church (Alexandrian)' },
+      { year: '1930', event: 'Syro-Malankara Catholic Church (Antiochene, India)' },
+    ],
+    resolution: 'All in full communion with Rome as sui iuris (self-governing) churches.',
+    fullDescription:
+      'The Catholic Church is far more than the Latin (Roman) Rite. Twenty-three sui iuris churches preserve a remarkable diversity of liturgical, theological, canonical, and spiritual traditions. The major groups are: Alexandrian tradition (Coptic Catholic, Ethiopian Catholic, Eritrean Catholic); Antiochene/West Syrian tradition (Maronite, Syriac Catholic, Syro-Malankara); Armenian tradition (Armenian Catholic); Byzantine tradition (Albanian, Belarusian, Bulgarian, Croatian/Serbian, Greek, Hungarian, Italo-Albanian, Macedonian, Melkite, Romanian, Russian, Ruthenian, Slovak, Ukrainian Greek Catholic); East Syrian / Chaldean tradition (Chaldean Catholic, Syro-Malabar). Each is led by its own hierarchy — patriarchs, major archbishops, or metropolitans — in full communion with the Bishop of Rome. The Melkite Patriarch of Antioch and All the East has historically been a particularly important voice in Catholic-Orthodox dialogue. The Eastern Catholic churches challenge the Western misconception that "Catholic" means "Latin Rite": the Catholic Church is, by Vatican II teaching, a communion of churches.',
+    catholicResponse: 'Full communion. Vatican II\'s decree Orientalium Ecclesiarum (1964) reaffirmed equal dignity.',
+    currentRelations: 'Each Eastern Catholic Church relates ecumenically with its Orthodox counterpart.',
+    sources: [
+      'Vatican II, Orientalium Ecclesiarum (1964)',
+      'Code of Canons of the Eastern Churches (1990)',
+      'Ronald Roberson, The Eastern Christian Churches: A Brief Survey (Oriental Institute, Rome)',
+    ],
+  },
+]
+
+// ============================================================================
+// COMPONENTS
+// ============================================================================
+
+function StatusBadge({ status }: { status: Status }) {
+  const config: Record<Status, { label: string; cls: string }> = {
+    'active': { label: 'Active', cls: 'bg-green-100 text-green-800 border-green-200' },
+    'extinct': { label: 'Extinct', cls: 'bg-gray-100 text-gray-700 border-gray-200' },
+    'reconciled': { label: 'Reconciled', cls: 'bg-blue-100 text-blue-800 border-blue-200' },
+    'partial-communion': { label: 'Partial Communion', cls: 'bg-amber-100 text-amber-800 border-amber-200' },
+  }
+  const c = config[status]
+  return (
+    <span className={`inline-flex items-center text-xs px-2 py-0.5 rounded-full font-medium border ${c.cls}`}>
+      {c.label}
+    </span>
+  )
+}
+
+function ToggleSwitch({ value, onChange }: { value: 'new' | 'old'; onChange: (v: 'new' | 'old') => void }) {
+  return (
+    <div className="inline-flex items-center bg-gray-100 rounded-lg p-1 border border-gray-200">
+      <button
+        onClick={() => onChange('new')}
+        className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+          value === 'new' ? 'bg-amber-500 text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'
+        }`}
+      >
+        New View
+      </button>
+      <button
+        onClick={() => onChange('old')}
+        className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+          value === 'old' ? 'bg-amber-500 text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'
+        }`}
+      >
+        Old View (Backup)
+      </button>
+    </div>
+  )
+}
+
+// ============================================================================
+// NEW VIEW
+// ============================================================================
+
+function NewView() {
+  const [search, setSearch] = useState('')
+  const [activeCategories, setActiveCategories] = useState<Set<Category>>(new Set())
+  const [selectedId, setSelectedId] = useState<string>(DIVISIONS[0]?.id || '')
+  const [expandedCategories, setExpandedCategories] = useState<Set<Category>>(
+    new Set(Object.keys(CATEGORY_META) as Category[])
+  )
+
+  // Filter logic
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return DIVISIONS.filter((d) => {
+      if (activeCategories.size > 0 && !activeCategories.has(d.category)) return false
+      if (!q) return true
+      const haystack = [
+        d.name,
+        ...(d.alternateNames || []),
+        d.founder || '',
+        d.region,
+        d.shortDescription,
+      ].join(' ').toLowerCase()
+      return haystack.includes(q)
+    })
+  }, [search, activeCategories])
+
+  // Group by category
+  const grouped = useMemo(() => {
+    const map = new Map<Category, Division[]>()
+    for (const d of filtered) {
+      if (!map.has(d.category)) map.set(d.category, [])
+      map.get(d.category)!.push(d)
+    }
+    return Array.from(map.entries()).sort((a, b) => CATEGORY_META[a[0]].order - CATEGORY_META[b[0]].order)
+  }, [filtered])
+
+  const selected = useMemo(
+    () => DIVISIONS.find((d) => d.id === selectedId) || filtered[0] || null,
+    [selectedId, filtered]
+  )
+
+  const toggleCategory = (c: Category) => {
+    setActiveCategories((prev) => {
+      const next = new Set(prev)
+      if (next.has(c)) next.delete(c)
+      else next.add(c)
+      return next
+    })
+  }
+
+  const toggleCategoryExpansion = (c: Category) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev)
+      if (next.has(c)) next.delete(c)
+      else next.add(c)
+      return next
+    })
+  }
+
+  // Counts per category
+  const categoryCounts = useMemo(() => {
+    const counts = new Map<Category, number>()
+    for (const d of DIVISIONS) {
+      counts.set(d.category, (counts.get(d.category) || 0) + 1)
+    }
+    return counts
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      {/* Search */}
+      <div className="relative">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <Search className="h-5 w-5 text-gray-400" />
+        </div>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name, founder, region…"
+          className="block w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-amber-500 focus:border-amber-500"
+        />
+      </div>
+
+      {/* Category filter chips */}
+      <div className="flex flex-wrap gap-2">
+        {(Object.keys(CATEGORY_META) as Category[])
+          .sort((a, b) => CATEGORY_META[a].order - CATEGORY_META[b].order)
+          .map((c) => {
+            const isActive = activeCategories.has(c)
+            const count = categoryCounts.get(c) || 0
+            return (
+              <button
+                key={c}
+                onClick={() => toggleCategory(c)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border transition-colors ${
+                  isActive
+                    ? 'bg-amber-500 text-white border-amber-500 shadow-sm'
+                    : `${CATEGORY_META[c].color} hover:shadow-sm`
+                }`}
+              >
+                {CATEGORY_META[c].label}
+                <span className={`text-xs ${isActive ? 'text-amber-100' : 'opacity-60'}`}>({count})</span>
+              </button>
+            )
+          })}
+        {activeCategories.size > 0 && (
+          <button
+            onClick={() => setActiveCategories(new Set())}
+            className="inline-flex items-center text-xs px-3 py-1.5 rounded-full text-gray-500 hover:text-gray-700 underline"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Tree / List */}
+        <div className="lg:col-span-1">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sticky top-4">
+            <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+              <Network className="w-4 h-4" />
+              Tree View
+              <span className="text-xs font-normal text-gray-500 ml-auto">
+                {filtered.length} of {DIVISIONS.length}
+              </span>
+            </h3>
+            <div className="space-y-3 max-h-[70vh] overflow-y-auto pr-1">
+              {grouped.length === 0 && (
+                <p className="text-sm text-gray-500 italic">No matches found.</p>
+              )}
+              {grouped.map(([category, items]) => {
+                const isExpanded = expandedCategories.has(category)
+                const meta = CATEGORY_META[category]
+                return (
+                  <div key={category}>
+                    <button
+                      onClick={() => toggleCategoryExpansion(category)}
+                      className="w-full flex items-center gap-2 text-left"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown className="w-4 h-4 text-gray-400 shrink-0" />
+                      ) : (
+                        <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
+                      )}
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded ${meta.color}`}>
+                        {meta.label}
+                      </span>
+                      <span className="text-xs text-gray-400 ml-auto">{items.length}</span>
+                    </button>
+                    {isExpanded && (
+                      <div className="ml-6 mt-1 space-y-1 border-l border-gray-200 pl-3">
+                        {items.map((d) => {
+                          const isSelected = selectedId === d.id
+                          return (
+                            <button
+                              key={d.id}
+                              onClick={() => setSelectedId(d.id)}
+                              className={`w-full text-left text-sm py-1 px-2 rounded transition-colors ${
+                                isSelected
+                                  ? 'bg-amber-100 text-amber-900 font-medium'
+                                  : 'text-gray-700 hover:bg-gray-50'
+                              }`}
+                            >
+                              <span className="block truncate">{d.name}</span>
+                              <span className="text-xs text-gray-400">
+                                {d.yearStart}{d.yearEnd ? `–${d.yearEnd}` : ''}
+                              </span>
+                            </button>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Detail panel */}
+        <div className="lg:col-span-2">
+          {selected ? <DetailPanel division={selected} /> : (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
+              <p className="text-gray-500">Select a division to view its details.</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Cross-links */}
+      <div className="bg-gray-50 border border-gray-200 rounded-xl p-6">
+        <h3 className="font-serif font-semibold text-gray-900 mb-3">Related Pages</h3>
+        <div className="flex flex-wrap gap-3 text-sm">
+          <Link href="/history/church" className="inline-flex items-center gap-2 px-3 py-1.5 bg-white border border-gray-300 rounded-lg hover:bg-amber-50 hover:border-amber-300 transition-colors">
+            <BookOpen className="w-4 h-4 text-amber-600" />
+            The Church in History
+          </Link>
+          <Link href="/history/church-tree" className="inline-flex items-center gap-2 px-3 py-1.5 bg-white border border-gray-300 rounded-lg hover:bg-amber-50 hover:border-amber-300 transition-colors">
+            <Network className="w-4 h-4 text-amber-600" />
+            Visual Church History Tree
+          </Link>
+          <Link href="/mysteries/public-revelation" className="inline-flex items-center gap-2 px-3 py-1.5 bg-white border border-gray-300 rounded-lg hover:bg-amber-50 hover:border-amber-300 transition-colors">
+            <BookOpen className="w-4 h-4 text-amber-600" />
+            Public Revelation
+          </Link>
+        </div>
+      </div>
+
+      {/* Note about extending data */}
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-900 space-y-2">
+        <p>
+          <strong>Note:</strong> This dataset currently covers {DIVISIONS.length} divisions —
+          comprehensive on Early Heresies through Reformation, with key Modern, Restorationist,
+          Traditionalist, and Eastern Catholic entries. The data structure is designed to grow:
+          ask to add specific denominations or movements as you encounter gaps.
+        </p>
+        <p>
+          <strong>What is NOT a division:</strong> Movements within the Catholic Church &mdash; such
+          as the <em>Catholic Charismatic Renewal</em> (1967&ndash;), Focolare, Communion and
+          Liberation, the Neocatechumenal Way, Opus Dei, and many religious orders &mdash; are not
+          divisions; they are ecclesial movements in full communion with Rome. A dedicated page on
+          the <em>History of the Catholic Charismatic Renewal</em> is planned and will be added as
+          a separate article.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function DetailPanel({ division: d }: { division: Division }) {
+  const meta = CATEGORY_META[d.category]
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <div className="flex items-start justify-between gap-4 mb-3">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-2">
+              <span className={`text-xs px-2 py-0.5 rounded font-medium ${meta.color}`}>{meta.label}</span>
+              <StatusBadge status={d.status} />
+            </div>
+            <h2 className="text-2xl sm:text-3xl font-serif font-bold text-gray-900">{d.name}</h2>
+            {d.alternateNames && d.alternateNames.length > 0 && (
+              <p className="text-sm text-gray-500 mt-1">
+                Also known as: {d.alternateNames.join(' · ')}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <p className="text-gray-700 leading-relaxed">{d.shortDescription}</p>
+      </div>
+
+      {/* Quick stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Year</p>
+          <p className="text-sm font-semibold text-gray-900">
+            {d.yearStart}{d.yearEnd ? `–${d.yearEnd}` : '–present'}
+          </p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Era</p>
+          <p className="text-sm font-medium text-gray-700">{d.era}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Region</p>
+          <p className="text-sm text-gray-700">{d.region}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Followers</p>
+          <p className="text-sm text-gray-700">{d.estimatedFollowers || '—'}</p>
+        </div>
+      </div>
+
+      {/* Founder */}
+      {d.founder && (
+        <div className="bg-white rounded-lg border border-gray-200 p-4 flex items-center gap-3">
+          <User className="w-5 h-5 text-gray-400 shrink-0" />
+          <div>
+            <p className="text-xs text-gray-500 uppercase tracking-wide">Founder / Origin</p>
+            <p className="text-sm text-gray-800">{d.founder}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Full Description */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h3 className="font-serif font-semibold text-gray-900 mb-3 flex items-center gap-2">
+          <BookOpen className="w-4 h-4 text-gray-500" />
+          Overview
+        </h3>
+        <p className="text-gray-700 leading-relaxed whitespace-pre-line">{d.fullDescription}</p>
+      </div>
+
+      {/* Causes */}
+      {(d.causes.theological?.length || d.causes.political?.length || d.causes.cultural?.length) && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h3 className="font-serif font-semibold text-gray-900 mb-3 flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4 text-red-500" />
+            Causes
+          </h3>
+          <div className="space-y-4">
+            {d.causes.theological && d.causes.theological.length > 0 && (
+              <div className="bg-red-50 rounded-lg p-4">
+                <p className="text-sm font-semibold text-red-900 mb-2">Theological</p>
+                <ul className="space-y-1.5 text-sm text-red-800">
+                  {d.causes.theological.map((c, i) => (
+                    <li key={i} className="flex items-start gap-2">
+                      <span className="mt-0.5 text-red-500">•</span>
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {d.causes.political && d.causes.political.length > 0 && (
+              <div className="bg-blue-50 rounded-lg p-4">
+                <p className="text-sm font-semibold text-blue-900 mb-2">Political</p>
+                <ul className="space-y-1.5 text-sm text-blue-800">
+                  {d.causes.political.map((c, i) => (
+                    <li key={i} className="flex items-start gap-2">
+                      <span className="mt-0.5 text-blue-500">•</span>
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {d.causes.cultural && d.causes.cultural.length > 0 && (
+              <div className="bg-amber-50 rounded-lg p-4">
+                <p className="text-sm font-semibold text-amber-900 mb-2">Cultural</p>
+                <ul className="space-y-1.5 text-sm text-amber-800">
+                  {d.causes.cultural.map((c, i) => (
+                    <li key={i} className="flex items-start gap-2">
+                      <span className="mt-0.5 text-amber-500">•</span>
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Key Figures */}
+      {d.keyFigures && d.keyFigures.length > 0 && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h3 className="font-serif font-semibold text-gray-900 mb-3 flex items-center gap-2">
+            <Users className="w-4 h-4 text-blue-500" />
+            Key Figures
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {d.keyFigures.map((f) => (
+              <span key={f} className="inline-flex items-center gap-1 px-3 py-1 bg-blue-50 text-blue-800 text-sm rounded-full border border-blue-100">
+                <User className="w-3 h-3" />
+                {f}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Key Events Timeline */}
+      {d.keyEvents && d.keyEvents.length > 0 && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h3 className="font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <Calendar className="w-4 h-4 text-amber-600" />
+            Key Events
+          </h3>
+          <div className="space-y-3">
+            {d.keyEvents.map((e, i) => (
+              <div key={i} className="flex gap-4 items-start">
+                <span className="bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium font-mono">
+                  {e.year}
+                </span>
+                <p className="text-gray-700 text-sm leading-relaxed">{e.event}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Resolution */}
+      {d.resolution && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h3 className="font-serif font-semibold text-gray-900 mb-2">Resolution &amp; Current Status</h3>
+          <p className="text-gray-700 leading-relaxed">{d.resolution}</p>
+        </div>
+      )}
+
+      {/* Catholic Response */}
+      {d.catholicResponse && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h3 className="font-serif font-semibold text-gray-900 mb-2 text-amber-800">Catholic Church&rsquo;s Response</h3>
+          <p className="text-gray-700 leading-relaxed">{d.catholicResponse}</p>
+        </div>
+      )}
+
+      {/* Current Relations */}
+      {d.currentRelations && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-5">
+          <h3 className="font-serif font-semibold text-blue-900 mb-2 flex items-center gap-2">
+            <MapPin className="w-4 h-4" />
+            Current Ecumenical Relations
+          </h3>
+          <p className="text-blue-900 text-sm leading-relaxed">{d.currentRelations}</p>
+        </div>
+      )}
+
+      {/* Sources */}
+      {d.sources && d.sources.length > 0 && (
+        <div className="bg-gray-50 rounded-lg p-5">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide flex items-center gap-2">
+            <ExternalLink className="w-3.5 h-3.5" />
+            Sources &amp; Further Reading
+          </h4>
+          <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+            {d.sources.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// OLD VIEW (preserved as backup — original DB-fetching implementation)
+// ============================================================================
+
+function OldView() {
   const [divisions, setDivisions] = useState<ChurchDivision[]>([])
   const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set())
   const [selectedDivision, setSelectedDivision] = useState<ChurchDivision | null>(null)
@@ -24,35 +2070,33 @@ export default function ChurchDivisionsPage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    const fetchDivisions = async () => {
+      try {
+        const response = await fetch('/api/history/church-divisions')
+        if (!response.ok) {
+          throw new Error('Failed to fetch church divisions data')
+        }
+        const data = await response.json()
+        setDivisions(data)
+        if (data.length > 0) {
+          setSelectedDivision(data[0])
+          data.forEach((division: ChurchDivision) => {
+            if (!division.parentId) {
+              setExpandedNodes((prev) => new Set([...prev, division.id]))
+            }
+          })
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred')
+      } finally {
+        setLoading(false)
+      }
+    }
     fetchDivisions()
   }, [])
 
-  const fetchDivisions = async () => {
-    try {
-      const response = await fetch('/api/history/church-divisions')
-      if (!response.ok) {
-        throw new Error('Failed to fetch church divisions data')
-      }
-      const data = await response.json()
-      setDivisions(data)
-      if (data.length > 0) {
-        setSelectedDivision(data[0]) // Select first division by default
-        // Expand first level by default
-        data.forEach((division: ChurchDivision) => {
-          if (!division.parentId) {
-            setExpandedNodes(prev => new Set([...prev, division.id]))
-          }
-        })
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred')
-    } finally {
-      setLoading(false)
-    }
-  }
-
   const toggleNode = (nodeId: string) => {
-    setExpandedNodes(prev => {
+    setExpandedNodes((prev) => {
       const newSet = new Set(prev)
       if (newSet.has(nodeId)) {
         newSet.delete(nodeId)
@@ -63,7 +2107,7 @@ export default function ChurchDivisionsPage() {
     })
   }
 
-  const renderDivisionNode = (division: ChurchDivision, level: number = 0) => {
+  const renderDivisionNode = (division: ChurchDivision, level: number = 0): React.ReactNode => {
     const isExpanded = expandedNodes.has(division.id)
     const hasChildren = division.children && division.children.length > 0
     const isSelected = selectedDivision?.id === division.id
@@ -82,24 +2126,17 @@ export default function ChurchDivisionsPage() {
           <button
             onClick={(e) => {
               e.stopPropagation()
-              if (hasChildren) {
-                toggleNode(division.id)
-              }
+              if (hasChildren) toggleNode(division.id)
             }}
             className="mr-2 p-1 hover:bg-gray-200 rounded"
             disabled={!hasChildren}
           >
             {hasChildren ? (
-              isExpanded ? (
-                <ChevronDown className="w-4 h-4" />
-              ) : (
-                <ChevronRight className="w-4 h-4" />
-              )
+              isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />
             ) : (
               <div className="w-4 h-4" />
             )}
           </button>
-          
           <div className="flex-1">
             <div className="flex items-center space-x-2">
               <h3 className="font-semibold text-gray-800">{division.name}</h3>
@@ -107,15 +2144,12 @@ export default function ChurchDivisionsPage() {
                 {division.year}
               </span>
             </div>
-            <p className="text-sm text-gray-600 mt-1 line-clamp-2">
-              {division.description}
-            </p>
+            <p className="text-sm text-gray-600 mt-1 line-clamp-2">{division.description}</p>
           </div>
         </div>
-
         {isExpanded && hasChildren && (
           <div className="mt-2">
-            {division.children.map(child => renderDivisionNode(child, level + 1))}
+            {division.children.map((child) => renderDivisionNode(child, level + 1))}
           </div>
         )}
       </div>
@@ -124,151 +2158,102 @@ export default function ChurchDivisionsPage() {
 
   if (loading) {
     return (
-      <div className="py-8">
-        <div className="container mx-auto px-4">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-600 mx-auto"></div>
-            <p className="mt-4 text-gray-600">Loading church divisions...</p>
-          </div>
-        </div>
+      <div className="text-center py-12">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-600 mx-auto"></div>
+        <p className="mt-4 text-gray-600">Loading church divisions…</p>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="py-8">
-        <div className="container mx-auto px-4">
-          <div className="text-center">
-            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-              <p className="font-bold">Error loading church divisions</p>
-              <p>{error}</p>
-            </div>
-          </div>
-        </div>
+      <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+        <p className="font-bold">Error loading church divisions</p>
+        <p>{error}</p>
       </div>
     )
   }
 
   return (
-    <div className="py-8">
-      <div className="container mx-auto px-4">
-        {/* Header */}
-        <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-gray-800 mb-4">
-            Divisions in the Church
-          </h1>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Explore the historical divisions and schisms that have shaped Christianity 
-            throughout history, from the Great Schism to the Protestant Reformation.
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* Division Tree */}
-          <div className="lg:col-span-1">
-            <div className="bg-white rounded-lg shadow-lg p-6 sticky top-8">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4">Church Divisions</h2>
-              <div className="space-y-2">
-                {divisions.map((division: ChurchDivision) => renderDivisionNode(division))}
-              </div>
-            </div>
-          </div>
-
-          {/* Division Details */}
-          <div className="lg:col-span-2">
-            {selectedDivision ? (
-              <div className="space-y-6">
-                {/* Division Header */}
-                <div className="bg-white rounded-lg shadow-lg p-6">
-                  <div className="flex items-start space-x-6">
-                    <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                      <AlertTriangle className="w-8 h-8 text-red-600" />
-                    </div>
-                    <div className="flex-1">
-                      <h2 className="text-3xl font-bold text-gray-800 mb-2">
-                        {selectedDivision.name}
-                      </h2>
-                      <div className="flex items-center space-x-4 text-sm text-gray-600 mb-4">
-                        <div className="flex items-center space-x-1">
-                          <Calendar className="w-4 h-4" />
-                          <span>{selectedDivision.year}</span>
-                        </div>
-                        {selectedDivision.relatedPopes && selectedDivision.relatedPopes.length > 0 && (
-                          <div className="flex items-center space-x-1">
-                            <Users className="w-4 h-4" />
-                            <span>{selectedDivision.relatedPopes.length} related popes</span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <div className="mt-6">
-                    <h3 className="text-xl font-semibold text-gray-800 mb-3">Description</h3>
-                    <p className="text-gray-600 leading-relaxed">{selectedDivision.description}</p>
-                  </div>
-
-                  {selectedDivision.cause && (
-                    <div className="mt-6">
-                      <h3 className="text-xl font-semibold text-gray-800 mb-3">Causes</h3>
-                      <p className="text-gray-600 leading-relaxed">{selectedDivision.cause}</p>
-                    </div>
-                  )}
-
-                  {selectedDivision.outcome && (
-                    <div className="mt-6">
-                      <h3 className="text-xl font-semibold text-gray-800 mb-3">Outcome</h3>
-                      <p className="text-gray-600 leading-relaxed">{selectedDivision.outcome}</p>
-                    </div>
-                  )}
-                </div>
-
-                {/* Related Popes */}
-                {selectedDivision.relatedPopes && selectedDivision.relatedPopes.length > 0 && (
-                  <div className="bg-white rounded-lg shadow-lg p-6">
-                    <h3 className="text-2xl font-bold text-gray-800 mb-6">Related Popes</h3>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      {selectedDivision.relatedPopes.map((pope: any) => (
-                        <div key={pope.id} className="p-4 bg-gray-50 rounded-lg">
-                          <h4 className="font-semibold text-gray-800 mb-2">{pope.regnalName}</h4>
-                          <p className="text-sm text-gray-600">
-                            Papacy: {pope.papacyStart} - {pope.papacyEnd || 'Present'}
-                          </p>
-                          <p className="text-sm text-gray-600">
-                            Papacy Number: {pope.papacyNumber}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Historical Context */}
-                <div className="bg-white rounded-lg shadow-lg p-6">
-                  <h3 className="text-2xl font-bold text-gray-800 mb-6">Historical Context</h3>
-                  <div className="prose max-w-none">
-                    <p className="text-gray-600 leading-relaxed">
-                      The {selectedDivision.name} represents a significant moment in Church history. 
-                      Understanding these divisions helps us appreciate the complexity of Christian 
-                      history and the ongoing work of Christian unity.
-                    </p>
-                    <p className="text-gray-600 leading-relaxed mt-4">
-                      While divisions have occurred throughout history, they have also led to 
-                      important theological developments and, in many cases, eventual reconciliation 
-                      and dialogue between different Christian traditions.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="bg-white rounded-lg shadow-lg p-8 text-center">
-                <p className="text-gray-600">Select a division to view its details</p>
-              </div>
-            )}
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <div className="lg:col-span-1">
+        <div className="bg-white rounded-lg shadow-lg p-6 sticky top-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4">Church Divisions (DB-backed)</h2>
+          <div className="space-y-2">
+            {divisions.map((division) => renderDivisionNode(division))}
           </div>
         </div>
       </div>
+      <div className="lg:col-span-2">
+        {selectedDivision ? (
+          <div className="space-y-6">
+            <div className="bg-white rounded-lg shadow-lg p-6">
+              <div className="flex items-start space-x-6">
+                <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-8 h-8 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h2 className="text-3xl font-bold text-gray-800 mb-2">{selectedDivision.name}</h2>
+                  <div className="flex items-center space-x-4 text-sm text-gray-600 mb-4">
+                    <div className="flex items-center space-x-1">
+                      <Calendar className="w-4 h-4" />
+                      <span>{selectedDivision.year}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-6">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Description</h3>
+                <p className="text-gray-600 leading-relaxed">{selectedDivision.description}</p>
+              </div>
+              {selectedDivision.cause && (
+                <div className="mt-6">
+                  <h3 className="text-xl font-semibold text-gray-800 mb-3">Causes</h3>
+                  <p className="text-gray-600 leading-relaxed">{selectedDivision.cause}</p>
+                </div>
+              )}
+              {selectedDivision.outcome && (
+                <div className="mt-6">
+                  <h3 className="text-xl font-semibold text-gray-800 mb-3">Outcome</h3>
+                  <p className="text-gray-600 leading-relaxed">{selectedDivision.outcome}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="bg-white rounded-lg shadow-lg p-8 text-center">
+            <p className="text-gray-600">Select a division to view its details</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// TOP-LEVEL PAGE
+// ============================================================================
+
+export default function ChurchDivisionsPage() {
+  const [view, setView] = useState<'new' | 'old'>('new')
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Header with toggle */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-3xl sm:text-4xl font-serif font-bold text-gray-900">
+            Divisions in the Church
+          </h1>
+          <p className="text-gray-600 mt-2 max-w-3xl">
+            How, when, and why divisions occurred in Christianity — from early heresies through the
+            Great Schism to the Reformation and modern denominations.
+          </p>
+        </div>
+        <ToggleSwitch value={view} onChange={setView} />
+      </div>
+
+      {view === 'new' ? <NewView /> : <OldView />}
     </div>
   )
 }

--- a/src/app/history/church/page.tsx
+++ b/src/app/history/church/page.tsx
@@ -1,0 +1,1247 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  Flame,
+  BookOpen,
+  Crown,
+  Globe,
+  Church,
+  Users,
+  Shield,
+  Scroll,
+  Star,
+  Cross,
+  Landmark,
+  ArrowRight,
+  Calendar,
+  Heart,
+  MapPin,
+} from 'lucide-react'
+
+type TabId = 'apostolic' | 'patristic' | 'medieval' | 'reformation' | 'modern' | 'today'
+
+const tabs: { id: TabId; label: string; years: string }[] = [
+  { id: 'apostolic', label: 'Apostolic Age', years: '33–100' },
+  { id: 'patristic', label: 'Patristic Era', years: '100–500' },
+  { id: 'medieval', label: 'Medieval Church', years: '500–1400' },
+  { id: 'reformation', label: 'Reformation & Renewal', years: '1400–1700' },
+  { id: 'modern', label: 'Modern Era', years: '1700–Present' },
+  { id: 'today', label: 'Church Today', years: '21st Century' },
+]
+
+export default function ChurchHistoryPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('apostolic')
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+      {/* Page Header */}
+      <div className="text-center mb-8">
+        <h1 className="text-4xl font-serif font-bold text-gray-900 mb-4">
+          History of the Catholic Church
+        </h1>
+        <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+          From the upper room in Jerusalem to 1.4 billion members across every nation, the story of
+          the Catholic Church spans two thousand years — centuries of saints and sinners, councils
+          and controversies, missionaries and martyrs. This is the longest continuous institutional
+          history in the Western world.
+        </p>
+      </div>
+
+      {/* Tab Bar */}
+      <div className="flex justify-center mb-8">
+        <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto max-w-full">
+          <div className="flex flex-nowrap gap-1">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap flex flex-col items-center gap-0.5 ${
+                  activeTab === tab.id
+                    ? 'bg-amber-100 text-amber-800 font-semibold border-b-2 border-amber-500'
+                    : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50'
+                }`}
+              >
+                <span>{tab.label}</span>
+                <span className={`text-xs font-normal ${activeTab === tab.id ? 'text-amber-600' : 'text-gray-400'}`}>
+                  ({tab.years})
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ==================== TAB 1: APOSTOLIC AGE ==================== */}
+      {activeTab === 'apostolic' && (
+        <div className="space-y-6">
+
+          {/* Introduction */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-amber-100 rounded-full flex items-center justify-center shrink-0">
+                <Flame className="w-5 h-5 text-amber-700" />
+              </div>
+              <h2 className="text-2xl font-serif font-bold text-gray-900">The Apostolic Age (AD 33–100)</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              The Church was born not with a manifesto or a constitution, but with a rushing wind and tongues
+              of fire. On the day of Pentecost, fifty days after the Resurrection of Christ, the Holy Spirit
+              descended upon the Apostles gathered in Jerusalem. Peter stood up and preached, and three thousand
+              were baptized in a single day. From that moment, the movement that would become the Catholic
+              Church began its inexorable spread across the Roman world and beyond.
+            </p>
+          </div>
+
+          {/* Pentecost and Jerusalem Community */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Flame className="w-5 h-5 text-amber-600" /> Pentecost and the Jerusalem Community
+            </h3>
+
+            <div className="bg-amber-50 border-l-4 border-amber-400 p-5 rounded-r-lg mb-5">
+              <p className="text-amber-900 italic leading-relaxed">
+                &ldquo;They devoted themselves to the apostles&apos; teaching and fellowship, to the breaking
+                of bread and the prayers.&rdquo;
+              </p>
+              <p className="text-amber-700 text-sm mt-2">&mdash; Acts 2:42 (NABRE)</p>
+            </div>
+
+            <p className="text-gray-700 leading-relaxed mb-4">
+              Pentecost (Acts 2:1–41) marks the Church&apos;s public birth. The Holy Spirit descends as tongues
+              of fire; Peter preaches that the crucified and risen Jesus is Lord and Christ; three thousand
+              people are baptized. Acts 2:42 then gives us a programmatic description of the early community,
+              built on four pillars: <strong>apostles&apos; teaching</strong> (doctrine),{' '}
+              <strong>fellowship</strong> (koinonia), <strong>breaking of bread</strong> (Eucharist), and{' '}
+              <strong>prayers</strong> (liturgical worship). These four pillars remain the skeleton of Catholic
+              life to this day.
+            </p>
+
+            <p className="text-gray-700 leading-relaxed">
+              This first community in Jerusalem shared goods, cared for the poor, and met daily in the Temple
+              courts and in houses for the breaking of bread. It was recognizably communal, sacramental, and
+              hierarchical — led by the Twelve under Peter&apos;s presidency.
+            </p>
+          </div>
+
+          {/* Key Events Timeline */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Calendar className="w-5 h-5 text-gray-500" /> Key Events
+            </h3>
+
+            <div className="space-y-4">
+              {[
+                {
+                  year: 'c. 33',
+                  event: 'Pentecost — Holy Spirit descends; Peter\'s sermon; 3,000 baptized (Acts 2)',
+                },
+                {
+                  year: 'c. 34',
+                  event: 'First deacons chosen (Acts 6): Stephen, Philip, and five others appointed to serve the poor',
+                },
+                {
+                  year: 'c. 34',
+                  event: 'Stephen martyred — the first Christian martyr; as he dies: "Lord, do not hold this sin against them" (Acts 7:60)',
+                },
+                {
+                  year: 'c. 35',
+                  event: 'Saul\'s conversion on the road to Damascus — blinded by light, hears: "Saul, Saul, why are you persecuting me?" (Acts 9)',
+                },
+                {
+                  year: 'c. 41',
+                  event: 'Peter\'s vision; baptism of Cornelius the centurion (Acts 10) — Gentiles explicitly included in the Church',
+                },
+                {
+                  year: 'c. 43',
+                  event: 'Antioch: disciples "first called Christians" (Acts 11:26) — the name that would define the movement',
+                },
+                {
+                  year: 'c. 49',
+                  event: 'Council of Jerusalem (Acts 15): Apostles and elders settle the Gentile question — circumcision not required; first council in Church history',
+                },
+                {
+                  year: '46–57',
+                  event: 'Paul\'s three missionary journeys: Cyprus & Galatia; Macedonia, Athens & Corinth; Ephesus — planting churches across the empire',
+                },
+                {
+                  year: 'c. 50–67',
+                  event: 'Paul\'s letters (Romans, Corinthians, Galatians, Philippians, Thessalonians…) — the earliest New Testament writings',
+                },
+                {
+                  year: '64',
+                  event: 'Nero\'s persecution: Rome burns; Christians blamed; Peter and Paul martyred in Rome',
+                },
+                {
+                  year: '70',
+                  event: 'Destruction of Jerusalem Temple by Roman general Titus — the decisive rupture with Temple Judaism; Church center shifts West',
+                },
+                {
+                  year: 'c. 90–100',
+                  event: 'John at Ephesus: the Fourth Gospel and Book of Revelation written; John is the only Apostle to die of natural causes (c. 100)',
+                },
+              ].map((item) => (
+                <div key={item.year + item.event} className="flex gap-4 items-start">
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">
+                    AD {item.year}
+                  </span>
+                  <p className="text-gray-700 text-sm leading-relaxed">{item.event}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Council of Jerusalem */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Users className="w-5 h-5 text-blue-600" /> The Council of Jerusalem (~AD 49)
+            </h3>
+            <div className="bg-blue-50 rounded-lg p-5">
+              <p className="text-blue-900 leading-relaxed mb-3">
+                The first Council of Jerusalem (Acts 15) is the prototype for all future Church councils. The
+                question: must Gentile Christians be circumcised and observe the Mosaic Law? After debate,
+                Peter speaks decisively, then James pronounces the judgment: Gentiles are not to be burdened
+                with the full Mosaic law. A letter is dispatched to the churches.
+              </p>
+              <p className="text-blue-800 text-sm">
+                The decision&apos;s form is significant: &ldquo;It seemed good to the Holy Spirit and to
+                us&hellip;&rdquo; (Acts 15:28). Collegial discernment under the Spirit&apos;s guidance — not
+                individual interpretation — becomes the Church&apos;s permanent mode of resolving doctrinal
+                disputes.
+              </p>
+            </div>
+          </div>
+
+          {/* Cross-link to Apostles */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-serif font-semibold text-gray-900 mb-1">The Apostles — Profiles & Missions</h3>
+                <p className="text-sm text-gray-600">
+                  Detailed accounts of each Apostle: their missions, traditions, and martyrdom.
+                </p>
+              </div>
+              <Link
+                href="/history/apostles"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-700 rounded-lg border border-amber-200 hover:bg-amber-100 transition-colors text-sm font-medium shrink-0 ml-4"
+              >
+                The Apostles <ArrowRight className="w-3.5 h-3.5" />
+              </Link>
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div className="bg-gray-50 rounded-lg p-5">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">Sources &amp; Further Reading</h4>
+            <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+              <li>Acts of the Apostles (NABRE) — primary source for the Apostolic Age</li>
+              <li>Eusebius of Caesarea, <em>Ecclesiastical History</em> (c. AD 313) — earliest Church history</li>
+              <li>Raymond E. Brown, <em>An Introduction to the New Testament</em> (Anchor Bible Reference Library, Doubleday, 1997)</li>
+              <li>Larry W. Hurtado, <em>Lord Jesus Christ: Devotion to Jesus in Earliest Christianity</em> (Eerdmans, 2003)</li>
+              <li>N.T. Wright, <em>The New Testament and the People of God</em> (Fortress, 1992)</li>
+              <li><em>Catechism of the Catholic Church</em> (CCC) §§ 748–810: &ldquo;The Church in God&apos;s Plan&rdquo;</li>
+            </ol>
+          </div>
+
+        </div>
+      )}
+
+      {/* ==================== TAB 2: PATRISTIC ERA ==================== */}
+      {activeTab === 'patristic' && (
+        <div className="space-y-6">
+
+          {/* Introduction */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center shrink-0">
+                <Scroll className="w-5 h-5 text-blue-700" />
+              </div>
+              <h2 className="text-2xl font-serif font-bold text-gray-900">The Patristic Era (AD 100–500)</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              The four centuries after the Apostles saw the Church emerge from underground persecution to become
+              the official religion of the Roman Empire — and simultaneously produce a body of theological
+              reflection that remains definitive to this day. The Church Fathers, writing in Greek and Latin,
+              hammered out the doctrines of the Trinity and the Incarnation in the fire of controversy. By the
+              time Rome fell in 476, the Catholic Church had inherited the task of preserving civilization itself.
+            </p>
+          </div>
+
+          {/* Age of Martyrs */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Shield className="w-5 h-5 text-red-600" /> The Age of Martyrs (100–313)
+            </h3>
+            <p className="text-gray-700 leading-relaxed mb-4">
+              For two hundred years, to be a Christian was potentially a capital offence. Persecution was
+              periodic rather than continuous — but under emperors like Domitian (81–96), Decius (249–251),
+              and Diocletian (303–311), it was savage and systematic. Thousands died rather than offer a pinch
+              of incense to the emperor. Far from destroying the Church, this witness drew more converts.
+            </p>
+            <div className="bg-red-50 border-l-4 border-red-400 p-5 rounded-r-lg">
+              <p className="text-red-900 italic leading-relaxed">
+                &ldquo;The blood of the martyrs is the seed of the Church.&rdquo;
+              </p>
+              <p className="text-red-700 text-sm mt-2">&mdash; Tertullian, <em>Apologeticus</em> (c. AD 197)</p>
+            </div>
+          </div>
+
+          {/* Key Fathers */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <BookOpen className="w-5 h-5 text-blue-600" /> The Church Fathers
+            </h3>
+            <div className="bg-blue-50 rounded-lg p-5">
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  {
+                    name: 'Ignatius of Antioch (c. 35–107)',
+                    desc: 'Bishop of Antioch; on his way to martyrdom in Rome, wrote seven letters describing the Eucharist as "medicine of immortality" and establishing the hierarchy of bishop, priest, and deacon.',
+                  },
+                  {
+                    name: 'Justin Martyr (c. 100–165)',
+                    desc: 'First great Christian philosopher; his First Apology (c. 155) gives the earliest detailed description of Sunday Eucharist: readings, homily, prayers, bread and cup. Martyred in Rome.',
+                  },
+                  {
+                    name: 'Irenaeus of Lyon (c. 130–202)',
+                    desc: 'Against Heresies demolished Gnosticism; articulated apostolic succession as the guarantee of authentic doctrine: the same faith passed from Apostles through bishops.',
+                  },
+                  {
+                    name: 'Origen of Alexandria (c. 185–253)',
+                    desc: 'First systematic theologian; pioneered allegorical Scripture interpretation; his Hexapla was the first critical edition of the Bible. Some views later condemned.',
+                  },
+                  {
+                    name: 'Cyprian of Carthage (c. 210–258)',
+                    desc: '"He cannot have God for his Father who has not the Church for his mother." Martyred under Valerian; his letters define episcopal collegiality and Church unity.',
+                  },
+                  {
+                    name: 'Athanasius of Alexandria (296–373)',
+                    desc: '"Athanasius against the world" (contra mundum) — exiled five times by Arian emperors, never compromised on Nicene orthodoxy. His persistence secured the Trinity for future generations.',
+                  },
+                  {
+                    name: 'Ambrose of Milan (340–397)',
+                    desc: 'Confronted Emperor Theodosius after the massacre at Thessalonica: "The Emperor is within the Church, not above it." Established the Church\'s moral authority over civil power.',
+                  },
+                  {
+                    name: 'Augustine of Hippo (354–430)',
+                    desc: 'The most influential theologian in Western Christianity. Confessions (autobiography of the soul), City of God (theology of history), and a vast correspondence; defined grace, original sin, and just war.',
+                  },
+                ].map((f) => (
+                  <div key={f.name} className="bg-white rounded-lg p-4 border border-blue-100">
+                    <p className="font-semibold text-blue-900 text-sm mb-1">{f.name}</p>
+                    <p className="text-blue-800 text-sm leading-relaxed">{f.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Councils */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Landmark className="w-5 h-5 text-amber-600" /> The Great Councils
+            </h3>
+
+            <div className="space-y-4">
+              <div className="bg-amber-50 border-l-4 border-amber-400 p-5 rounded-r-lg">
+                <p className="font-semibold text-amber-900 mb-1">Edict of Milan (313)</p>
+                <p className="text-amber-800 text-sm leading-relaxed">
+                  Emperor Constantine grants religious freedom across the Empire. The Church emerges from the
+                  catacombs. Basilicas are built; bishops become public figures. Christianity goes from persecuted
+                  sect to favoured religion within a generation.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 rounded-lg p-5">
+                <p className="font-semibold text-blue-900 mb-1">First Council of Nicaea (325)</p>
+                <p className="text-blue-800 text-sm leading-relaxed mb-2">
+                  Called by Constantine to settle the Arian controversy: Arius taught that the Son was a
+                  creature — "there was a time when he was not." Nicaea condemned Arianism and proclaimed that
+                  the Son is <em>homoousios</em> — consubstantial, of one being with the Father. The Nicene
+                  Creed is born.
+                </p>
+                <p className="text-blue-700 text-xs italic">
+                  "We believe in one Lord, Jesus Christ, the only Son of God, eternally begotten of the
+                  Father, God from God, Light from Light, true God from true God, begotten, not made,
+                  consubstantial with the Father…"
+                </p>
+              </div>
+
+              <div className="bg-blue-50 rounded-lg p-5">
+                <p className="font-semibold text-blue-900 mb-1">Cappadocian Fathers and Council of Constantinople (381)</p>
+                <p className="text-blue-800 text-sm leading-relaxed">
+                  Basil the Great, Gregory of Nyssa, and Gregory of Nazianzus articulate the full doctrine of
+                  the Trinity: three Persons, one divine Nature. Constantinople I completes the Nicene Creed,
+                  affirming the full divinity of the Holy Spirit: &ldquo;the Lord, the giver of life, who
+                  proceeds from the Father, who with the Father and the Son is adored and glorified.&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-green-50 rounded-lg p-5">
+                <p className="font-semibold text-green-900 mb-1">Council of Ephesus (431) — Mary as Theotokos</p>
+                <p className="text-green-800 text-sm leading-relaxed">
+                  Nestorius, patriarch of Constantinople, refused to call Mary <em>Theotokos</em>
+                  (God-Bearer), preferring <em>Christotokos</em>. Ephesus declared Mary truly Theotokos — not
+                  to exalt Mary for her own sake, but to protect the doctrine that Jesus is truly one divine
+                  Person, not a human person merely inhabited by God.
+                </p>
+              </div>
+
+              <div className="bg-green-50 rounded-lg p-5">
+                <p className="font-semibold text-green-900 mb-1">Council of Chalcedon (451) — The Two Natures of Christ</p>
+                <p className="text-green-800 text-sm leading-relaxed mb-2">
+                  The most precise Christological definition in history. Christ is one divine Person in two
+                  complete natures — human and divine — united "without confusion, without change, without
+                  division, without separation." The <em>Tome of Leo</em> (Pope Leo I&apos;s letter to the
+                  Council) was read out and acclaimed: "Peter has spoken through Leo."
+                </p>
+              </div>
+
+              <div className="bg-amber-50 border-l-4 border-amber-400 p-5 rounded-r-lg">
+                <p className="font-semibold text-amber-900 mb-1">Fall of Western Roman Empire (476)</p>
+                <p className="text-amber-800 text-sm leading-relaxed">
+                  When the last Western emperor Romulus Augustulus is deposed, the Catholic Church becomes the
+                  primary institution preserving Roman law, Latin literacy, the classics, and the very concept
+                  of civilization. The Papacy and the episcopate take up the work of governance, scholarship,
+                  and charity that the Empire can no longer perform.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div className="bg-gray-50 rounded-lg p-5">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">Sources &amp; Further Reading</h4>
+            <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+              <li><em>Early Christian Writings</em> (Penguin Classics) — Ignatius, Justin, Irenaeus, and others in translation</li>
+              <li>Henry Chadwick, <em>The Early Church</em> (Penguin History of the Church, Vol. 1, rev. ed. 1993)</li>
+              <li>Jaroslav Pelikan, <em>The Christian Tradition, Vol. 1: The Emergence of the Catholic Tradition (100&ndash;600)</em> (University of Chicago, 1971)</li>
+              <li>Norman P. Tanner SJ (ed.), <em>Decrees of the Ecumenical Councils, Vol. 1: Nicaea I to Lateran V</em> (Sheed &amp; Ward / Georgetown, 1990)</li>
+              <li>St. Augustine, <em>Confessions</em> and <em>City of God</em> (Penguin Classics editions)</li>
+              <li><em>Catechism of the Catholic Church</em> (CCC) §§ 811–870: &ldquo;The Church — One, Holy, Catholic, Apostolic&rdquo;</li>
+            </ol>
+          </div>
+
+        </div>
+      )}
+
+      {/* ==================== TAB 3: MEDIEVAL CHURCH ==================== */}
+      {activeTab === 'medieval' && (
+        <div className="space-y-6">
+
+          {/* Introduction */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-amber-100 rounded-full flex items-center justify-center shrink-0">
+                <Crown className="w-5 h-5 text-amber-700" />
+              </div>
+              <h2 className="text-2xl font-serif font-bold text-gray-900">The Medieval Church (AD 500–1400)</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              The Middle Ages are often caricatured as a period of ignorance and oppression. In reality, the
+              Catholic Church during these nine centuries founded Europe&apos;s universities, built its greatest
+              art and architecture, codified its law, fed its poor through monastic networks, and produced
+              some of the most brilliant thinkers in Western history. It was also a period of serious failures
+              — political entanglement, schism, and excess — that sowed the seeds of later crisis.
+            </p>
+          </div>
+
+          {/* Monasticism */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Heart className="w-5 h-5 text-green-600" /> Monasticism and the Preservation of Civilization
+            </h3>
+            <p className="text-gray-700 leading-relaxed mb-4">
+              <strong>Benedict of Nursia (~480–547)</strong> founded Monte Cassino and wrote the Rule of Saint
+              Benedict — perhaps the most influential document in Western cultural history after the Bible.
+              Its motto <em>ora et labora</em> (pray and work) balanced contemplation and manual labour.
+              Benedictine monasteries became the libraries, hospitals, farms, schools, and inns of medieval
+              Europe. They copied manuscripts through the dark centuries after Rome&apos;s fall, preserving
+              Virgil and Cicero alongside Scripture and the Fathers.
+            </p>
+            <div className="bg-green-50 rounded-lg p-5">
+              <p className="text-green-900 font-semibold mb-2">What the Monasteries Gave Europe:</p>
+              <ul className="text-green-800 text-sm space-y-1.5">
+                <li className="flex items-start gap-2"><span className="font-bold mt-0.5">&bull;</span><span>Preservation of classical manuscripts (Latin and Greek)</span></li>
+                <li className="flex items-start gap-2"><span className="font-bold mt-0.5">&bull;</span><span>Agricultural innovation: crop rotation, land drainage, viticulture</span></li>
+                <li className="flex items-start gap-2"><span className="font-bold mt-0.5">&bull;</span><span>Care of the sick — monastic infirmaries are the ancestors of hospitals</span></li>
+                <li className="flex items-start gap-2"><span className="font-bold mt-0.5">&bull;</span><span>Schools and scriptoria: literacy preserved in a post-literate world</span></li>
+                <li className="flex items-start gap-2"><span className="font-bold mt-0.5">&bull;</span><span>Hospitality to travellers: monasteries were the motorway service stations of the medieval world</span></li>
+              </ul>
+            </div>
+          </div>
+
+          {/* Key events */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Calendar className="w-5 h-5 text-gray-500" /> Key Events
+            </h3>
+            <div className="space-y-4">
+              {[
+                {
+                  year: '590–604',
+                  event: 'Gregory the Great — called himself "servant of servants of God"; codified Gregorian chant; sent Augustine of Canterbury to evangelize England (596); set the template for the medieval papacy',
+                },
+                {
+                  year: '622',
+                  event: 'Muhammad\'s Hijra — Islam founded; within a century, North Africa, the Middle East, Spain, and Persia fall to Islamic armies; the Church loses its oldest sees',
+                },
+                {
+                  year: '800',
+                  event: 'Charlemagne crowned Holy Roman Emperor by Pope Leo III on Christmas Day — the birth of the idea of Christendom: a unified Christian civilization under shared spiritual and temporal authority',
+                },
+                {
+                  year: '1049–1122',
+                  event: 'Gregorian Reform: Pope Gregory VII battles Emperor Henry IV over investiture (who appoints bishops). Henry is excommunicated; stands barefoot in snow at Canossa (1077) begging absolution. The Church asserts its independence from secular power',
+                },
+                {
+                  year: '1054',
+                  event: 'Great Schism: mutual excommunications between Pope Leo IX\'s legate and Patriarch Michael Cerularius of Constantinople. Theological disputes (filioque, papal primacy) and political rivalry produce the permanent split between Catholic and Orthodox — though full separation was gradual over subsequent centuries',
+                },
+                {
+                  year: '1088–1167',
+                  event: 'Universities founded under Church patronage: Bologna (1088), Paris (c. 1150), Oxford (c. 1167) — the Church creates the modern university',
+                },
+                {
+                  year: '1095',
+                  event: 'First Crusade: Pope Urban II at Clermont — "Deus vult!" Nine Crusades follow over two centuries. Mixed legacy: defense of pilgrim routes and Eastern Christians vs. the sack of Jerusalem and Constantinople; Jewish communities targeted',
+                },
+                {
+                  year: '1209–1221',
+                  event: 'Mendicant orders founded: Francis of Assisi (Franciscans, 1209) — poverty, joy, "Rebuild my Church"; Dominic (Dominicans, 1216) — preaching and scholarship. Renewal from below',
+                },
+                {
+                  year: '1225–1274',
+                  event: 'Thomas Aquinas: Summa Theologiae — the greatest synthesis of faith and reason. Five philosophical proofs for God\'s existence; theology as "science of God." Still the foundation of Catholic intellectual tradition',
+                },
+                {
+                  year: '1309–1377',
+                  event: 'Avignon Papacy: seven French popes reside in Avignon, France — perceived as captivity to French crown. Catherine of Siena (a young Dominican laywoman) writes boldly to Gregory XI, persuading him to return to Rome (1377)',
+                },
+                {
+                  year: '1378–1417',
+                  event: 'Great Western Schism: rival papal claimants (at one point three simultaneously). Resolved by Council of Constance — a crisis that raises lasting questions about the relationship between pope and council',
+                },
+              ].map((item) => (
+                <div key={item.year} className="flex gap-4 items-start">
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">
+                    {item.year}
+                  </span>
+                  <p className="text-gray-700 text-sm leading-relaxed">{item.event}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Medieval Thinkers */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <BookOpen className="w-5 h-5 text-blue-600" /> Great Medieval Thinkers
+            </h3>
+            <div className="bg-blue-50 rounded-lg p-5">
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  {
+                    name: 'Anselm of Canterbury (1033–1109)',
+                    desc: 'Ontological argument for God\'s existence; coined the phrase "faith seeking understanding" (fides quaerens intellectum) — the motto of Catholic intellectual life.',
+                  },
+                  {
+                    name: 'Bernard of Clairvaux (1090–1153)',
+                    desc: 'Cistercian renewal; mystical theology of love; profound Mariology. Combined contemplation and action — preached the Second Crusade, reformed corrupt monasteries.',
+                  },
+                  {
+                    name: 'Thomas Aquinas (1225–1274)',
+                    desc: 'Summa Theologiae — synthesis of Aristotle and Christian revelation. The Five Ways to God. "Doctor Communis" of the Church. His thought was declared normative by Leo XIII in 1879.',
+                  },
+                  {
+                    name: 'Dante Alighieri (1265–1321)',
+                    desc: 'The Divine Comedy — not a theologian but the greatest poetic expression of medieval Catholic thought: the journey of the soul through Hell, Purgatory, and Paradise.',
+                  },
+                ].map((f) => (
+                  <div key={f.name} className="bg-white rounded-lg p-4 border border-blue-100">
+                    <p className="font-semibold text-blue-900 text-sm mb-1">{f.name}</p>
+                    <p className="text-blue-800 text-sm leading-relaxed">{f.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Great Schism cross-link */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-serif font-semibold text-gray-900 mb-1">The Great Schism & Church Divisions</h3>
+                <p className="text-sm text-gray-600">
+                  Explore the full history of schisms, separations, and how Christianity fragmented over the centuries.
+                </p>
+              </div>
+              <Link
+                href="/history/church-divisions"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-700 rounded-lg border border-amber-200 hover:bg-amber-100 transition-colors text-sm font-medium shrink-0 ml-4"
+              >
+                Church Divisions <ArrowRight className="w-3.5 h-3.5" />
+              </Link>
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div className="bg-gray-50 rounded-lg p-5">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">Sources &amp; Further Reading</h4>
+            <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+              <li>Eamon Duffy, <em>Saints &amp; Sinners: A History of the Popes</em> (Yale, 4th ed., 2014)</li>
+              <li>Norman Cantor, <em>The Civilization of the Middle Ages</em> (HarperCollins, rev. ed. 1993)</li>
+              <li>Brian Tierney, <em>The Crisis of Church and State, 1050&ndash;1300</em> (Toronto, 1988)</li>
+              <li>Thomas E. Woods Jr., <em>How the Catholic Church Built Western Civilization</em> (Regnery, 2005)</li>
+              <li>St. Thomas Aquinas, <em>Summa Theologiae</em> (multiple translations; classic ed. by the English Dominican Province)</li>
+              <li><em>Catechism of the Catholic Church</em> (CCC) §§ 871–962: &ldquo;The Hierarchical Constitution of the Church&rdquo;</li>
+            </ol>
+          </div>
+
+        </div>
+      )}
+
+      {/* ==================== TAB 4: REFORMATION & RENEWAL ==================== */}
+      {activeTab === 'reformation' && (
+        <div className="space-y-6">
+
+          {/* Introduction */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-orange-100 rounded-full flex items-center justify-center shrink-0">
+                <Flame className="w-5 h-5 text-orange-700" />
+              </div>
+              <h2 className="text-2xl font-serif font-bold text-gray-900">Reformation &amp; Renewal (1400–1700)</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              The sixteenth century shattered the unity of Western Christianity. The Reformation was not
+              simply the revolt of one German monk; it was the intersection of genuine calls for moral
+              reform, Renaissance humanism&apos;s new tools of textual criticism, Gutenberg&apos;s printing
+              press, and a series of catastrophically weak or corrupt Church leaders. The Catholic response —
+              the Council of Trent and the Counter-Reformation — was belated but thoroughgoing, producing a
+              renewed Catholicism that would endure for four centuries.
+            </p>
+          </div>
+
+          {/* Background */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <BookOpen className="w-5 h-5 text-gray-600" /> Background and Pre-Reform Critics
+            </h3>
+            <p className="text-gray-700 leading-relaxed mb-4">
+              The abuses that fuelled the Reformation — simony (buying church offices), nepotism, absentee
+              bishops, the commercial sale of indulgences — were not new. Reformers had been raising these
+              complaints for a century before Luther.
+            </p>
+            <div className="space-y-3">
+              <div className="flex gap-4 items-start">
+                <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">d. 1384</span>
+                <p className="text-gray-700 text-sm leading-relaxed"><strong>John Wycliffe</strong> (England): translated the Bible into English; attacked papal authority and transubstantiation. His followers, the Lollards, were suppressed. His bones were later exhumed and burned.</p>
+              </div>
+              <div className="flex gap-4 items-start">
+                <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">d. 1415</span>
+                <p className="text-gray-700 text-sm leading-relaxed"><strong>Jan Huss</strong> (Bohemia): influenced by Wycliffe; called for reform, rejected indulgences. Burned at the stake at the Council of Constance despite a promise of safe conduct.</p>
+              </div>
+              <div className="flex gap-4 items-start">
+                <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">1509</span>
+                <p className="text-gray-700 text-sm leading-relaxed"><strong>Erasmus of Rotterdam</strong>: <em>In Praise of Folly</em> skewered clerical corruption with biting satire. He called for reform from within — and refused to break with Rome when Luther did. "Erasmus laid the egg; Luther hatched it," contemporaries said.</p>
+              </div>
+              <div className="flex gap-4 items-start">
+                <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">1440</span>
+                <p className="text-gray-700 text-sm leading-relaxed"><strong>Gutenberg&apos;s printing press</strong>: Luther&apos;s pamphlets reached every corner of Germany within weeks. The printing press transformed religious controversy in the same way the internet would transform politics five centuries later.</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Luther and the Protestant Split */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Flame className="w-5 h-5 text-red-600" /> Luther and the Protestant Reformation
+            </h3>
+
+            <div className="bg-amber-50 border-l-4 border-amber-400 p-5 rounded-r-lg mb-5">
+              <p className="text-amber-900 italic leading-relaxed">
+                &ldquo;Here I stand. I can do no other. God help me. Amen.&rdquo;
+              </p>
+              <p className="text-amber-700 text-sm mt-2">&mdash; Martin Luther, Diet of Worms, April 18, 1521 (traditional account)</p>
+            </div>
+
+            <p className="text-gray-700 leading-relaxed mb-4">
+              On October 31, 1517, Martin Luther, an Augustinian monk and professor at Wittenberg, posted
+              (or circulated) his 95 Theses — a list of arguments against the sale of indulgences. The
+              immediate cause was Johann Tetzel&apos;s notorious campaign, where people were told: "As soon
+              as the coin in the coffer rings, the soul from Purgatory springs." Luther&apos;s core theological
+              insights — <em>sola fide</em> (faith alone justifies), <em>sola scriptura</em> (Scripture alone
+              is the rule of faith) — struck at the foundations of medieval Catholic practice and authority.
+            </p>
+
+            <div className="bg-red-50 rounded-lg p-5">
+              <p className="font-semibold text-red-900 mb-3">Protestant Branches</p>
+              <div className="space-y-2">
+                {[
+                  { name: 'Lutheranism', detail: 'Luther (Wittenberg, 1517); sola fide, sola scriptura; retained bishops and liturgy' },
+                  { name: 'Reformed / Calvinist', detail: 'Zwingli (Zurich, 1519); Calvin (Geneva, 1536); predestination; simpler worship; Presbyterian polity' },
+                  { name: 'Anglican', detail: 'Henry VIII\'s Act of Supremacy (1534) — a split over marriage and royal authority, not primarily over doctrine; Cranmer\'s Book of Common Prayer' },
+                  { name: 'Anabaptist', detail: 'Radical reformers; rebaptism of adults; separation of church and state; pacifism; persecuted by Catholics and Protestants alike' },
+                ].map((b) => (
+                  <div key={b.name} className="flex items-start gap-2">
+                    <span className="font-bold text-red-700 text-sm mt-0.5">&bull;</span>
+                    <p className="text-red-800 text-sm"><strong>{b.name}:</strong> {b.detail}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Council of Trent */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Landmark className="w-5 h-5 text-blue-600" /> Council of Trent (1545–1563)
+            </h3>
+            <div className="bg-blue-50 rounded-lg p-5 mb-4">
+              <p className="text-blue-900 leading-relaxed mb-3">
+                The Catholic Church&apos;s response to the Reformation. Trent met in three sessions over
+                eighteen years and addressed both doctrine and discipline simultaneously:
+              </p>
+              <div className="space-y-2">
+                {[
+                  'Affirmed Scripture AND Tradition as sources of revelation (against sola scriptura)',
+                  'Affirmed justification by faith — but as a process involving cooperation with grace, not "faith alone" in Luther\'s sense',
+                  'Defined transubstantiation precisely: the substance of bread and wine become the Body and Blood of Christ',
+                  'Affirmed seven sacraments against Protestant reductions',
+                  'Required seminaries in every diocese — the single most practical reform, raising the standard of the priesthood',
+                  'Ended the worst abuses: simony, absenteeism, nepotism, sale of indulgences (the formal sale was abolished)',
+                  'Standardised the Tridentine Mass, which would remain the Roman Rite for four centuries',
+                ].map((point) => (
+                  <div key={point} className="flex items-start gap-2">
+                    <span className="text-blue-500 font-bold text-sm mt-0.5">✓</span>
+                    <p className="text-blue-800 text-sm leading-relaxed">{point}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Saints of the Counter-Reformation */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Star className="w-5 h-5 text-amber-600" /> Saints of the Renewal
+            </h3>
+            <div className="bg-blue-50 rounded-lg p-5">
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  {
+                    name: 'Ignatius of Loyola (1491–1556)',
+                    desc: 'Founded the Society of Jesus (Jesuits, 1540). "Ad Majorem Dei Gloriam" (AMDG). Spiritual Exercises. Jesuits became the shock troops of the Counter-Reformation: educators, missionaries, papal servants.',
+                  },
+                  {
+                    name: 'Teresa of Avila (1515–1582)',
+                    desc: 'Interior Castle — a masterwork of mystical theology. Reformed the Carmelite order. First woman declared Doctor of the Church (1970). Said: "God has no hands but yours."',
+                  },
+                  {
+                    name: 'John of the Cross (1542–1591)',
+                    desc: 'Dark Night of the Soul — the classic account of spiritual purification. Co-founder of the Discalced Carmelites with Teresa. Doctor of the Church.',
+                  },
+                  {
+                    name: 'Francis Xavier (1506–1552)',
+                    desc: 'Jesuit missionary to India, Malacca, the Moluccas, and Japan. Baptised an estimated 300,000 people. Died waiting to enter China. Patron of foreign missions.',
+                  },
+                  {
+                    name: 'Matteo Ricci (1552–1610)',
+                    desc: 'Jesuit to China; mastered Mandarin and Confucian classics; became a court mandarin; pioneered inculturation — presenting the Gospel in Chinese categories.',
+                  },
+                  {
+                    name: 'Bartolomé de las Casas (1484–1566)',
+                    desc: 'Dominican friar; former conquistador; became the greatest defender of the indigenous peoples of the Americas, arguing before the Spanish crown for their full humanity and rights.',
+                  },
+                ].map((f) => (
+                  <div key={f.name} className="bg-white rounded-lg p-4 border border-blue-100">
+                    <p className="font-semibold text-blue-900 text-sm mb-1">{f.name}</p>
+                    <p className="text-blue-800 text-sm leading-relaxed">{f.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Peace of Westphalia */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="bg-amber-50 border-l-4 border-amber-400 p-5 rounded-r-lg">
+              <p className="font-semibold text-amber-900 mb-2">Peace of Westphalia (1648)</p>
+              <p className="text-amber-800 text-sm leading-relaxed">
+                After the catastrophic Thirty Years&apos; War (8 million dead), the Peace of Westphalia
+                established the principle <em>cuius regio, eius religio</em> — "whose realm, his religion."
+                Christianity was permanently fragmented across national lines. The age of a single Christian
+                Europe was over. The modern secular state — defined by territory rather than religion — begins
+                here.
+              </p>
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div className="bg-gray-50 rounded-lg p-5">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">Sources &amp; Further Reading</h4>
+            <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+              <li>Diarmaid MacCulloch, <em>The Reformation: A History</em> (Viking, 2003) — definitive modern account</li>
+              <li>John W. O&apos;Malley SJ, <em>Trent: What Happened at the Council</em> (Harvard, 2013)</li>
+              <li>Norman P. Tanner SJ (ed.), <em>Decrees of the Ecumenical Councils, Vol. 2: Trent to Vatican II</em> (Sheed &amp; Ward / Georgetown, 1990)</li>
+              <li>Brad S. Gregory, <em>The Unintended Reformation</em> (Harvard, 2012)</li>
+              <li>St. Teresa of Avila, <em>The Interior Castle</em>; St. John of the Cross, <em>Dark Night of the Soul</em> (ICS Publications)</li>
+              <li><em>Catechism of the Catholic Church</em> (CCC) §§ 874–896: &ldquo;The Ordained Ministry&rdquo;</li>
+            </ol>
+          </div>
+
+        </div>
+      )}
+
+      {/* ==================== TAB 5: MODERN ERA ==================== */}
+      {activeTab === 'modern' && (
+        <div className="space-y-6">
+
+          {/* Introduction */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-purple-100 rounded-full flex items-center justify-center shrink-0">
+                <Globe className="w-5 h-5 text-purple-700" />
+              </div>
+              <h2 className="text-2xl font-serif font-bold text-gray-900">The Modern Era (1700–Present)</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              Modernity — the age of Enlightenment, revolution, industrialization, and totalitarianism —
+              presented the Catholic Church with a series of challenges unlike anything since the fall of
+              Rome. Two world wars, communist and fascist persecution, the sexual revolution, and the
+              secularization of the West tested the Church to its foundations. Yet these centuries also
+              produced some of the greatest popes in history, the Second Vatican Council&apos;s renewal, and
+              a global Catholicism more diverse and more numerous than ever before.
+            </p>
+          </div>
+
+          {/* Timeline: 18th-19th Century */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Calendar className="w-5 h-5 text-gray-500" /> Enlightenment to Vatican I
+            </h3>
+            <div className="space-y-4">
+              {[
+                {
+                  year: '1700s',
+                  event: 'The Enlightenment: reason over revelation; Voltaire, Hume, and later Feuerbach challenge the intellectual foundations of faith. Deism replaces Christianity among European elites. The Church is put on the intellectual defensive.',
+                },
+                {
+                  year: '1789–99',
+                  event: 'French Revolution: de-Christianization campaign; priests massacred or exiled; Notre Dame turned into a "Temple of Reason"; Popes Pius VI and VII both imprisoned. The Revolution\'s violence gives the Church martyrs — including the sixteen Carmelites of Compiègne, beatified 1906.',
+                },
+                {
+                  year: '1801',
+                  event: 'Napoleon\'s Concordat with Pius VII: partial restoration of the Church\'s position in France. Napoleon later turns on the Pope again — but the agreement shows the Church cannot simply be erased.',
+                },
+                {
+                  year: '1854',
+                  event: 'Pius IX defines the Immaculate Conception of the Blessed Virgin Mary as dogma in the bull Ineffabilis Deus — solemnly defined by the pope alone, sixteen years before Vatican I would formally articulate the doctrine of papal infallibility (1870).',
+                },
+                {
+                  year: '1858',
+                  event: 'Our Lady of Lourdes: eighteen apparitions to Bernadette Soubirous; healing spring; six million pilgrims per year today. A powerful sign of continued supernatural presence in the industrial age.',
+                },
+                {
+                  year: '1864',
+                  event: 'Pius IX\'s Syllabus of Errors: a list of 80 condemned propositions, including liberalism and the separation of Church and state. The Church and modernity in open conflict.',
+                },
+                {
+                  year: '1869–70',
+                  event: 'Vatican I: defines papal primacy and infallibility (Pastor Aeternus). The Council is interrupted when Italian troops seize Rome; the Pope becomes a "prisoner in the Vatican" until the Lateran Treaty of 1929.',
+                },
+              ].map((item) => (
+                <div key={item.year} className="flex gap-4 items-start">
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">
+                    {item.year}
+                  </span>
+                  <p className="text-gray-700 text-sm leading-relaxed">{item.event}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Catholic Social Teaching */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Heart className="w-5 h-5 text-green-600" /> Catholic Social Teaching: Leo XIII and Rerum Novarum (1891)
+            </h3>
+            <div className="bg-green-50 rounded-lg p-5 mb-4">
+              <p className="text-green-900 leading-relaxed mb-3">
+                <strong>Rerum Novarum</strong> (&ldquo;On New Things&rdquo;, 1891) by Leo XIII is the founding
+                document of modern Catholic Social Teaching. Written at the height of the Industrial Revolution,
+                it confronted the exploitation of workers — and simultaneously rejected both laissez-faire
+                capitalism and Marxist socialism as incompatible with human dignity.
+              </p>
+              <div className="space-y-2">
+                {[
+                  'Workers have the right to a just and living wage',
+                  'Private property is a natural right — but it carries social obligations',
+                  'Workers have the right to form trade unions',
+                  'The State may intervene when the market destroys human dignity',
+                  'Neither capital nor labour can crush the other; both must serve the common good',
+                ].map((point) => (
+                  <div key={point} className="flex items-start gap-2">
+                    <span className="text-green-500 font-bold text-sm mt-0.5">✓</span>
+                    <p className="text-green-800 text-sm leading-relaxed">{point}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* 20th Century */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Calendar className="w-5 h-5 text-gray-500" /> The Twentieth Century
+            </h3>
+            <div className="space-y-4">
+              {[
+                {
+                  year: '1914–18',
+                  event: 'World War I: Benedict XV proposes peace negotiations ("the useless slaughter"); ignored by all sides. He coordinates prisoner-of-war exchanges and relief efforts.',
+                },
+                {
+                  year: '1937',
+                  event: 'Mit brennender Sorge (Pius XI): the first official condemnation of Nazism by any government or institution, smuggled into Germany and read from every pulpit on Palm Sunday.',
+                },
+                {
+                  year: '1939–45',
+                  event: 'World War II and Pius XII: a complex and still-debated role. Pius XII opened Vatican City and Roman convents and seminaries to shelter Jews; Vatican-organized networks saved an estimated 700,000–800,000 Jewish lives across Europe, with Roman rabbi Israel Zolli converting after the war and taking the name "Eugenio" in gratitude. Critics argue Pius\'s public condemnations of the Holocaust were too restrained, fearing reprisals would worsen Nazi violence. Vatican archives opened to scholars in 2020.',
+                },
+                {
+                  year: '1903–14',
+                  event: 'Pius X: promoted early and frequent reception of Communion; anti-Modernism campaign; reformed Church music; began the codification of Canon Law.',
+                },
+                {
+                  year: '1929',
+                  event: 'Lateran Treaty (Pius XI / Mussolini): Vatican City established as an independent state; the "Roman Question" resolved sixty years after 1870.',
+                },
+              ].map((item) => (
+                <div key={item.year + item.event.slice(0, 20)} className="flex gap-4 items-start">
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">
+                    {item.year}
+                  </span>
+                  <p className="text-gray-700 text-sm leading-relaxed">{item.event}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Vatican II */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Landmark className="w-5 h-5 text-blue-600" /> The Second Vatican Council (1962–1965)
+            </h3>
+            <p className="text-gray-700 leading-relaxed mb-4">
+              Pope John XXIII shocked the world by calling an Ecumenical Council — the first since Vatican I
+              nearly a century earlier. He used the Italian word <em>aggiornamento</em> (bringing up to date)
+              and <em>ressourcement</em> (return to the sources). Continued by Paul VI after John&apos;s
+              death in 1963, Vatican II produced sixteen documents. The four constitutions are the heart of the
+              Council:
+            </p>
+            <div className="bg-blue-50 rounded-lg p-5">
+              <div className="space-y-3">
+                {[
+                  {
+                    name: 'Sacrosanctum Concilium (Liturgy)',
+                    desc: 'Liturgical reform: vernacular languages permitted; active participation of the faithful emphasized; the Novus Ordo Mass follows in 1969.',
+                  },
+                  {
+                    name: 'Lumen Gentium (The Church)',
+                    desc: 'The Church as "People of God" and "Body of Christ." Affirms the universal call to holiness; clarifies the role of the laity; restores the theology of episcopal collegiality.',
+                  },
+                  {
+                    name: 'Dei Verbum (Scripture and Tradition)',
+                    desc: 'Scripture and Tradition as two modes of one Deposit of Faith; the Church subject to the Word of God, not above it; recovery of biblical theology.',
+                  },
+                  {
+                    name: 'Gaudium et Spes (Church in the Modern World)',
+                    desc: '"The joys and the hopes, the griefs and the anxieties of the men of this age…" The Church in dialogue with the modern world on family, culture, economics, peace, and human dignity.',
+                  },
+                  {
+                    name: 'Nostra Aetate (World Religions)',
+                    desc: 'Repudiates collective Jewish guilt for the death of Christ; affirms truth in non-Christian religions; the watershed document in Catholic-Jewish relations.',
+                  },
+                ].map((doc) => (
+                  <div key={doc.name} className="bg-white rounded-lg p-4 border border-blue-100">
+                    <p className="font-semibold text-blue-900 text-sm mb-1">{doc.name}</p>
+                    <p className="text-blue-800 text-sm leading-relaxed">{doc.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Post-Conciliar Popes */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Crown className="w-5 h-5 text-amber-600" /> Post-Conciliar Popes
+            </h3>
+            <div className="space-y-4">
+              {[
+                {
+                  year: '1968',
+                  event: 'Paul VI: Humanae Vitae — reaffirms the Church\'s prohibition of artificial contraception; one of the most contested documents in modern Catholic history. Also promulgated the Novus Ordo Mass (1969).',
+                },
+                {
+                  year: '1978–2005',
+                  event: 'John Paul II: first non-Italian pope in 455 years; survived assassination attempt (1981); Theology of the Body; Catechism of the Catholic Church (1992); over 100 countries visited; 1.17 billion Catholics at his death; beatified 2011, canonised 2014. His moral support for Solidarity helped end communism in Poland.',
+                },
+                {
+                  year: '2005–2013',
+                  event: 'Benedict XVI: Summorum Pontificum (2007) — liberalized the traditional Latin Mass; three encyclicals on love, hope, and charity; resigned February 28, 2013 — first voluntary papal resignation since Gregory XII in 1415.',
+                },
+                {
+                  year: '2013–present',
+                  event: 'Francis: first Jesuit pope; first from the Americas; Laudato Si\' (2015, environment and integral ecology); Amoris Laetitia (2016, family and mercy); Synod on Synodality (2021–24).',
+                },
+              ].map((item) => (
+                <div key={item.year} className="flex gap-4 items-start">
+                  <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 mt-1 font-medium">
+                    {item.year}
+                  </span>
+                  <p className="text-gray-700 text-sm leading-relaxed">{item.event}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div className="bg-gray-50 rounded-lg p-5">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">Sources &amp; Further Reading</h4>
+            <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+              <li>Austin Flannery OP (ed.), <em>Vatican Council II: The Conciliar and Post Conciliar Documents</em> (Liturgical Press, rev. ed. 1996)</li>
+              <li>John W. O&apos;Malley SJ, <em>What Happened at Vatican II</em> (Harvard, 2008)</li>
+              <li>Pope Leo XIII, <em>Rerum Novarum</em> (1891); Pius XI, <em>Quadragesimo Anno</em> (1931); John Paul II, <em>Centesimus Annus</em> (1991) — the social encyclicals</li>
+              <li>George Weigel, <em>Witness to Hope: The Biography of Pope John Paul II</em> (HarperCollins, 1999)</li>
+              <li>Joseph Ratzinger / Benedict XVI, <em>Jesus of Nazareth</em>, 3 vols. (Doubleday/Ignatius, 2007&ndash;2012)</li>
+              <li>James Hitchcock, <em>History of the Catholic Church: From the Apostolic Age to the Third Millennium</em> (Ignatius, 2012)</li>
+              <li><em>Catechism of the Catholic Church</em> (CCC) §§ 748–975: &ldquo;The Profession of Faith&rdquo;</li>
+            </ol>
+          </div>
+
+        </div>
+      )}
+
+      {/* ==================== TAB 6: CHURCH TODAY ==================== */}
+      {activeTab === 'today' && (
+        <div className="space-y-6">
+
+          {/* Introduction */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center shrink-0">
+                <Globe className="w-5 h-5 text-green-700" />
+              </div>
+              <h2 className="text-2xl font-serif font-bold text-gray-900">The Church Today (21st Century)</h2>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              The Catholic Church enters the twenty-first century as the world&apos;s largest and oldest
+              religious institution — 1.4 billion members, every nation on earth, parishes in rainforests and
+              skyscrapers. It faces profound challenges: the clergy abuse crisis, rapid secularization in its
+              historic heartlands, and fierce internal debates about doctrine and governance. It also possesses
+              extraordinary resources: a global network of schools, hospitals, and charities; a two-thousand-year
+              intellectual tradition; and communities of extraordinary holiness.
+            </p>
+          </div>
+
+          {/* Statistics */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Users className="w-5 h-5 text-blue-600" /> The Global Church: A Portrait (2024)
+            </h3>
+            <div className="grid sm:grid-cols-2 gap-4 mb-5">
+              {[
+                { stat: '1.4 billion', label: 'Catholics worldwide', note: '17.4% of the world\'s population' },
+                { stat: '~5,600', label: 'Bishops worldwide', note: 'Leading dioceses and religious orders' },
+                { stat: '~400,000', label: 'Parishes globally', note: 'Plus missions and communities' },
+                { stat: '~220,000', label: 'Catholic schools', note: 'Educating over 60 million students' },
+                { stat: '~5,500', label: 'Catholic hospitals', note: 'Largest non-governmental healthcare provider' },
+                { stat: '23', label: 'Eastern Catholic Churches', note: 'In full communion with Rome' },
+              ].map((item) => (
+                <div key={item.label} className="bg-blue-50 rounded-lg p-4 text-center">
+                  <p className="text-2xl font-bold text-blue-800">{item.stat}</p>
+                  <p className="text-sm font-medium text-blue-700 mt-0.5">{item.label}</p>
+                  <p className="text-xs text-blue-600 mt-0.5">{item.note}</p>
+                </div>
+              ))}
+            </div>
+            <div className="space-y-3">
+              <div className="bg-green-50 rounded-lg p-4">
+                <p className="font-semibold text-green-900 text-sm mb-1">Growing Regions</p>
+                <p className="text-green-800 text-sm">Sub-Saharan Africa is the fastest-growing region (over 250 million Catholics, growing rapidly). Also strong growth in the Philippines, Vietnam, South Korea, and parts of Latin America.</p>
+              </div>
+              <div className="bg-amber-50 rounded-lg p-4">
+                <p className="font-semibold text-amber-900 text-sm mb-1">Declining Regions</p>
+                <p className="text-amber-800 text-sm">Western Europe and North America see declining Mass attendance, secularization, and a crisis of transmission to the next generation. Ireland, once 90%+ Catholic, now sees weekly Mass attendance below 35%.</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Pope Francis */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Heart className="w-5 h-5 text-amber-600" /> Pope Francis and the &ldquo;Field Hospital&rdquo; Church
+            </h3>
+            <div className="bg-amber-50 border-l-4 border-amber-400 p-5 rounded-r-lg mb-4">
+              <p className="text-amber-900 italic leading-relaxed">
+                &ldquo;I see clearly that the thing the Church needs most today is the ability to heal wounds
+                and to warm the hearts of the faithful; it needs nearness, proximity. I see the Church as a
+                field hospital after battle. It is useless to ask a seriously injured person if he has high
+                cholesterol and about the level of his blood sugars! You have to heal his wounds. Then we can
+                talk about everything else.&rdquo;
+              </p>
+              <p className="text-amber-700 text-sm mt-2">&mdash; Pope Francis, Interview with Antonio Spadaro SJ, <em>La Civiltà Cattolica</em>, August 2013</p>
+            </div>
+            <p className="text-gray-700 leading-relaxed">
+              Francis&apos;s pontificate has been marked by emphases on mercy, the poor, environmental
+              responsibility, and the reform of Vatican governance. His apostolic exhortation{' '}
+              <em>Evangelii Gaudium</em> (2013) sets out his vision of a missionary Church that &ldquo;goes
+              out&rdquo; rather than waiting for people to come in. <em>Laudato Si&apos;</em> (2015)
+              applies Catholic Social Teaching to the ecological crisis.
+            </p>
+          </div>
+
+          {/* Key Issues */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-5 flex items-center gap-2">
+              <Shield className="w-5 h-5 text-gray-600" /> Key Issues Facing the Church
+            </h3>
+            <div className="space-y-4">
+
+              <div className="bg-red-50 rounded-lg p-5">
+                <p className="font-semibold text-red-900 mb-2">Clergy Abuse Crisis and Reforms</p>
+                <p className="text-red-800 text-sm leading-relaxed">
+                  The sexual abuse scandal — first exposed at scale in Boston in 2002 — remains the most
+                  serious credibility crisis in modern Church history. Responses include the Dallas Charter
+                  (2002, USA): mandatory reporting, removal of accused priests, lay review boards.
+                  Globally: <em>Vos Estis Lux Mundi</em> (2019) — new norms holding bishops accountable.
+                  Much healing remains to be done.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 rounded-lg p-5">
+                <p className="font-semibold text-blue-900 mb-2">New Evangelization</p>
+                <p className="text-blue-800 text-sm leading-relaxed">
+                  John Paul II coined the term: re-evangelizing cultures that were once Christian but have
+                  become post-Christian. Not missions to the unbaptized (that is the "first evangelization")
+                  but re-proposing the faith with new ardor, new methods, and new expressions to the baptized
+                  who have drifted away.
+                </p>
+              </div>
+
+              <div className="bg-green-50 rounded-lg p-5">
+                <p className="font-semibold text-green-900 mb-2">Ecumenism</p>
+                <p className="text-green-800 text-sm leading-relaxed">
+                  The Joint Declaration on the Doctrine of Justification (1999): Catholics and Lutherans sign
+                  a common statement on justification — the very issue at the heart of the Reformation split.
+                  Ongoing dialogues with Anglicans, Orthodox, and other churches. Full visible unity remains
+                  a distant goal, but the tone of the last sixty years has transformed from polemic to prayer.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 rounded-lg p-5">
+                <p className="font-semibold text-blue-900 mb-2">Eastern Catholic Churches</p>
+                <p className="text-blue-800 text-sm leading-relaxed">
+                  Twenty-three Churches are in full communion with Rome while maintaining their own liturgical
+                  rites, disciplines, and spiritual traditions — Maronite, Ukrainian Greek Catholic,
+                  Syro-Malabar, Coptic Catholic, Melkite, and others. They are not "Roman Catholic" but are
+                  fully Catholic. Their existence shows that Catholic unity does not mean liturgical uniformity.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 rounded-lg p-5">
+                <p className="font-semibold text-amber-900 mb-2">Synod on Synodality (2021–2024)</p>
+                <p className="text-amber-800 text-sm leading-relaxed">
+                  The largest formal consultation in Church history: every diocese in the world invited to
+                  gather input from the faithful on how the Church should operate. Francis describes synodality
+                  — walking together, listening to the Spirit in all members — as the Church&apos;s defining
+                  way of being in the 21st century. Controversial among both progressives (wanting doctrinal
+                  change) and traditionalists (fearing confusion).
+                </p>
+              </div>
+
+            </div>
+          </div>
+
+          {/* Four Marks */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-serif font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <Church className="w-5 h-5 text-amber-600" /> One, Holy, Catholic, Apostolic
+            </h3>
+            <p className="text-gray-700 leading-relaxed mb-4">
+              The Nicene Creed professes faith in &ldquo;one, holy, catholic, and apostolic Church.&rdquo;
+              These Four Marks are not achievements but vocations — what the Church is called to be and, by
+              God&apos;s grace, already is in an imperfect but real way.
+            </p>
+            <div className="bg-blue-50 rounded-lg p-5">
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  {
+                    mark: 'One',
+                    desc: 'One Lord, one faith, one baptism (Eph 4:5). Unity of doctrine, sacraments, and governance — despite the scandals and failures that have wounded that unity.',
+                  },
+                  {
+                    mark: 'Holy',
+                    desc: 'The Church is holy not because all its members are sinless, but because it is the Body of Christ and the Temple of the Spirit, and because it produces genuine holiness — the saints.',
+                  },
+                  {
+                    mark: 'Catholic',
+                    desc: 'Katholikos: "according to the whole." Universal — for all peoples, all times, all cultures. Not a sect or a national religion, but humanity\'s universal sacrament of salvation.',
+                  },
+                  {
+                    mark: 'Apostolic',
+                    desc: 'Founded on the Apostles (Eph 2:20); the same faith transmitted unbroken; bishops in succession from the Apostles who are successors of those sent by Christ himself.',
+                  },
+                ].map((m) => (
+                  <div key={m.mark} className="bg-white rounded-lg p-4 border border-blue-100">
+                    <p className="font-bold text-blue-900 text-base mb-1">{m.mark}</p>
+                    <p className="text-blue-800 text-sm leading-relaxed">{m.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Cross-link to Church Tree */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-serif font-semibold text-gray-900 mb-1">Church History Tree</h3>
+                <p className="text-sm text-gray-600">
+                  Visual exploration of how the Church has branched and divided across two millennia.
+                </p>
+              </div>
+              <Link
+                href="/history/church-tree"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-700 rounded-lg border border-amber-200 hover:bg-amber-100 transition-colors text-sm font-medium shrink-0 ml-4"
+              >
+                Church History Tree <ArrowRight className="w-3.5 h-3.5" />
+              </Link>
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div className="bg-gray-50 rounded-lg p-5">
+            <h4 className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">Sources &amp; Further Reading</h4>
+            <ol className="text-sm text-gray-600 space-y-1.5 list-decimal list-inside">
+              <li><em>Annuarium Statisticum Ecclesiae</em> (Vatican Statistical Yearbook of the Church, 2024)</li>
+              <li>Pope Francis, <em>Evangelii Gaudium</em> &mdash; The Joy of the Gospel (2013); <em>Laudato Si&apos;</em> (2015); <em>Fratelli Tutti</em> (2020)</li>
+              <li>John Paul II, <em>Ut Unum Sint</em> (1995, on ecumenism); <em>Tertio Millennio Adveniente</em> (1994)</li>
+              <li>Pew Research Center, <em>The Future of World Religions</em> (2015 and updates)</li>
+              <li>Synod of Bishops, <em>Final Document of the Synod on Synodality</em> (October 2024)</li>
+              <li>Lumen Gentium and Unitatis Redintegratio (Vatican II) &mdash; foundational documents on the Church and ecumenism</li>
+              <li><em>Catechism of the Catholic Church</em> (CCC) §§ 748–810: &ldquo;The Church in God&apos;s Plan&rdquo;</li>
+            </ol>
+          </div>
+
+        </div>
+      )}
+
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -49,6 +49,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/history/apostles`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/history/church`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/mysteries/public-revelation`,
       lastModified: new Date(),
       changeFrequency: 'monthly' as const,

--- a/src/components/HistoryNavigation.tsx
+++ b/src/components/HistoryNavigation.tsx
@@ -13,6 +13,7 @@ const categories = [
       { href: '/history/christ', label: 'Lord Jesus Christ' },
       { href: '/history/resurrection', label: 'Resurrection' },
       { href: '/history/apostles', label: 'The Apostles' },
+      { href: '/history/church', label: 'The Church' },
       { href: '/history/papal-timeline', label: 'Papal Timeline' },
       { href: '/history/church-divisions', label: 'Church Divisions' },
       { href: '/history/church-tree', label: 'Church Tree' },


### PR DESCRIPTION
## Summary

Two commits aggregating the recent content and structural work on the History and Commentary sections:

- **The Church history page** (`/history/church`) — new tab covering 2,000 years across 6 era-based sub-tabs (Apostolic, Patristic, Medieval, Reformation, Modern, Today)
- **Apostles page** (`/history/apostles`) — full implementation with 4 tabs (The Twelve, St. Paul, Missions, Martyrdom) replacing the previous "Coming Soon" placeholder
- **Sunday Gospel Commentary for May 3, 2026** — Fifth Sunday of Easter Year C (John 13:31-33a, 34-35), prepended to the commentary page
- **Church Divisions rework** (`/history/church-divisions`) — toggle for old/new view, 31 division entries across 10 categories, live search, category filter chips, tree view, rich detail panel; old DB-backed view preserved as backup
- Pentecostalism entry explicitly distinguished from the Catholic Charismatic Renewal (CCR is a movement within the Catholic Church, not a division)
- Navigation, sitemap, and cross-links updated; broken `/history/church-timeline` link fixed; CSS dev-server cache issue resolved
- Sources strengthened across all tabs with authoritative scholarly works (Pelikan, Tanner, Duffy, MacCulloch, O'Malley, Hurtado, Brown, Bauckham, Weigel, Ratzinger)

## Test plan

- [ ] `/history/church` — all 6 tabs render and switch
- [ ] `/history/apostles` — all 4 tabs render; cross-links to Christ, Resurrection, Indian Church, Church work
- [ ] `/history/church-divisions` — toggle switches between New and Old view; search filters live; category chips toggle; selecting a division updates the right panel
- [ ] `/commentary` — May 3 entry appears expanded by default; April 26 entry collapses underneath
- [ ] Navigation: "The Church" tab appears between The Apostles and Papal Timeline
- [ ] No TypeScript errors (`npx tsc --noEmit`)
- [ ] No 500s on any history or commentary route

🤖 Generated with [Claude Code](https://claude.com/claude-code)