### PR TITLE
feat: Sunday Gospel commentary page — May 10 entry, card layout, print-clean UX

### DIFF
--- a/src/app/commentary/page.tsx
+++ b/src/app/commentary/page.tsx
@@ -12,6 +12,13 @@ function splitReading(raw: string): { ref: string; summary: string } {
   return { ref: raw.slice(0, idx), summary: raw.slice(idx + 3) }
 }
 
+function toBullets(text: string): string[] {
+  return text
+    .split(/\.[ \n]+(?=[A-Z"""])/)
+    .map(s => s.replace(/\.+$/, '').trim())
+    .filter(Boolean)
+}
+
 const today = new Date()
 const currentCycle = getCycleForDate(today)
 const currentSpan = getCycleSpan(today)
@@ -105,19 +112,46 @@ export default function CommentaryPage() {
                             <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 flex flex-col gap-2">
                               <span className="text-xs font-bold uppercase tracking-wide text-indigo-500">First Reading</span>
                               <p className="font-semibold text-indigo-900 text-sm leading-snug">{fr.ref}</p>
-                              {fr.summary && <p className="text-sm text-indigo-800 leading-relaxed">{fr.summary}</p>}
+                              {fr.summary && (
+                                <ul className="space-y-1 mt-1">
+                                  {toBullets(fr.summary).map((pt, i) => (
+                                    <li key={i} className="flex items-start gap-2 text-sm text-indigo-800">
+                                      <span className="mt-2 w-1 h-1 rounded-full bg-indigo-400 shrink-0" />
+                                      <span>{pt}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              )}
                             </div>
                             {/* Responsorial Psalm */}
                             <div className="rounded-xl border border-green-100 bg-green-50 p-4 flex flex-col gap-2">
                               <span className="text-xs font-bold uppercase tracking-wide text-green-500">Responsorial Psalm</span>
                               <p className="font-semibold text-green-900 text-sm leading-snug">{ps.ref}</p>
-                              {ps.summary && <p className="text-sm text-green-800 leading-relaxed">{ps.summary}</p>}
+                              {ps.summary && (
+                                <ul className="space-y-1 mt-1">
+                                  {toBullets(ps.summary).map((pt, i) => (
+                                    <li key={i} className="flex items-start gap-2 text-sm text-green-800">
+                                      <span className="mt-2 w-1 h-1 rounded-full bg-green-400 shrink-0" />
+                                      <span>{pt}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              )}
                             </div>
                             {/* Second Reading */}
                             <div className="rounded-xl border border-rose-100 bg-rose-50 p-4 flex flex-col gap-2">
                               <span className="text-xs font-bold uppercase tracking-wide text-rose-500">Second Reading</span>
                               <p className="font-semibold text-rose-900 text-sm leading-snug">{sr.ref}</p>
-                              {sr.summary && <p className="text-sm text-rose-800 leading-relaxed">{sr.summary}</p>}
+                              {sr.summary && (
+                                <ul className="space-y-1 mt-1">
+                                  {toBullets(sr.summary).map((pt, i) => (
+                                    <li key={i} className="flex items-start gap-2 text-sm text-rose-800">
+                                      <span className="mt-2 w-1 h-1 rounded-full bg-rose-400 shrink-0" />
+                                      <span>{pt}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              )}
                             </div>
                             {/* Gospel */}
                             <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 flex flex-col gap-2">
@@ -127,7 +161,14 @@ export default function CommentaryPage() {
                                 <p className="font-semibold text-amber-900 text-sm leading-snug">{entry.gospelRef}</p>
                               </div>
                               {entry.gospelTextIsSummary && (
-                                <p className="text-sm text-amber-800 leading-relaxed">{splitReading(entry.gospelText).summary}</p>
+                                <ul className="space-y-1 mt-1">
+                                  {toBullets(splitReading(entry.gospelText).summary).map((pt, i) => (
+                                    <li key={i} className="flex items-start gap-2 text-sm text-amber-800">
+                                      <span className="mt-2 w-1 h-1 rounded-full bg-amber-400 shrink-0" />
+                                      <span>{pt}</span>
+                                    </li>
+                                  ))}
+                                </ul>
                               )}
                             </div>
                           </div>

--- a/src/app/commentary/page.tsx
+++ b/src/app/commentary/page.tsx
@@ -6,6 +6,12 @@ import { BookOpen, Calendar, ChevronDown, ChevronUp, Share2 } from 'lucide-react
 import sundayCommentaries from '@/lib/lectionary/sundayCommentaries'
 import { getCycleForDate, getCycleSpan } from '@/lib/lectionary'
 
+function splitReading(raw: string): { ref: string; summary: string } {
+  const idx = raw.indexOf(' — ')
+  if (idx === -1) return { ref: raw, summary: '' }
+  return { ref: raw.slice(0, idx), summary: raw.slice(idx + 3) }
+}
+
 const today = new Date()
 const currentCycle = getCycleForDate(today)
 const currentSpan = getCycleSpan(today)
@@ -86,44 +92,74 @@ export default function CommentaryPage() {
                       </div>
                     </div>
 
-                    {/* Readings Overview */}
-                    <div className="bg-blue-50 rounded-lg p-5 mb-6">
-                      <h4 className="font-semibold text-blue-900 mb-3">Today&apos;s Readings</h4>
-                      <ul className="space-y-2 text-sm text-blue-800">
-                        <li><span className="font-medium">First Reading:</span> {entry.firstReading}</li>
-                        <li><span className="font-medium">Responsorial Psalm:</span> {entry.psalm}</li>
-                        <li><span className="font-medium">Second Reading:</span> {entry.secondReading}</li>
-                        <li><span className="font-medium">Gospel:</span> {entry.gospelRef}</li>
-                      </ul>
-                      {entry.usccbReadingsUrl && (
-                        <p className="mt-3 text-sm">
-                          <a
-                            href={entry.usccbReadingsUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue-700 hover:text-blue-900 font-medium underline"
-                            onClick={e => e.stopPropagation()}
-                          >
-                            Read the full proclaimed readings on USCCB &rarr;
-                          </a>
-                        </p>
-                      )}
-                    </div>
+                    {/* Today's Readings — 4 cards */}
+                    {(() => {
+                      const fr = splitReading(entry.firstReading)
+                      const ps = splitReading(entry.psalm)
+                      const sr = splitReading(entry.secondReading)
+                      return (
+                        <div className="mb-6">
+                          <h4 className="font-semibold text-gray-900 mb-3">Readings at a Glance</h4>
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            {/* First Reading */}
+                            <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 flex flex-col gap-2">
+                              <span className="text-xs font-bold uppercase tracking-wide text-indigo-500">First Reading</span>
+                              <p className="font-semibold text-indigo-900 text-sm leading-snug">{fr.ref}</p>
+                              {fr.summary && <p className="text-sm text-indigo-800 leading-relaxed">{fr.summary}</p>}
+                            </div>
+                            {/* Responsorial Psalm */}
+                            <div className="rounded-xl border border-green-100 bg-green-50 p-4 flex flex-col gap-2">
+                              <span className="text-xs font-bold uppercase tracking-wide text-green-500">Responsorial Psalm</span>
+                              <p className="font-semibold text-green-900 text-sm leading-snug">{ps.ref}</p>
+                              {ps.summary && <p className="text-sm text-green-800 leading-relaxed">{ps.summary}</p>}
+                            </div>
+                            {/* Second Reading */}
+                            <div className="rounded-xl border border-rose-100 bg-rose-50 p-4 flex flex-col gap-2">
+                              <span className="text-xs font-bold uppercase tracking-wide text-rose-500">Second Reading</span>
+                              <p className="font-semibold text-rose-900 text-sm leading-snug">{sr.ref}</p>
+                              {sr.summary && <p className="text-sm text-rose-800 leading-relaxed">{sr.summary}</p>}
+                            </div>
+                            {/* Gospel */}
+                            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 flex flex-col gap-2">
+                              <span className="text-xs font-bold uppercase tracking-wide text-amber-600">Gospel</span>
+                              <div className="flex items-center gap-1.5">
+                                <BookOpen className="w-4 h-4 text-amber-700 shrink-0" />
+                                <p className="font-semibold text-amber-900 text-sm leading-snug">{entry.gospelRef}</p>
+                              </div>
+                              {entry.gospelTextIsSummary && (
+                                <p className="text-sm text-amber-800 leading-relaxed">{splitReading(entry.gospelText).summary}</p>
+                              )}
+                            </div>
+                          </div>
+                          {entry.usccbReadingsUrl && (
+                            <p className="mt-3 text-sm text-center">
+                              <a
+                                href={entry.usccbReadingsUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-900 font-medium underline underline-offset-2"
+                                onClick={e => e.stopPropagation()}
+                              >
+                                Read the full proclaimed readings on USCCB &rarr;
+                              </a>
+                            </p>
+                          )}
+                        </div>
+                      )
+                    })()}
 
-                    {/* Gospel Text */}
-                    <div className="bg-amber-50 rounded-lg p-6 mb-6 border-l-4 border-amber-400">
-                      <div className="flex items-center gap-2 mb-3">
-                        <BookOpen className="w-5 h-5 text-amber-700" />
-                        <h4 className="font-serif font-bold text-gray-900">
-                          {entry.gospelTextIsSummary
-                            ? `Gospel Summary from ${entry.gospelRef}`
-                            : `Gospel — ${entry.gospelRef}`}
-                        </h4>
+                    {/* Gospel full text — only shown when not a summary */}
+                    {!entry.gospelTextIsSummary && (
+                      <div className="bg-amber-50 rounded-lg p-6 mb-6 border-l-4 border-amber-400">
+                        <div className="flex items-center gap-2 mb-3">
+                          <BookOpen className="w-5 h-5 text-amber-700" />
+                          <h4 className="font-serif font-bold text-gray-900">Gospel — {entry.gospelRef}</h4>
+                        </div>
+                        <div className="text-gray-800 leading-relaxed whitespace-pre-line text-[15px]">
+                          {entry.gospelText}
+                        </div>
                       </div>
-                      <div className="text-gray-800 leading-relaxed whitespace-pre-line text-[15px]">
-                        {entry.gospelText}
-                      </div>
-                    </div>
+                    )}
 
                     {/* Historical & Literary Context */}
                     <div className="mb-6">

--- a/src/app/commentary/sunday-gospel/[slug]/ShareButtons.tsx
+++ b/src/app/commentary/sunday-gospel/[slug]/ShareButtons.tsx
@@ -1,11 +1,88 @@
 'use client'
 
-import { Copy, Share2 } from 'lucide-react'
+import { Copy, Printer, Share2 } from 'lucide-react'
+import { useState } from 'react'
 
-export default function ShareButtons({ url, title }: { url: string; title: string }) {
+interface ShareButtonsProps {
+  url: string
+  title: string
+  layout?: 'horizontal' | 'vertical'
+}
+
+export default function ShareButtons({ url, title, layout = 'horizontal' }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false)
   const waText = encodeURIComponent(`${title}\n${url}`)
   const fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`
   const waUrl = `https://wa.me/?text=${waText}`
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  if (layout === 'vertical') {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-gray-400 writing-mode-vertical">
+          Share
+        </span>
+        <a
+          href={waUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Share on WhatsApp"
+          className="flex flex-col items-center gap-1 group"
+        >
+          <span className="w-10 h-10 flex items-center justify-center rounded-full bg-green-100 text-green-700 hover:bg-green-600 hover:text-white transition-colors shadow-sm">
+            {/* WhatsApp icon */}
+            <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" aria-hidden="true">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/>
+              <path d="M12 0C5.373 0 0 5.373 0 12c0 2.126.556 4.12 1.529 5.849L0 24l6.335-1.502A11.946 11.946 0 0 0 12 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 22c-1.885 0-3.65-.507-5.17-1.394l-.37-.22-3.76.892.944-3.648-.242-.375A9.956 9.956 0 0 1 2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10z"/>
+            </svg>
+          </span>
+          <span className="text-[10px] text-gray-500 group-hover:text-gray-700">WhatsApp</span>
+        </a>
+        <a
+          href={fbUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Share on Facebook"
+          className="flex flex-col items-center gap-1 group"
+        >
+          <span className="w-10 h-10 flex items-center justify-center rounded-full bg-blue-100 text-blue-700 hover:bg-blue-600 hover:text-white transition-colors shadow-sm">
+            {/* Facebook icon */}
+            <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" aria-hidden="true">
+              <path d="M24 12.073C24 5.404 18.627 0 12 0S0 5.404 0 12.073C0 18.1 4.388 23.094 10.125 24v-8.437H7.078v-3.49h3.047V9.41c0-3.025 1.792-4.697 4.533-4.697 1.312 0 2.686.236 2.686.236v2.97h-1.513c-1.491 0-1.956.93-1.956 1.886v2.267h3.328l-.532 3.49h-2.796V24C19.612 23.094 24 18.1 24 12.073z"/>
+            </svg>
+          </span>
+          <span className="text-[10px] text-gray-500 group-hover:text-gray-700">Facebook</span>
+        </a>
+        <button
+          onClick={handleCopy}
+          title="Copy link"
+          className="flex flex-col items-center gap-1 group"
+        >
+          <span className="w-10 h-10 flex items-center justify-center rounded-full bg-gray-100 text-gray-600 hover:bg-gray-300 hover:text-gray-900 transition-colors shadow-sm">
+            <Copy className="w-4 h-4" />
+          </span>
+          <span className="text-[10px] text-gray-500 group-hover:text-gray-700">
+            {copied ? 'Copied!' : 'Copy'}
+          </span>
+        </button>
+        <button
+          onClick={() => window.print()}
+          title="Print or save as PDF"
+          className="flex flex-col items-center gap-1 group"
+        >
+          <span className="w-10 h-10 flex items-center justify-center rounded-full bg-gray-100 text-gray-600 hover:bg-gray-300 hover:text-gray-900 transition-colors shadow-sm">
+            <Printer className="w-4 h-4" />
+          </span>
+          <span className="text-[10px] text-gray-500 group-hover:text-gray-700">Print</span>
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -29,10 +106,16 @@ export default function ShareButtons({ url, title }: { url: string; title: strin
         Facebook
       </a>
       <button
-        onClick={() => navigator.clipboard.writeText(url)}
+        onClick={handleCopy}
         className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors"
       >
-        <Copy className="w-3.5 h-3.5" /> Copy link
+        <Copy className="w-3.5 h-3.5" /> {copied ? 'Copied!' : 'Copy link'}
+      </button>
+      <button
+        onClick={() => window.print()}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors"
+      >
+        <Printer className="w-3.5 h-3.5" /> Print / PDF
       </button>
     </div>
   )

--- a/src/app/commentary/sunday-gospel/[slug]/page.tsx
+++ b/src/app/commentary/sunday-gospel/[slug]/page.tsx
@@ -51,6 +51,12 @@ export async function generateMetadata({
   }
 }
 
+function splitReading(raw: string): { ref: string; summary: string } {
+  const idx = raw.indexOf(' — ')
+  if (idx === -1) return { ref: raw, summary: '' }
+  return { ref: raw.slice(0, idx), summary: raw.slice(idx + 3) }
+}
+
 function parseCommentary(text: string) {
   return text.split('\n\n').map((para, i) => {
     if (para.startsWith('**')) {
@@ -135,43 +141,73 @@ export default async function SundayGospelPage({
         <ShareButtons url={pageUrl} title={`${entry.sundayName} — ${entry.gospelRef}`} />
       </div>
 
-      {/* Readings overview */}
-      <div className="bg-blue-50 rounded-xl p-5 mb-6">
-        <h2 className="font-semibold text-blue-900 mb-3">Today&apos;s Readings</h2>
-        <ul className="space-y-2 text-sm text-blue-800">
-          <li><span className="font-medium">First Reading:</span> {entry.firstReading}</li>
-          <li><span className="font-medium">Responsorial Psalm:</span> {entry.psalm}</li>
-          <li><span className="font-medium">Second Reading:</span> {entry.secondReading}</li>
-          <li><span className="font-medium">Gospel:</span> {entry.gospelRef}</li>
-        </ul>
-        {entry.usccbReadingsUrl && (
-          <p className="mt-3 text-sm">
-            <a
-              href={entry.usccbReadingsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-700 hover:text-blue-900 font-medium underline"
-            >
-              Read the full proclaimed readings on USCCB &rarr;
-            </a>
-          </p>
-        )}
-      </div>
+      {/* Today's Readings — 4 cards */}
+      {(() => {
+        const fr = splitReading(entry.firstReading)
+        const ps = splitReading(entry.psalm)
+        const sr = splitReading(entry.secondReading)
+        return (
+          <div className="mb-6">
+            <h2 className="text-xl font-serif font-bold text-gray-900 mb-4">Readings at a Glance</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {/* First Reading */}
+              <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 flex flex-col gap-2">
+                <span className="text-xs font-bold uppercase tracking-wide text-indigo-500">First Reading</span>
+                <p className="font-semibold text-indigo-900 text-sm leading-snug">{fr.ref}</p>
+                {fr.summary && <p className="text-sm text-indigo-800 leading-relaxed">{fr.summary}</p>}
+              </div>
+              {/* Responsorial Psalm */}
+              <div className="rounded-xl border border-green-100 bg-green-50 p-4 flex flex-col gap-2">
+                <span className="text-xs font-bold uppercase tracking-wide text-green-500">Responsorial Psalm</span>
+                <p className="font-semibold text-green-900 text-sm leading-snug">{ps.ref}</p>
+                {ps.summary && <p className="text-sm text-green-800 leading-relaxed">{ps.summary}</p>}
+              </div>
+              {/* Second Reading */}
+              <div className="rounded-xl border border-rose-100 bg-rose-50 p-4 flex flex-col gap-2">
+                <span className="text-xs font-bold uppercase tracking-wide text-rose-500">Second Reading</span>
+                <p className="font-semibold text-rose-900 text-sm leading-snug">{sr.ref}</p>
+                {sr.summary && <p className="text-sm text-rose-800 leading-relaxed">{sr.summary}</p>}
+              </div>
+              {/* Gospel */}
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 flex flex-col gap-2">
+                <span className="text-xs font-bold uppercase tracking-wide text-amber-600">Gospel</span>
+                <div className="flex items-center gap-1.5">
+                  <BookOpen className="w-4 h-4 text-amber-700 shrink-0" />
+                  <p className="font-semibold text-amber-900 text-sm leading-snug">{entry.gospelRef}</p>
+                </div>
+                {entry.gospelTextIsSummary && (
+                  <p className="text-sm text-amber-800 leading-relaxed">{splitReading(entry.gospelText).summary}</p>
+                )}
+              </div>
+            </div>
+            {entry.usccbReadingsUrl && (
+              <p className="mt-4 text-sm text-center">
+                <a
+                  href={entry.usccbReadingsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-900 font-medium underline underline-offset-2"
+                >
+                  Read the full proclaimed readings on USCCB &rarr;
+                </a>
+              </p>
+            )}
+          </div>
+        )
+      })()}
 
-      {/* Gospel text */}
-      <div className="bg-amber-50 rounded-xl p-6 mb-6 border-l-4 border-amber-400">
-        <div className="flex items-center gap-2 mb-3">
-          <BookOpen className="w-5 h-5 text-amber-700" />
-          <h2 className="font-serif font-bold text-gray-900">
-            {entry.gospelTextIsSummary
-              ? `Gospel Summary from ${entry.gospelRef}`
-              : `Gospel — ${entry.gospelRef}`}
-          </h2>
+      {/* Gospel text — only shown when full text is stored (not a summary) */}
+      {!entry.gospelTextIsSummary && (
+        <div className="bg-amber-50 rounded-xl p-6 mb-6 border-l-4 border-amber-400">
+          <div className="flex items-center gap-2 mb-3">
+            <BookOpen className="w-5 h-5 text-amber-700" />
+            <h2 className="font-serif font-bold text-gray-900">Gospel — {entry.gospelRef}</h2>
+          </div>
+          <div className="text-gray-800 leading-relaxed whitespace-pre-line text-[15px]">
+            {entry.gospelText}
+          </div>
         </div>
-        <div className="text-gray-800 leading-relaxed whitespace-pre-line text-[15px]">
-          {entry.gospelText}
-        </div>
-      </div>
+      )}
 
       {/* Key themes */}
       <div className="bg-green-50 rounded-xl p-5 mb-6">

--- a/src/app/commentary/sunday-gospel/[slug]/page.tsx
+++ b/src/app/commentary/sunday-gospel/[slug]/page.tsx
@@ -133,7 +133,7 @@ export default async function SundayGospelPage({
       </div>
 
       {/* Floating share sidebar — 2xl only: at max-w-6xl need ≥1536px to have clear margin left */}
-      <div className="hidden 2xl:block fixed left-6 top-1/2 -translate-y-1/2 z-30">
+      <div className="hidden 2xl:block print:hidden fixed left-6 top-1/2 -translate-y-1/2 z-30">
         <div className="bg-white rounded-2xl shadow-md border border-gray-100 px-2 py-4">
           <ShareButtons layout="vertical" url={pageUrl} title={`${entry.sundayName} — ${entry.gospelRef}`} />
         </div>
@@ -235,7 +235,7 @@ export default async function SundayGospelPage({
           <div className="lg:grid lg:grid-cols-4 lg:gap-8 lg:items-start">
 
             {/* Right sticky sidebar — DOM first so mobile shows readings above content */}
-            <aside className="lg:col-span-1 lg:order-last mb-8 lg:mb-0">
+            <aside className="lg:col-span-1 lg:order-last mb-8 lg:mb-0 print:hidden">
               <div className="lg:sticky lg:top-6">
                 {readingCards}
               </div>
@@ -259,7 +259,7 @@ export default async function SundayGospelPage({
 
               {/* USCCB readings prompt — shown before commentary so readers can read the source first */}
               {entry.usccbReadingsUrl && (
-                <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 mb-6">
+                <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 mb-6 print:hidden">
                   <BookOpen className="w-4 h-4 text-amber-600 shrink-0" />
                   <p className="text-sm text-amber-800">
                     <span className="font-medium">Before you read:</span>{' '}
@@ -277,7 +277,7 @@ export default async function SundayGospelPage({
 
               {/* Key Themes — collapsible, so it doesn't block the reader but is easy to open */}
               {entry.themes.length > 0 && (
-                <details className="group bg-green-50 border border-green-200 rounded-xl mb-6">
+                <details className="group bg-green-50 border border-green-200 rounded-xl mb-6 print:hidden">
                   <summary className="flex items-center justify-between px-4 py-3 cursor-pointer list-none select-none">
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-bold text-green-900 uppercase tracking-wide">Key Themes</span>
@@ -344,7 +344,7 @@ export default async function SundayGospelPage({
               </div>
 
               {/* Bottom share strip — primary CTA on mobile; xl users have the floating sidebar */}
-              <div className="border-t border-gray-200 pt-6">
+              <div className="border-t border-gray-200 pt-6 print:hidden">
                 <p className="text-sm text-gray-600 mb-3">
                   Found this helpful? Share it with your parish or priest:
                 </p>

--- a/src/app/commentary/sunday-gospel/[slug]/page.tsx
+++ b/src/app/commentary/sunday-gospel/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import { BookOpen, Calendar } from 'lucide-react'
+import { BookOpen, Calendar, ChevronDown } from 'lucide-react'
 import sundayCommentaries from '@/lib/lectionary/sundayCommentaries'
 import type { SundayCommentary } from '@/lib/lectionary/types'
 import { getCycleForDate } from '@/lib/lectionary'
@@ -57,6 +57,13 @@ function splitReading(raw: string): { ref: string; summary: string } {
   return { ref: raw.slice(0, idx), summary: raw.slice(idx + 3) }
 }
 
+function toBullets(text: string): string[] {
+  return text
+    .split(/\.[ \n]+(?=[A-Z“”"])/)
+    .map(s => s.replace(/\.+$/, '').trim())
+    .filter(Boolean)
+}
+
 function parseCommentary(text: string) {
   return text.split('\n\n').map((para, i) => {
     if (para.startsWith('**')) {
@@ -97,7 +104,7 @@ export default async function SundayGospelPage({
   })
 
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 relative">
       {/* Breadcrumb */}
       <nav className="text-sm text-gray-500 mb-6 flex flex-wrap items-center gap-1">
         <Link href="/commentary" className="hover:text-amber-600 transition-colors">
@@ -125,6 +132,13 @@ export default async function SundayGospelPage({
         </p>
       </div>
 
+      {/* Floating share sidebar — 2xl only: at max-w-6xl need ≥1536px to have clear margin left */}
+      <div className="hidden 2xl:block fixed left-6 top-1/2 -translate-y-1/2 z-30">
+        <div className="bg-white rounded-2xl shadow-md border border-gray-100 px-2 py-4">
+          <ShareButtons layout="vertical" url={pageUrl} title={`${entry.sundayName} — ${entry.gospelRef}`} />
+        </div>
+      </div>
+
       {/* Content-cycle mismatch warning (shown when commentary was written for a different cycle) */}
       {contentMismatch && (
         <div className="mb-6 p-4 bg-yellow-50 rounded-xl border border-yellow-300">
@@ -136,37 +150,62 @@ export default async function SundayGospelPage({
         </div>
       )}
 
-      {/* Share buttons */}
-      <div className="mb-8 p-4 bg-amber-50 rounded-xl border border-amber-200">
-        <ShareButtons url={pageUrl} title={`${entry.sundayName} — ${entry.gospelRef}`} />
-      </div>
-
-      {/* Today's Readings — 4 cards */}
+      {/* 2-column layout: sidebar right (readings + themes) | main left (context → commentary) */}
       {(() => {
         const fr = splitReading(entry.firstReading)
         const ps = splitReading(entry.psalm)
         const sr = splitReading(entry.secondReading)
-        return (
-          <div className="mb-6">
-            <h2 className="text-xl font-serif font-bold text-gray-900 mb-4">Readings at a Glance</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+
+        const readingCards = (
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-base font-serif font-bold text-gray-900 mb-3">Readings at a Glance</h2>
+              {/* Single-column stacked cards in sidebar; 2-col on mobile standalone */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-3">
               {/* First Reading */}
               <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 flex flex-col gap-2">
                 <span className="text-xs font-bold uppercase tracking-wide text-indigo-500">First Reading</span>
                 <p className="font-semibold text-indigo-900 text-sm leading-snug">{fr.ref}</p>
-                {fr.summary && <p className="text-sm text-indigo-800 leading-relaxed">{fr.summary}</p>}
+                {fr.summary && (
+                  <ul className="space-y-1 mt-1">
+                    {toBullets(fr.summary).map((pt, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-indigo-800">
+                        <span className="mt-2 w-1 h-1 rounded-full bg-indigo-400 shrink-0" />
+                        <span>{pt}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
               {/* Responsorial Psalm */}
               <div className="rounded-xl border border-green-100 bg-green-50 p-4 flex flex-col gap-2">
                 <span className="text-xs font-bold uppercase tracking-wide text-green-500">Responsorial Psalm</span>
                 <p className="font-semibold text-green-900 text-sm leading-snug">{ps.ref}</p>
-                {ps.summary && <p className="text-sm text-green-800 leading-relaxed">{ps.summary}</p>}
+                {ps.summary && (
+                  <ul className="space-y-1 mt-1">
+                    {toBullets(ps.summary).map((pt, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-green-800">
+                        <span className="mt-2 w-1 h-1 rounded-full bg-green-400 shrink-0" />
+                        <span>{pt}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
               {/* Second Reading */}
               <div className="rounded-xl border border-rose-100 bg-rose-50 p-4 flex flex-col gap-2">
                 <span className="text-xs font-bold uppercase tracking-wide text-rose-500">Second Reading</span>
                 <p className="font-semibold text-rose-900 text-sm leading-snug">{sr.ref}</p>
-                {sr.summary && <p className="text-sm text-rose-800 leading-relaxed">{sr.summary}</p>}
+                {sr.summary && (
+                  <ul className="space-y-1 mt-1">
+                    {toBullets(sr.summary).map((pt, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-rose-800">
+                        <span className="mt-2 w-1 h-1 rounded-full bg-rose-400 shrink-0" />
+                        <span>{pt}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
               {/* Gospel */}
               <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 flex flex-col gap-2">
@@ -176,110 +215,155 @@ export default async function SundayGospelPage({
                   <p className="font-semibold text-amber-900 text-sm leading-snug">{entry.gospelRef}</p>
                 </div>
                 {entry.gospelTextIsSummary && (
-                  <p className="text-sm text-amber-800 leading-relaxed">{splitReading(entry.gospelText).summary}</p>
+                  <ul className="space-y-1 mt-1">
+                    {toBullets(splitReading(entry.gospelText).summary).map((pt, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-amber-800">
+                        <span className="mt-2 w-1 h-1 rounded-full bg-amber-400 shrink-0" />
+                        <span>{pt}</span>
+                      </li>
+                    ))}
+                  </ul>
                 )}
               </div>
             </div>
-            {entry.usccbReadingsUrl && (
-              <p className="mt-4 text-sm text-center">
-                <a
-                  href={entry.usccbReadingsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-900 font-medium underline underline-offset-2"
+            </div>
+
+          </div>
+        )
+
+        return (
+          <div className="lg:grid lg:grid-cols-4 lg:gap-8 lg:items-start">
+
+            {/* Right sticky sidebar — DOM first so mobile shows readings above content */}
+            <aside className="lg:col-span-1 lg:order-last mb-8 lg:mb-0">
+              <div className="lg:sticky lg:top-6">
+                {readingCards}
+              </div>
+            </aside>
+
+            {/* Main content column */}
+            <div className="lg:col-span-3">
+
+              {/* Gospel full text — only for older non-summary entries */}
+              {!entry.gospelTextIsSummary && (
+                <div className="bg-amber-50 rounded-xl p-6 mb-6 border-l-4 border-amber-400">
+                  <div className="flex items-center gap-2 mb-3">
+                    <BookOpen className="w-5 h-5 text-amber-700" />
+                    <h2 className="font-serif font-bold text-gray-900">Gospel — {entry.gospelRef}</h2>
+                  </div>
+                  <div className="text-gray-800 leading-relaxed whitespace-pre-line text-[15px]">
+                    {entry.gospelText}
+                  </div>
+                </div>
+              )}
+
+              {/* USCCB readings prompt — shown before commentary so readers can read the source first */}
+              {entry.usccbReadingsUrl && (
+                <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 mb-6">
+                  <BookOpen className="w-4 h-4 text-amber-600 shrink-0" />
+                  <p className="text-sm text-amber-800">
+                    <span className="font-medium">Before you read:</span>{' '}
+                    <a
+                      href={entry.usccbReadingsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-2 hover:text-amber-900 font-medium"
+                    >
+                      Read this Sunday&apos;s full Mass readings at USCCB.org &rarr;
+                    </a>
+                  </p>
+                </div>
+              )}
+
+              {/* Key Themes — collapsible, so it doesn't block the reader but is easy to open */}
+              {entry.themes.length > 0 && (
+                <details className="group bg-green-50 border border-green-200 rounded-xl mb-6">
+                  <summary className="flex items-center justify-between px-4 py-3 cursor-pointer list-none select-none">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-bold text-green-900 uppercase tracking-wide">Key Themes</span>
+                      <span className="text-xs font-semibold bg-green-200 text-green-800 px-2 py-0.5 rounded-full">
+                        {entry.themes.length}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5 text-xs text-green-600">
+                      <span className="group-open:hidden">Tap to expand</span>
+                      <span className="hidden group-open:inline">Collapse</span>
+                      <ChevronDown className="w-4 h-4 transition-transform duration-200 group-open:rotate-180" />
+                    </div>
+                  </summary>
+                  <ul className="px-4 pb-4 pt-1 space-y-2 border-t border-green-200">
+                    {entry.themes.map((theme, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-green-800 pt-2">
+                        <span className="text-green-500 mt-0.5 shrink-0 font-bold">&#x2022;</span>
+                        {theme}
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+
+              {/* Historical & literary context — first thing to read */}
+              <div className="mb-8">
+                <h2 className="text-xl font-serif font-bold text-gray-900 mb-3">
+                  Historical &amp; Literary Context
+                </h2>
+                <div className="text-gray-700 leading-relaxed whitespace-pre-line">
+                  {entry.context}
+                </div>
+              </div>
+
+              {/* Commentary */}
+              <div className="mb-8">
+                <h2 className="text-xl font-serif font-bold text-gray-900 mb-3">Commentary</h2>
+                <div className="prose prose-sm max-w-none text-gray-700 leading-relaxed">
+                  {parseCommentary(entry.commentary)}
+                </div>
+              </div>
+
+              {/* Practical application */}
+              <div className="bg-purple-50 rounded-xl p-6 mb-8">
+                <h2 className="font-semibold text-purple-900 mb-3">Living the Gospel This Week</h2>
+                <div className="text-sm text-purple-800 leading-relaxed whitespace-pre-line">
+                  {entry.application}
+                </div>
+              </div>
+
+              {/* Sources */}
+              <div className="mb-8">
+                <h2 className="text-lg font-serif font-bold text-gray-900 mb-3">
+                  Sources &amp; Further Reading
+                </h2>
+                <ul className="space-y-1.5">
+                  {entry.sources.map((source, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm text-gray-600">
+                      <span className="mt-2 w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
+                      <span dangerouslySetInnerHTML={{ __html: source.replace(/\*(.*?)\*/g, '<em>$1</em>') }} />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Bottom share strip — primary CTA on mobile; xl users have the floating sidebar */}
+              <div className="border-t border-gray-200 pt-6">
+                <p className="text-sm text-gray-600 mb-3">
+                  Found this helpful? Share it with your parish or priest:
+                </p>
+                <ShareButtons url={pageUrl} title={`${entry.sundayName} — ${entry.gospelRef}`} layout="horizontal" />
+              </div>
+
+              {/* Back link */}
+              <div className="mt-8">
+                <Link
+                  href="/commentary"
+                  className="text-sm text-amber-600 hover:text-amber-800 transition-colors font-medium"
                 >
-                  Read the full proclaimed readings on USCCB &rarr;
-                </a>
-              </p>
-            )}
+                  ← Back to Sunday Gospel
+                </Link>
+              </div>
+            </div>
           </div>
         )
       })()}
-
-      {/* Gospel text — only shown when full text is stored (not a summary) */}
-      {!entry.gospelTextIsSummary && (
-        <div className="bg-amber-50 rounded-xl p-6 mb-6 border-l-4 border-amber-400">
-          <div className="flex items-center gap-2 mb-3">
-            <BookOpen className="w-5 h-5 text-amber-700" />
-            <h2 className="font-serif font-bold text-gray-900">Gospel — {entry.gospelRef}</h2>
-          </div>
-          <div className="text-gray-800 leading-relaxed whitespace-pre-line text-[15px]">
-            {entry.gospelText}
-          </div>
-        </div>
-      )}
-
-      {/* Key themes */}
-      <div className="bg-green-50 rounded-xl p-5 mb-6">
-        <h2 className="font-semibold text-green-900 mb-3">Key Themes</h2>
-        <ul className="space-y-2">
-          {entry.themes.map((theme, i) => (
-            <li key={i} className="flex items-start gap-2 text-sm text-green-800">
-              <span className="text-green-600 mt-0.5">&#x2022;</span>
-              {theme}
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      {/* Historical & literary context */}
-      <div className="mb-6">
-        <h2 className="text-xl font-serif font-bold text-gray-900 mb-3">
-          Historical &amp; Literary Context
-        </h2>
-        <div className="text-gray-700 leading-relaxed whitespace-pre-line">
-          {entry.context}
-        </div>
-      </div>
-
-      {/* Commentary */}
-      <div className="mb-6">
-        <h2 className="text-xl font-serif font-bold text-gray-900 mb-3">Commentary</h2>
-        <div className="prose prose-sm max-w-none text-gray-700 leading-relaxed">
-          {parseCommentary(entry.commentary)}
-        </div>
-      </div>
-
-      {/* Practical application */}
-      <div className="bg-purple-50 rounded-xl p-6 mb-6">
-        <h2 className="font-semibold text-purple-900 mb-3">Living the Gospel This Week</h2>
-        <div className="text-sm text-purple-800 leading-relaxed whitespace-pre-line">
-          {entry.application}
-        </div>
-      </div>
-
-      {/* Sources */}
-      <div className="mb-8">
-        <h2 className="text-lg font-serif font-bold text-gray-900 mb-3">
-          Sources &amp; Further Reading
-        </h2>
-        <ul className="space-y-1.5">
-          {entry.sources.map((source, i) => (
-            <li key={i} className="flex items-start gap-2 text-sm text-gray-600">
-              <span className="mt-2 w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
-              <span dangerouslySetInnerHTML={{ __html: source.replace(/\*(.*?)\*/g, '<em>$1</em>') }} />
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      {/* Bottom share strip */}
-      <div className="border-t border-gray-200 pt-6">
-        <p className="text-sm text-gray-600 mb-3">
-          Found this helpful? Share it with your parish or priest:
-        </p>
-        <ShareButtons url={pageUrl} title={`${entry.sundayName} — ${entry.gospelRef}`} />
-      </div>
-
-      {/* Back link */}
-      <div className="mt-8">
-        <Link
-          href="/commentary"
-          className="text-sm text-amber-600 hover:text-amber-800 transition-colors font-medium"
-        >
-          ← Back to Sunday Gospel
-        </Link>
-      </div>
     </div>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,3 +108,16 @@ select:focus {
   color: #D4AF37;
   text-decoration-color: #1B365D;
 }
+
+/* Remove browser-injected print headers/footers (date, title, URL, page number).
+   The browser renders those in the @page margin area — setting it to 0 removes them.
+   Body padding restores readable whitespace around the content. */
+@page {
+  margin: 0;
+}
+
+@media print {
+  body {
+    padding: 14mm 18mm;
+  }
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import DatabaseTestButton from "./DatabaseTestButton"
 
 export default function Footer() {
   return (
-    <footer className="bg-white/95 backdrop-blur border-t border-amber-200 mt-16">
+    <footer className="bg-white/95 backdrop-blur border-t border-amber-200 mt-16 print:hidden">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         <div className="flex items-center justify-between">
           <p className="text-gray-600 text-sm">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
-    <header className="shadow-lg border-b border-amber-200" style={{ backgroundColor: '#DBEAFE' }}>
+    <header className="shadow-lg border-b border-amber-200 print:hidden" style={{ backgroundColor: '#DBEAFE' }}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           {/* Brand Title */}

--- a/src/components/HistoryNavigation.tsx
+++ b/src/components/HistoryNavigation.tsx
@@ -94,7 +94,7 @@ export default function HistoryNavigation() {
   const activeCategory = categories.find(c => c.id === openCategory)
 
   return (
-    <div className="bg-white border-b border-gray-200">
+    <div className="bg-white border-b border-gray-200 print:hidden">
       <div className="container mx-auto px-4">
         {/* Top row: Home + Category toggles */}
         <div className="flex items-center gap-1 overflow-x-auto">


### PR DESCRIPTION
## Summary

- **May 10, 2026 commentary** — 6th Sunday of Easter, Year A (John 14:15-21, *The Promise of the Advocate*): paraphrased gospel summary, readings summaries, context, 7 themes, 9-section commentary, application, 13 sources. Includes `gospelTextIsSummary` + `usccbReadingsUrl` fields and a weekly-generation recipe in `CLAUDE.md`.
- **Readings at a Glance** — flat list replaced with 4 colour-coded cards (indigo, green, rose, amber) in a responsive 2×2 / sidebar grid; summaries rendered as dot bullet lists via `toBullets()` helper.
- **Page layout redesign** — `max-w-6xl`, 2-column grid (3:1): sticky right sidebar (readings cards) + left main column (Context first → Commentary → Application → Sources). Historical & Literary Context promoted to top of main content.
- **UX additions** — "Before you read" USCCB prompt above context; Key Themes as native `<details>` collapsible with count badge and rotating chevron; section renamed "Readings at a Glance".
- **Share sidebar** — floating vertical pill (WhatsApp, Facebook, Copy, Print/PDF) fixed at left edge, `2xl:` only; Print button calls `window.print()`; Copy shows "Copied!" feedback.
- **Clean print/PDF** — `print:hidden` on Header, Footer, HistoryNavigation, sidebar, share buttons, USCCB prompt, Key Themes; `@page { margin: 0 }` suppresses browser date/title/URL headers from the printed page.
- **Also includes** earlier commits: custom domain (`ajaycatholic.com`), Liturgical Calendar tab, per-Sunday shareable routes, liturgical calendar apostrophe fixes, church divisions updates, Apostles page.

## Test plan

- [ ] `/commentary/sunday-gospel/2026-05-10` — 2-col layout renders; sidebar shows 4 reading cards; USCCB "Before you read" prompt visible; Key Themes collapsed by default, expands on click
- [ ] Sidebar cards display bullet-point summaries; Gospel card shows ref + paraphrased summary
- [ ] Floating share pill visible at ≥1536px; Print/PDF button triggers browser print; Copy shows "Copied!" feedback
- [ ] Print preview: no header, footer, nav bar, sidebar, share buttons, USCCB prompt, Key Themes; no browser date/title line at top
- [ ] Existing entries (May 3, Apr 26) — "Gospel —" heading unchanged; full gospel text still renders; no regression in layout
- [ ] Mobile: sidebar stacks above main content; bottom share strip visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)