### PR TITLE
fix: Hide Readings at a Glance sidebar on mobile

### DIFF
--- a/src/app/commentary/sunday-gospel/[slug]/page.tsx
+++ b/src/app/commentary/sunday-gospel/[slug]/page.tsx
@@ -238,7 +238,7 @@ export default async function SundayGospelPage({
           <div className="lg:grid lg:grid-cols-4 lg:gap-8 lg:items-start">
 
             {/* Right sticky sidebar — DOM first so mobile shows readings above content */}
-            <aside className="lg:col-span-1 lg:order-last mb-8 lg:mb-0 print:hidden">
+            <aside className="hidden lg:block lg:col-span-1 lg:order-last print:hidden">
               <div className="lg:sticky lg:top-6">
                 {readingCards}
               </div>


### PR DESCRIPTION
## Summary

- Sidebar was stacking above the commentary on mobile, forcing readers to scroll past the full readings grid before reaching any commentary content
- Added `hidden lg:block` to the aside — sidebar is invisible below the `lg` breakpoint and unchanged on desktop

## Test plan
- [ ] Mobile — commentary is the first content below the header; no reading cards visible
- [ ] Desktop (lg+) — sticky sidebar still appears to the right as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)