### PR TITLE
feat: Curated PPT workflow — upload, serve, fallback, admin manager

### DIFF
--- a/src/app/admin/commentary/page.tsx
+++ b/src/app/admin/commentary/page.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Download, Trash2, Upload, CheckCircle, AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react'
+
+interface EntryStatus {
+  id: string
+  sundayName: string
+  gospelRef: string
+  date: string
+  cycle: string
+  sundaySlug: string
+  curatedUrl: string | null
+}
+
+export default function AdminCommentaryPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [entries, setEntries] = useState<EntryStatus[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState<Record<string, boolean>>({})
+  const [message, setMessage] = useState<{ id: string; text: string; ok: boolean } | null>(null)
+  const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({})
+
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session || (session.user as { role?: string }).role !== 'ADMIN') {
+      router.push('/auth/signin')
+    }
+  }, [session, status, router])
+
+  useEffect(() => {
+    fetchStatuses()
+  }, [])
+
+  async function fetchStatuses() {
+    setLoading(true)
+    const res = await fetch('/api/commentary/ppt-status')
+    if (res.ok) setEntries(await res.json())
+    setLoading(false)
+  }
+
+  function flash(id: string, text: string, ok: boolean) {
+    setMessage({ id, text, ok })
+    setTimeout(() => setMessage(null), 3500)
+  }
+
+  async function handleUpload(id: string, file: File) {
+    setBusy(b => ({ ...b, [id]: true }))
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch(`/api/commentary/ppt/${id}`, { method: 'POST', body: form })
+    if (res.ok) {
+      flash(id, 'Curated PPT uploaded successfully', true)
+      await fetchStatuses()
+    } else {
+      const err = await res.json()
+      flash(id, err.error ?? 'Upload failed', false)
+    }
+    setBusy(b => ({ ...b, [id]: false }))
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm('Remove curated PPT? Downloads will fall back to auto-generated.')) return
+    setBusy(b => ({ ...b, [id]: true }))
+    const res = await fetch(`/api/commentary/ppt/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      flash(id, 'Curated PPT removed — auto-generated fallback active', true)
+      await fetchStatuses()
+    } else {
+      flash(id, 'Delete failed', false)
+    }
+    setBusy(b => ({ ...b, [id]: false }))
+  }
+
+  async function handleDownload(entry: EntryStatus) {
+    const a = document.createElement('a')
+    a.href = `/api/commentary/ppt/${entry.id}`
+    a.download = `${entry.id}-${entry.sundaySlug}.pptx`
+    a.click()
+  }
+
+  if (status === 'loading' || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-600" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <Link href="/admin" className="flex items-center gap-1 text-sm text-amber-600 hover:text-amber-800 mb-2">
+            <ArrowLeft className="w-4 h-4" /> Back to Admin
+          </Link>
+          <h1 className="text-2xl font-serif font-bold text-gray-900">Commentary PPT Manager</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Upload a curated .pptx per Sunday. If none is uploaded, the download button auto-generates one.
+          </p>
+        </div>
+        <button onClick={fetchStatuses} className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700">
+          <RefreshCw className="w-4 h-4" /> Refresh
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {entries.map(entry => {
+          const isBusy = !!busy[entry.id]
+          const msg = message?.id === entry.id ? message : null
+
+          return (
+            <div
+              key={entry.id}
+              className="bg-white rounded-xl border border-gray-200 p-4 flex flex-col sm:flex-row sm:items-center gap-4"
+            >
+              {/* Info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-xs font-bold text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full">
+                    Year {entry.cycle}
+                  </span>
+                  <span className="text-xs text-gray-400">{entry.date}</span>
+                  {entry.curatedUrl ? (
+                    <span className="flex items-center gap-1 text-xs font-semibold text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+                      <CheckCircle className="w-3 h-3" /> Curated PPT
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
+                      <AlertCircle className="w-3 h-3" /> Auto-generated
+                    </span>
+                  )}
+                </div>
+                <p className="font-semibold text-gray-900 text-sm mt-1 truncate">{entry.sundayName}</p>
+                <p className="text-xs text-gray-500">{entry.gospelRef}</p>
+                {msg && (
+                  <p className={`text-xs mt-1 font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>
+                    {msg.text}
+                  </p>
+                )}
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-2 shrink-0 flex-wrap">
+                {/* Download (serves curated if available, else auto) */}
+                <button
+                  onClick={() => handleDownload(entry)}
+                  disabled={isBusy}
+                  title="Download PPT (curated if available)"
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors disabled:opacity-50"
+                >
+                  <Download className="w-3.5 h-3.5" /> Download
+                </button>
+
+                {/* Upload curated */}
+                <label
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
+                    isBusy
+                      ? 'bg-indigo-50 text-indigo-400 opacity-50 cursor-not-allowed'
+                      : 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'
+                  }`}
+                  title="Upload curated .pptx"
+                >
+                  <Upload className="w-3.5 h-3.5" />
+                  {isBusy ? 'Uploading…' : entry.curatedUrl ? 'Replace PPT' : 'Upload PPT'}
+                  <input
+                    type="file"
+                    accept=".pptx"
+                    className="hidden"
+                    disabled={isBusy}
+                    ref={el => { fileInputRefs.current[entry.id] = el }}
+                    onChange={e => {
+                      const file = e.target.files?.[0]
+                      if (file) handleUpload(entry.id, file)
+                      e.target.value = ''
+                    }}
+                  />
+                </label>
+
+                {/* Delete curated */}
+                {entry.curatedUrl && (
+                  <button
+                    onClick={() => handleDelete(entry.id)}
+                    disabled={isBusy}
+                    title="Remove curated PPT (revert to auto-generated)"
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-red-50 text-red-600 hover:bg-red-100 transition-colors disabled:opacity-50"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" /> Remove
+                  </button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+
+        {entries.length === 0 && !loading && (
+          <div className="text-center py-12 text-gray-400">No commentary entries found.</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -262,6 +262,21 @@ export default function AdminDashboard() {
           </Link>
 
           <Link
+            href="/admin/commentary"
+            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+          >
+            <div className="flex items-center">
+              <div className="p-2 rounded-lg bg-amber-100">
+                <BookOpen className="w-6 h-6 text-amber-700" />
+              </div>
+              <div className="ml-4">
+                <h3 className="font-semibold text-gray-900">Commentary PPTs</h3>
+                <p className="text-sm text-gray-600">Upload &amp; manage PPT files</p>
+              </div>
+            </div>
+          </Link>
+
+          <Link
             href="/admin/settings"
             className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
           >

--- a/src/app/api/commentary/ppt-status/route.ts
+++ b/src/app/api/commentary/ppt-status/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
+import sundayCommentaries from '@/lib/lectionary/sundayCommentaries'
+import { getPPTCloudinaryUrl } from '@/lib/cloudinary'
+
+// Returns curated-PPT status for all commentary entries (admin only)
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session || (session.user as { role?: string }).role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const statuses = await Promise.all(
+    sundayCommentaries.map(async entry => ({
+      id: entry.id,
+      sundayName: entry.sundayName,
+      gospelRef: entry.gospelRef,
+      date: entry.date,
+      cycle: entry.cycle,
+      sundaySlug: entry.sundaySlug,
+      curatedUrl: await getPPTCloudinaryUrl(entry.id),
+    }))
+  )
+
+  return NextResponse.json(statuses)
+}

--- a/src/app/api/commentary/ppt/[id]/route.ts
+++ b/src/app/api/commentary/ppt/[id]/route.ts
@@ -1,25 +1,90 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
 import sundayCommentaries from '@/lib/lectionary/sundayCommentaries'
 import { generateCommentaryPPTBuffer } from '@/lib/generateCommentaryPPT'
+import {
+  getPPTCloudinaryUrl,
+  uploadPPTToCloudinary,
+  deletePPTFromCloudinary,
+} from '@/lib/cloudinary'
 
+async function getEntry(id: string) {
+  return sundayCommentaries.find(e => e.id === id) ?? null
+}
+
+// GET — serve curated Cloudinary PPT if available, fall back to auto-generated
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params
-  const entry = sundayCommentaries.find(e => e.id === id)
+  const entry = await getEntry(id)
   if (!entry) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
+  const fileName = `${entry.id}-${entry.sundaySlug}.pptx`
+  const pptHeaders = {
+    'Content-Type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'Content-Disposition': `attachment; filename="${fileName}"`,
+  }
+
+  // 1. Try curated file from Cloudinary
+  const curatedUrl = await getPPTCloudinaryUrl(entry.id)
+  if (curatedUrl) {
+    const upstream = await fetch(curatedUrl)
+    if (upstream.ok) {
+      const buffer = await upstream.arrayBuffer()
+      return new NextResponse(buffer as unknown as BodyInit, { headers: pptHeaders })
+    }
+  }
+
+  // 2. Fall back to auto-generated
   const displayDate = new Date(entry.date + 'T12:00:00').toLocaleDateString('en-US', {
     weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
   })
-
   const buffer = await generateCommentaryPPTBuffer(entry, displayDate)
+  return new NextResponse(buffer as unknown as BodyInit, { headers: pptHeaders })
+}
 
-  return new NextResponse(buffer as unknown as BodyInit, {
-    headers: {
-      'Content-Type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      'Content-Disposition': `attachment; filename="${entry.id}-${entry.sundaySlug}.pptx"`,
-    },
-  })
+// POST — admin only: upload a curated .pptx
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions)
+  if (!session || (session.user as { role?: string }).role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+  const entry = await getEntry(id)
+  if (!entry) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const formData = await req.formData()
+  const file = formData.get('file') as File | null
+  if (!file || !file.name.endsWith('.pptx')) {
+    return NextResponse.json({ error: 'A .pptx file is required' }, { status: 400 })
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const url = await uploadPPTToCloudinary(buffer, entry.id)
+  return NextResponse.json({ url })
+}
+
+// DELETE — admin only: remove curated file (reverts to auto-generated)
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions)
+  if (!session || (session.user as { role?: string }).role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+  const entry = await getEntry(id)
+  if (!entry) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  await deletePPTFromCloudinary(entry.id)
+  return NextResponse.json({ ok: true })
 }

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -48,6 +48,40 @@ export async function uploadImageToCloudinary(
   }
 }
 
+// ─── PPT (raw file) helpers ───────────────────────────────────────────────────
+
+const PPT_FOLDER = 'commentary-ppt'
+
+function pptPublicId(entryId: string) {
+  return `${PPT_FOLDER}/${entryId}`
+}
+
+export async function uploadPPTToCloudinary(
+  buffer: Buffer,
+  entryId: string
+): Promise<string> {
+  const result = await new Promise<{ secure_url: string }>((resolve, reject) => {
+    cloudinary.uploader.upload_stream(
+      { folder: PPT_FOLDER, public_id: entryId, resource_type: 'raw', overwrite: true },
+      (error, res) => { if (error) reject(error); else resolve(res as { secure_url: string }) }
+    ).end(buffer)
+  })
+  return result.secure_url
+}
+
+export async function getPPTCloudinaryUrl(entryId: string): Promise<string | null> {
+  try {
+    const result = await cloudinary.api.resource(pptPublicId(entryId), { resource_type: 'raw' })
+    return result.secure_url as string
+  } catch {
+    return null
+  }
+}
+
+export async function deletePPTFromCloudinary(entryId: string): Promise<void> {
+  await cloudinary.uploader.destroy(pptPublicId(entryId), { resource_type: 'raw' })
+}
+
 // Helper function to delete image from Cloudinary
 export async function deleteImageFromCloudinary(publicId: string): Promise<void> {
   try {


### PR DESCRIPTION
## Summary

Adds a three-tier PPT download system: curated (admin-uploaded) → auto-generated fallback. No change to the public download button UX.

### New workflow for Ajay
1. Generate commentary → auto-download PPT → refine in PowerPoint/Keynote
2. Go to `/admin/commentary` → upload refined `.pptx` for that Sunday
3. Public "Download PPT" button now serves the curated version automatically
4. "Remove" reverts to auto-generated if needed

### What was built

**`src/lib/cloudinary.ts`** — 3 new helpers:
- `uploadPPTToCloudinary(buffer, entryId)` — stores `.pptx` as raw asset at `commentary-ppt/{entryId}` with overwrite
- `getPPTCloudinaryUrl(entryId)` — returns URL or `null` if not found
- `deletePPTFromCloudinary(entryId)` — removes curated asset

**`GET /api/commentary/ppt/[id]`** (updated) — checks Cloudinary first, falls back to pptxgenjs auto-generation

**`POST /api/commentary/ppt/[id]`** (new, admin-only) — accepts `.pptx` multipart upload → Cloudinary

**`DELETE /api/commentary/ppt/[id]`** (new, admin-only) — removes curated file

**`GET /api/commentary/ppt-status`** (new, admin-only) — returns all entries with `curatedUrl` for the admin dashboard

**`src/app/admin/commentary/page.tsx`** (new) — lists all entries with:
- Green "Curated PPT" / grey "Auto-generated" badge
- Download, Upload PPT (replace), Remove buttons per row
- Inline flash messages; refresh button

**`src/app/admin/page.tsx`** — "Commentary PPTs" quick-action card added

### Storage
Cloudinary `commentary-ppt/` folder — no DB migration, no new env vars, works with existing credentials.

## ⚠️ Testing pending
User confirmed testing is pending before merge.

## Test plan
- [ ] `/admin/commentary` — lists all Sunday entries with correct badges
- [ ] Upload a `.pptx` → badge changes to "Curated PPT"
- [ ] Public "Download PPT" now serves the uploaded file
- [ ] Remove → badge reverts to "Auto-generated", download falls back to pptxgenjs
- [ ] Non-admin cannot access POST/DELETE routes (403)
- [ ] Entry with no curated file auto-generates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)