### PR TITLE
fix: Return JSON error body from PPT upload/delete routes

### DIFF
--- a/src/app/api/commentary/ppt/[id]/route.ts
+++ b/src/app/api/commentary/ppt/[id]/route.ts
@@ -67,8 +67,14 @@ export async function POST(
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())
-  const url = await uploadPPTToCloudinary(buffer, entry.id)
-  return NextResponse.json({ url })
+  try {
+    const url = await uploadPPTToCloudinary(buffer, entry.id)
+    return NextResponse.json({ url })
+  } catch (err) {
+    console.error('[PPT upload] Cloudinary error:', err)
+    const msg = err instanceof Error ? err.message : 'Upload failed'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }
 
 // DELETE — admin only: remove curated file (reverts to auto-generated)
@@ -85,6 +91,12 @@ export async function DELETE(
   const entry = await getEntry(id)
   if (!entry) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-  await deletePPTFromCloudinary(entry.id)
-  return NextResponse.json({ ok: true })
+  try {
+    await deletePPTFromCloudinary(entry.id)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('[PPT delete] Cloudinary error:', err)
+    const msg = err instanceof Error ? err.message : 'Delete failed'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary
- Wraps `uploadPPTToCloudinary` and `deletePPTFromCloudinary` calls in try/catch
- 500 responses now return `{ error: "..." }` JSON instead of an empty body
- Without this fix, empty 500 responses caused `res.json()` on the client to throw `"Unexpected end of JSON input"` — hiding the real Cloudinary error message

## Root cause
Missing Cloudinary credentials in local `.env.development` caused the SDK to throw. The unhandled promise rejection produced an empty 500, which the client couldn't parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)