### PR TITLE
refactor: Rework Church History Tree — 50+ nodes, full details, clean UI

### DIFF
--- a/src/app/eschatology/apocalyptic-literature/page.tsx
+++ b/src/app/eschatology/apocalyptic-literature/page.tsx
@@ -1,0 +1,964 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Clock,
+  Scale,
+  Lightbulb,
+  Eye,
+  Calendar,
+  AlertTriangle,
+  Hash,
+  CheckCircle,
+  XCircle,
+  ScrollText,
+  Quote,
+  Newspaper,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-is-apocalyptic'
+  | 'daniel'
+  | 'synoptic-apocalypse'
+  | 'reading-symbols'
+  | 'mistakes-to-avoid'
+  | 'catholic-hermeneutics'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-is-apocalyptic', label: 'What Is Apocalyptic?' },
+  { id: 'daniel', label: 'Daniel: The Prototype' },
+  { id: 'synoptic-apocalypse', label: 'The Synoptic Apocalypse' },
+  { id: 'reading-symbols', label: 'Reading the Symbols' },
+  { id: 'mistakes-to-avoid', label: 'Mistakes to Avoid' },
+  { id: 'catholic-hermeneutics', label: 'Catholic Hermeneutics' },
+]
+
+export default function ApocalypticLiteraturePage() {
+  const [activeTab, setActiveTab] = useState<TabId>('what-is-apocalyptic')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Apocalyptic Literature in the Bible
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            Apocalyptic literature is among the most misread genre in Scripture. Understanding how
+            ancient apocalyptic texts work &mdash; their symbols, their purpose, their historical
+            context &mdash; is essential to reading the Bible responsibly.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: WHAT IS APOCALYPTIC? ==================== */}
+        {activeTab === 'what-is-apocalyptic' && (
+          <div className="space-y-8">
+            {/* Defining Apocalyptic */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Defining Apocalyptic Literature</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The word &ldquo;Apocalypse&rdquo; comes from the Greek <em>apokalypsis</em>, meaning
+                unveiling or revelation &mdash; the pulling back of a curtain to reveal what is
+                ordinarily hidden. As a literary genre, apocalyptic flourished in Judaism roughly from
+                200 BC to 200 AD and was taken up and transformed in early Christianity.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Defining Characteristics of Apocalyptic Literature
+                </h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>1. Heavenly visions</strong> received by a human seer, often through an angelic intermediary</li>
+                  <li><strong>2. Symbolic imagery:</strong> beasts, numbers, cosmic events, strange creatures</li>
+                  <li><strong>3. Dualistic worldview:</strong> the present evil age contrasted with the coming age of God</li>
+                  <li><strong>4. Pseudonymity</strong> &mdash; often written in the name of an ancient worthy (Enoch, Abraham, Moses, Daniel)</li>
+                  <li><strong>5. Cosmic scope:</strong> angels, demons, the heavenly realm, the fate of all nations</li>
+                  <li><strong>6. Imminent crisis context:</strong> addressed to communities under severe persecution or oppression</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Key examples of apocalyptic literature include: the Book of Daniel (Old Testament),
+                1 Enoch, 4 Ezra, 2 Baruch, and &mdash; in the New Testament &mdash; the Book of
+                Revelation (the Apocalypse of St. John). Portions of the Synoptic Gospels (Mark 13,
+                Matthew 24, Luke 21) also employ apocalyptic idiom, as do passages of Paul&rsquo;s
+                letters (1 Thess 4:13&ndash;18; 2 Thess 2).
+              </p>
+            </div>
+
+            {/* Historical Context */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Historical Context of Apocalyptic</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Apocalyptic literature does not emerge in comfortable times. It is the literature of
+                communities that are suffering under foreign oppression with no political solution in
+                sight. The genre arises precisely when normal prophetic exhortation &mdash;
+                &ldquo;repent and God will restore you&rdquo; &mdash; seems inadequate to the
+                magnitude of the crisis.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Crises Behind the Texts</h3>
+                <ul className="text-blue-800 space-y-2 text-sm">
+                  <li>
+                    <strong>Jewish apocalyptic:</strong> Emerged under Greek persecution (Antiochus IV Epiphanes, 167 BC &mdash;
+                    the direct context for Daniel); continued under Roman occupation
+                  </li>
+                  <li>
+                    <strong>Christian apocalyptic (Revelation):</strong> Emerged under Roman imperial persecution,
+                    probably under Domitian (~95 AD) or possibly Nero (~65 AD)
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The message of apocalyptic literature is always essentially the same: God is in
+                control of history even when it does not appear so; the present oppressive powers will
+                fall; the suffering community will be vindicated; hold on. This is fundamentally a
+                message of <strong>encouragement</strong>, not a prophecy timetable for distant
+                future readers.
+              </p>
+            </div>
+
+            {/* Apocalyptic vs. Prophecy */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Apocalyptic vs. Prophecy</h2>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-3">Old Testament Prophecy</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Primarily <em>forth-telling</em> &mdash; speaking God&rsquo;s word to a present situation</li>
+                    <li>Secondarily <em>fore-telling</em> &mdash; announcing consequences of covenant faithfulness or unfaithfulness</li>
+                    <li>Usually specific historical referents: kings, nations, coming events</li>
+                    <li>Language is often direct and historical</li>
+                  </ul>
+                </div>
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-lg font-semibold text-purple-900 mb-3">Apocalyptic Literature</h3>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>Focused on cosmic divine intervention; present order assumed unredeemable</li>
+                    <li>Uses visionary, heavily symbolic language throughout</li>
+                    <li>Usually delivered through angelic mediators</li>
+                    <li>Expects God to break in from outside history</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The two genres overlap in several important texts: Isaiah 24&ndash;27 (often called
+                the &ldquo;Isaiah Apocalypse&rdquo;), Ezekiel 38&ndash;39 (the Gog and Magog vision),
+                and Zechariah 9&ndash;14 all employ apocalyptic idiom within the prophetic books.
+                Understanding which genre a given passage belongs to &mdash; or how it blends genres
+                &mdash; is essential for correct interpretation.
+              </p>
+            </div>
+
+            {/* Purpose of Imagery */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Lightbulb className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Purpose of Apocalyptic Imagery</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The bizarre imagery of apocalyptic texts &mdash; ten-horned beasts, whores riding
+                scarlet beasts, dragons, numbered seals &mdash; was not meant to be a literal
+                prediction map for distant future readers. It was symbolic code that the <em>original
+                readers understood</em>. It had to be encoded to protect readers if the text fell into
+                hostile hands; it was, in essence, wartime resistance literature.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Decoding the Symbols for First-Century Readers
+                </h3>
+                <ul className="text-green-800 space-y-2 text-sm">
+                  <li><strong>&ldquo;Babylon&rdquo;</strong> = Rome (the great oppressor of God&rsquo;s people in the current age)</li>
+                  <li><strong>&ldquo;The Beast&rdquo;</strong> = Nero or Domitian, depending on the date of composition</li>
+                  <li><strong>&ldquo;666&rdquo;</strong> = the numerical value (<em>gematria</em>) of &ldquo;Nero Caesar&rdquo; in Hebrew/Aramaic letters: NRWN QSR = 50+200+6+50+100+60+200 = 666</li>
+                  <li><strong>&ldquo;144,000&rdquo;</strong> = 12 &times; 12 &times; 1,000 = symbolic completeness: the fullness of God&rsquo;s people (12 tribes &times; 12 apostles &times; a great multitude)</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Far from being obscure puzzles for future generations to decode, these images were
+                immediately legible to their intended audience. The task of the modern interpreter
+                is to recover that original legibility through historical study &mdash; not to
+                project the images onto contemporary political figures.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 2: DANIEL: THE PROTOTYPE ==================== */}
+        {activeTab === 'daniel' && (
+          <div className="space-y-8">
+            {/* Daniel: Structure */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Daniel: Structure and Purpose</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Book of Daniel is the foundational apocalyptic text of the Old Testament and the
+                direct precursor to the New Testament Apocalypse. It stands in the Hebrew canon among
+                the Writings (<em>Ketuvim</em>), not the Prophets &mdash; a canonical location that
+                reflects its genre and composition history.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Structure of Daniel</h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li>
+                    <strong>Chapters 1&ndash;6:</strong> Court narratives &mdash; Daniel and his companions
+                    (Hananiah, Mishael, Azariah) in the Babylonian and Persian royal court; the fiery
+                    furnace; Daniel in the lion&rsquo;s den
+                  </li>
+                  <li>
+                    <strong>Chapters 7&ndash;12:</strong> Visionary/apocalyptic section &mdash; the four beasts,
+                    the Ancient of Days, the Son of Man, the &ldquo;abomination of desolation,&rdquo;
+                    the seventy weeks, the general resurrection
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The historical setting claimed by the book is the Babylonian exile (6th century BC).
+                However, the scholarly consensus &mdash; including among Catholic biblical scholars
+                in line with the Pontifical Biblical Commission&rsquo;s 1993 document on Scripture
+                interpretation &mdash; is that the book reached its present form in the Maccabean
+                period, around 165 BC, during the crisis of Antiochus IV Epiphanes&rsquo;s
+                persecution. The Catholic approach accepts this historical-critical context while
+                maintaining the text&rsquo;s divinely inspired and genuinely prophetic character.
+              </p>
+            </div>
+
+            {/* Four Beasts and Son of Man */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Eye className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Four Beasts and the Son of Man (Daniel 7)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Daniel 7 is one of the most important chapters in the entire Bible for understanding
+                both Jewish eschatological hope and the New Testament&rsquo;s presentation of Jesus.
+                Four great beasts rise from the sea: a lion with eagle&rsquo;s wings (Babylon), a
+                bear with ribs in its mouth (Media), a four-headed leopard (Persia), and a terrifying
+                beast with iron teeth and ten horns (the Greek/Seleucid Empire under Antiochus).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Ancient of Days and the Son of Man
+                </h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;I saw in the night visions, and behold, with the clouds of heaven there came
+                  one like a son of man, and he came to the Ancient of Days and was presented before
+                  him. And to him was given dominion and glory and a kingdom, that all peoples, nations,
+                  and languages should serve him; his dominion is an everlasting dominion, which shall
+                  not pass away.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Daniel 7:13&ndash;14</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Jesus applies &ldquo;Son of Man&rdquo; from Daniel 7:13 to himself throughout the
+                Gospels &mdash; it is the most common title Jesus uses for himself. At his trial
+                before the Sanhedrin he quotes it directly: &ldquo;you will see the Son of Man seated
+                at the right hand of Power and coming on the clouds of heaven&rdquo; (Matt 26:64).
+                The key theological point: the four kingdoms of the world are temporary; the kingdom
+                given to the &ldquo;one like a son of man&rdquo; is eternal.
+              </p>
+            </div>
+
+            {/* The Seventy Weeks */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Seventy Weeks (Daniel 9)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Daniel 9:24&ndash;27, the &ldquo;Seventy Weeks&rdquo; prophecy, is perhaps the most
+                calculated-over passage in all of biblical prophecy. Every major end-times system has
+                used it to construct prophetic timelines; it has generated centuries of interpretive
+                conflict. Understanding what the text says &mdash; and what Catholic tradition requires
+                us to believe about it &mdash; is important for responsible reading.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The Key Passage
+                </h3>
+                <p className="text-purple-800 italic mb-3">
+                  &ldquo;Seventy weeks are decreed for your people and your holy city, to finish
+                  the transgression, to put an end to sin, and to atone for iniquity, to bring in
+                  everlasting righteousness, to seal both vision and prophet, and to anoint a most
+                  holy place.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm">&mdash; Daniel 9:24</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The Catholic interpretation, following the Fathers and mainstream Catholic
+                scholarship, reads this passage as fulfilled in the first coming of Christ and the
+                events of 70 AD: the &ldquo;cutting off of the anointed one&rdquo; refers to the
+                death of Christ; the &ldquo;abomination of desolation&rdquo; refers both to
+                Antiochus IV&rsquo;s desecration of the Temple (167 BC, the original historical
+                referent) and to the Roman destruction of Jerusalem (70 AD), with a possible
+                further eschatological fulfillment. The Church does not require any specific
+                literalistic fulfillment chart; the text is prophetic, not a timetable.
+              </p>
+            </div>
+
+            {/* Abomination of Desolation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Abomination of Desolation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The phrase &ldquo;the abomination that causes desolation&rdquo; (Dan 9:27, 11:31,
+                12:11) is one of the most-discussed phrases in all of biblical prophecy. It has been
+                read as referring to: (1) the altar of Zeus installed in the Jerusalem Temple by
+                Antiochus IV Epiphanes in 167 BC, including his sacrifice of a pig; (2) the Roman
+                destruction of Jerusalem in 70 AD (Jesus&rsquo;s explicit usage in Matt 24:15); and
+                (3) a still-future eschatological figure or event at the end of the age.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">Catholic Position (CCC 675&ndash;677)</h3>
+                <p className="text-red-800 mb-3">
+                  The Catechism acknowledges a &ldquo;final trial&rdquo; before the end of the age,
+                  associated with the figure of &ldquo;the Antichrist&rdquo; &mdash; &ldquo;a
+                  religious deception offering men an apparent solution to their problems at the price
+                  of apostasy from the truth.&rdquo; However, the Church resists precise prophetic
+                  mapping. The text has already been fulfilled historically; further fulfillment is
+                  acknowledged as possible but cannot be precisely charted.
+                </p>
+                <p className="text-red-700 text-sm">&mdash; CCC 675&ndash;677</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE SYNOPTIC APOCALYPSE ==================== */}
+        {activeTab === 'synoptic-apocalypse' && (
+          <div className="space-y-8">
+            {/* The Little Apocalypse */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Mark 13 / Matthew 24 / Luke 21: The &ldquo;Little Apocalypse&rdquo;</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                All three Synoptic Gospels record Jesus&rsquo;s extended discourse about future
+                events, delivered on the Mount of Olives shortly before his Passion. This discourse
+                has been called the &ldquo;Synoptic Apocalypse&rdquo; or the &ldquo;Little
+                Apocalypse&rdquo; because it employs the language and imagery of the apocalyptic
+                genre.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Context and the Double Horizon</h3>
+                <p className="text-amber-800 mb-3">
+                  The disciples admire the Temple stones; Jesus predicts the Temple&rsquo;s
+                  destruction (&ldquo;not one stone will be left upon another&rdquo;, fulfilled in
+                  70 AD). They ask two questions: <em>when</em> will this happen? And <em>what</em>{' '}
+                  will be the sign of the end of the age? Jesus&rsquo;s answer interweaves two
+                  distinct horizons: (1) the imminent fall of Jerusalem (fulfilled 70 AD) and (2)
+                  the final end of the age (future). This <strong>&ldquo;double horizon&rdquo;</strong>{' '}
+                  is the key to understanding the entire discourse &mdash; and the primary reason
+                  it is so frequently misread.
+                </p>
+              </div>
+            </div>
+
+            {/* Fulfilled in 70 AD */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Was Fulfilled in 70 AD</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A careful reading of the discourse shows that many of its elements were fulfilled
+                within the lifetime of Jesus&rsquo;s original hearers, in the catastrophe of the
+                First Jewish-Roman War (66&ndash;73 AD) and the Roman destruction of Jerusalem and
+                its Temple.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Historically Fulfilled Predictions
+                </h3>
+                <ul className="text-green-800 space-y-2 text-sm">
+                  <li><strong>&ldquo;Not one stone upon another&rdquo;:</strong> The Romans dismantled the Temple in 70 AD; confirmed by archaeology</li>
+                  <li><strong>False messiahs and prophets:</strong> The Jewish historian Josephus documents multiple false messiahs active during the Jewish War</li>
+                  <li><strong>&ldquo;Nation against nation&rdquo;:</strong> The Jewish-Roman War was precisely this</li>
+                  <li><strong>&ldquo;The abomination of desolation&rdquo;:</strong> Luke 21:20 makes the referent explicit &mdash; &ldquo;When you see Jerusalem surrounded by armies, know that its desolation is at hand&rdquo;</li>
+                  <li><strong>&ldquo;Flee to the mountains&rdquo;:</strong> Historically, Christians fled to Pella before the Roman siege</li>
+                  <li><strong>&ldquo;This generation will not pass away&rdquo; (Matt 24:34):</strong> Jesus speaking of the 70 AD events; fulfilled within the lifetimes of his hearers</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* What Remains Future */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Remains Future</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                While many verses of the discourse describe the 70 AD crisis, others clearly look
+                beyond it to the end of the age. The Catholic reading (CCC 673&ndash;677) holds both
+                horizons together, refusing to collapse all of the discourse into either the past
+                or a purely future event.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Second Horizon: The Parousia
+                </h3>
+                <ul className="text-blue-800 space-y-2 text-sm">
+                  <li><strong>Cosmic signs (Matt 24:29):</strong> &ldquo;After the tribulation of those days the sun will be darkened&rdquo; &mdash; language of the Parousia, not 70 AD</li>
+                  <li><strong>The sign of the Son of Man (Matt 24:30):</strong> &ldquo;Then will appear in heaven the sign of the Son of Man&hellip; they will see the Son of Man coming on the clouds of heaven&rdquo; &mdash; the Second Coming</li>
+                  <li><strong>No one knows the hour (Matt 24:36):</strong> &ldquo;Of that day or hour no one knows, not even the angels of heaven, nor the Son, but only the Father&rdquo; &mdash; we cannot calculate the date of the Parousia</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Catholic approach (CCC 673&ndash;677) holds a &ldquo;double horizon&rdquo;
+                reading: some verses were fulfilled in 70 AD; the final fulfillment at the Parousia
+                remains future. No detailed chronological timetable is prescribed. The emphatic
+                point of &ldquo;no one knows the hour&rdquo; stands against all end-times
+                date-setting.
+              </p>
+            </div>
+
+            {/* The Fig Tree Parable */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Fig Tree Parable</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Matt 24:32&ndash;35: &ldquo;From the fig tree learn its lesson: as soon as its branch
+                becomes tender and puts out its leaves, you know that summer is near. So also, when
+                you see all these things, you know that he is near, at the very gates. Truly, I say
+                to you, this generation will not pass away until all these things take place.&rdquo;
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  A Frequently Misread Passage
+                </h3>
+                <p className="text-red-800 mb-3">
+                  Many end-times teachers read the &ldquo;fig tree&rdquo; as a symbol for Israel,
+                  interpret &ldquo;putting out its leaves&rdquo; as the establishment of the modern
+                  Israeli state (1948), and then calculate &ldquo;this generation&rdquo; as 40&ndash;80
+                  years &mdash; yielding predictions of the end by 1988 or 2028. This reading has
+                  no support in Catholic tradition and repeatedly fails.
+                </p>
+                <ul className="text-red-700 text-sm space-y-1">
+                  <li><strong>Problem 1:</strong> In context, &ldquo;fig tree&rdquo; is a seasonal parable, not a national symbol</li>
+                  <li><strong>Problem 2:</strong> &ldquo;This generation&rdquo; in context refers to Jesus&rsquo;s own hearers (the 70 AD events)</li>
+                  <li><strong>Problem 3:</strong> Jesus explicitly states no one knows the hour &mdash; making all calculations invalid</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 4: READING THE SYMBOLS ==================== */}
+        {activeTab === 'reading-symbols' && (
+          <div className="space-y-8">
+            {/* Numbers */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Hash className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Numbers in Apocalyptic Literature</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Numbers in apocalyptic literature are symbolic, not literal. This is one of the most
+                important interpretive keys for reading Daniel and Revelation responsibly. Ancient
+                readers understood this instinctively; modern Western readers, trained in literal
+                numerical thinking, often do not.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Key Symbolic Numbers</h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>7:</strong> Perfection, completeness (7 churches, 7 seals, 7 trumpets, 7 bowls in Revelation)</li>
+                  <li><strong>12:</strong> God&rsquo;s people (12 tribes + 12 apostles; 144,000 = 12&times;12&times;1,000 = symbolic fullness of the saved)</li>
+                  <li><strong>3.5 (half of 7):</strong> A time of testing and incompleteness; &ldquo;42 months,&rdquo; &ldquo;1,260 days,&rdquo; and &ldquo;time, times, and half a time&rdquo; all denote the same period (Dan 7:25, Rev 12:6, 12:14)</li>
+                  <li><strong>1,000 (<em>chilias</em>):</strong> A very large indefinite number; completeness; divine time. &ldquo;1,000 years&rdquo; (the Millennium in Rev 20) is almost certainly symbolic of the Church age, not a literal thousand-year period</li>
+                  <li><strong>40:</strong> Testing (40 years in the desert; 40 days of Jesus&rsquo;s temptation)</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Beasts and Animals */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Eye className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Beasts, Animals, and Imagery</h2>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-3">Revelation&rsquo;s Symbolic World</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li><strong>The Beast from the sea (Rev 13):</strong> Rome / the Roman Empire; the seven heads = seven hills of Rome (17:9) and/or seven emperors</li>
+                    <li><strong>666:</strong> Gematria of &ldquo;Nero Caesar&rdquo; in Hebrew (NRWN QSR = 666); a mockery of imperial claims to divinity</li>
+                    <li><strong>The Whore of Babylon (Rev 17&ndash;18):</strong> Rome, the city of seven hills (17:9), &ldquo;drunk with the blood of the saints&rdquo;</li>
+                    <li><strong>The dragon:</strong> Satan, explicitly identified in Rev 12:9</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-3">More Symbolic Figures</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li><strong>The woman clothed with the sun (Rev 12):</strong> Israel / the Church / Mary &mdash; multiple levels of meaning</li>
+                    <li><strong>White, red, black horses (Rev 6):</strong> Conquest, war, famine, death &mdash; classic biblical imagery for divine judgment</li>
+                    <li><strong>The Lamb (Rev 5):</strong> The risen Christ who was &ldquo;slain&rdquo; &mdash; the paradox of weakness that is ultimate power</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* The Millennium */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Millennium (Rev 20:1&ndash;6)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation 20:1&ndash;6 describes Satan being bound for a thousand years while
+                those who had been beheaded for their testimony &ldquo;came to life and reigned
+                with Christ for a thousand years.&rdquo; This is the most contested passage in all
+                of Revelation. Three main interpretive traditions have developed around it.
+              </p>
+
+              <div className="grid sm:grid-cols-3 gap-4 mb-6">
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <h4 className="font-semibold text-blue-900 mb-2 text-sm">Premillennialism</h4>
+                  <p className="text-blue-800 text-sm">Christ returns <em>before</em> the millennium and literally reigns 1,000 years on earth from Jerusalem. Popular in Protestant evangelical circles, especially Dispensationalism.</p>
+                </div>
+                <div className="bg-green-50 p-4 rounded-lg">
+                  <h4 className="font-semibold text-green-900 mb-2 text-sm">Amillennialism (Catholic Mainstream)</h4>
+                  <p className="text-green-800 text-sm">The &ldquo;1,000 years&rdquo; symbolizes the <em>current</em> Church age; Christ already reigns through the Church; Satan is &ldquo;bound&rdquo; in the sense that the Gospel can spread to all nations.</p>
+                </div>
+                <div className="bg-purple-50 p-4 rounded-lg">
+                  <h4 className="font-semibold text-purple-900 mb-2 text-sm">Postmillennialism</h4>
+                  <p className="text-purple-800 text-sm">The Gospel gradually Christianizes the world; a golden age precedes Christ&rsquo;s return. Less common in contemporary Catholic thought.</p>
+                </div>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  The Catholic Magisterium: CCC 676
+                </h3>
+                <p className="text-red-800 italic mb-3">
+                  &ldquo;The Antichrist&rsquo;s deception already begins to take shape in the world
+                  every time the claim is made to realize within history that messianic hope which
+                  can only be realized beyond history through the eschatological judgement. The Church
+                  has rejected even modified forms of this falsification of the kingdom to come under
+                  the name of millenarianism.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm">&mdash; CCC 676</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 5: MISTAKES TO AVOID ==================== */}
+        {activeTab === 'mistakes-to-avoid' && (
+          <div className="space-y-8">
+            {/* Fundamentalism */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Fundamentalism / Hyper-Literalism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The most common interpretive error in popular culture is reading apocalyptic
+                literature as if it were a newspaper &mdash; treating symbolic numbers as literal,
+                symbolic beasts as identifiable political entities, and the visionary sequences as
+                a chronological timeline of future events. This approach ignores the historical and
+                literary context in which God chose to communicate.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  The PBC&rsquo;s Judgment (1993)
+                </h3>
+                <p className="text-red-800 italic mb-3">
+                  &ldquo;The fundamentalist approach is dangerous, for it is attractive to people
+                  who look to the Bible for ready answers to the problems of life. It can deceive
+                  these people, offering them interpretations that are pious but illusory, instead
+                  of telling them that the Bible does not necessarily contain an immediate answer
+                  to each and every problem. Without saying as much in so many words, fundamentalism
+                  actually invites people to a kind of intellectual suicide.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm">
+                  &mdash; Pontifical Biblical Commission, <em>The Interpretation of the Bible in the Church</em> (1993), I.F
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The practical consequences of hyper-literalism in prophecy interpretation have been
+                severe: repeated prediction failures, sensationalism, and people making costly life
+                decisions based on false timelines. Examples of failed predictions: William Miller
+                (Baptist, 1844), Charles Russell (Jehovah&rsquo;s Witnesses, 1914), Harold Camping
+                (1994, 2011). Every failed prediction further damages the credibility of
+                Christian witness.
+              </p>
+            </div>
+
+            {/* Newspaper Exegesis */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Newspaper className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Newspaper Exegesis Fallacy</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Closely related to fundamentalism is the practice of reading Revelation (or Daniel,
+                or Matthew 24) as a coded map of current events &mdash; finding the
+                &ldquo;Antichrist&rdquo; in each successive political figure and the &ldquo;Mark
+                of the Beast&rdquo; in each new technology. This approach treats the Bible as an
+                oracle aimed at our own historical moment rather than a book addressed first to
+                its original audience.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  A Recurring Pattern of Failure
+                </h3>
+                <p className="text-red-800 mb-3">
+                  Historical figures identified by various interpreters as &ldquo;the
+                  Antichrist&rdquo; or &ldquo;the Beast&rdquo;: Napoleon, Kaiser Wilhelm, Hitler,
+                  Stalin, Mussolini, Henry Kissinger, Pope John Paul II, Ronald Reagan, various
+                  US Presidents, the European Union, the United Nations, barcodes, RFID chips,
+                  and COVID-19 vaccines &mdash; all identified and all wrong. The identification
+                  is always contemporary; it always fails when the figure passes.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Catholic principle: Revelation was written for its original first-century
+                audience; its primary referent was the Roman Empire. Its universal message &mdash;
+                God wins; the powers of oppression fall; bear up under persecution &mdash; applies
+                to every age without requiring a specific decoded political map.
+              </p>
+            </div>
+
+            {/* Rapture */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <XCircle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Separating &ldquo;Rapture&rdquo; from Biblical Text</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The &ldquo;Rapture&rdquo; &mdash; the pre-Tribulation secret disappearance of
+                Christians before the end &mdash; is not found in Catholic tradition, in Eastern
+                Orthodox tradition, or in any Protestant theology before the 1830s. It originates
+                with John Nelson Darby (Plymouth Brethren, c. 1830&ndash;1835), based on a
+                particular reading of 1 Thess 4:17 (&ldquo;caught up together in the clouds to meet
+                the Lord in the air&rdquo;).
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  The Catholic Reading of 1 Thess 4:17
+                </h3>
+                <p className="text-red-800 mb-3">
+                  The phrase &ldquo;meeting in the air&rdquo; (<em>apant&#275;sis</em>) refers to a
+                  Roman civic custom: when a dignitary or emperor was arriving at a city, the
+                  citizens went out <em>to meet</em> him and then escort him back into the city.
+                  Paul&rsquo;s image is a royal reception of the returning Christ, not a secret
+                  escape from tribulation. No Church Father, no medieval theologian, no
+                  Reformer taught a pre-Tribulation Rapture.
+                </p>
+              </div>
+            </div>
+
+            {/* Over-spiritualizing */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Over-Spiritualizing / De-Historicizing</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The opposite error is treating all eschatological language as purely spiritual or
+                metaphorical, with no real future reference. Some liberal Protestant and progressive
+                Catholic thinkers have reduced the Second Coming to a metaphor for moral progress,
+                or the resurrection to a symbol for spiritual renewal rather than a bodily event.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catholic Teaching: Real Future Events
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Catholic teaching firmly maintains: the Second Coming (Parousia) is a real future
+                  event in history&rsquo;s culmination; the bodily resurrection of the dead is real;
+                  the Last Judgment is real; the New Creation is real. These are not metaphors
+                  for progress &mdash; they are the content of Christian hope.
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 647, 988&ndash;991, 1038&ndash;1041</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 6: CATHOLIC HERMENEUTICS ==================== */}
+        {activeTab === 'catholic-hermeneutics' && (
+          <div className="space-y-8">
+            {/* Catholic Approach */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Catholic Approach to Apocalyptic Texts</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catholic Church&rsquo;s approach to apocalyptic literature is neither hyper-literal
+                nor purely allegorical. It reads these texts within the whole of Scripture and
+                Tradition, attends to their historical context, and applies the Church&rsquo;s
+                interpretive principles consistently. Five key principles govern the approach.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Five Catholic Interpretive Principles</h3>
+                <ol className="text-amber-800 space-y-2 text-sm list-decimal list-inside">
+                  <li>Read within the whole of Scripture and Tradition &mdash; no isolated proof-texts</li>
+                  <li>Identify the literary genre (CCC 116; <em>Dei Verbum</em> 12): apocalyptic is not history or prediction-chart</li>
+                  <li>Attend to the historical context: who wrote it, to whom, and in what crisis situation</li>
+                  <li>Apply the four senses: literal (original audience), allegorical (christological meaning), moral (ethical application), anagogical (final destination of history)</li>
+                  <li>Trust the Church&rsquo;s interpretive tradition, particularly the Fathers and the Councils</li>
+                </ol>
+              </div>
+            </div>
+
+            {/* Key Magisterial Guidance */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Key Magisterial Guidance</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  <em>Dei Verbum</em> 12 (Vatican II, 1965)
+                </h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;The interpreter of sacred Scripture, in order to see clearly what God wanted
+                  to communicate to us, should carefully investigate what meaning the sacred writers
+                  really intended, and what God wanted to manifest by means of their words. In
+                  determining the intention of the sacred writers, attention must be paid, among other
+                  things, to literary genres.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Dei Verbum</em> 12</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Pontifical Biblical Commission (1993)
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  The PBC&rsquo;s landmark document <em>The Interpretation of the Bible in the
+                  Church</em> warns explicitly against &ldquo;fundamentalist interpretation&rdquo;
+                  which &ldquo;does not take into account the historical character of biblical
+                  revelation&rdquo; and &ldquo;makes itself look deceptively attractive to people
+                  who look to the Bible for ready answers to the problems of life.&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">CCC 676: Against Millenarianism</h3>
+                <p className="text-red-800 italic mb-3">
+                  &ldquo;The Church has rejected even modified forms of this falsification of the
+                  kingdom to come under the name of millenarianism, especially the &lsquo;intrinsically
+                  perverse&rsquo; political form of a secular messianism.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm">&mdash; CCC 676</p>
+              </div>
+            </div>
+
+            {/* Church Fathers on Revelation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Quote className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Church Fathers on Revelation</h2>
+              </div>
+
+              <div className="space-y-4">
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">Justin Martyr (d. ~165 AD)</h3>
+                  <p className="text-purple-800 text-sm">
+                    One of the earliest commentators on Revelation; anticipated a literal millennium.
+                    This early premillennialism was widespread in the 2nd century but declined as the
+                    Church developed a more sophisticated scriptural hermeneutic.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">Origen (~184&ndash;253 AD)</h3>
+                  <p className="text-purple-800 text-sm">
+                    Championed allegorical interpretation throughout Scripture; warned consistently
+                    against hyper-literalism in prophetic texts. His approach to Revelation was
+                    primarily symbolic and spiritual.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">St. Augustine, <em>City of God</em> Book XX (~420 AD)</h3>
+                  <p className="text-purple-800 text-sm">
+                    The most influential reading of Revelation in Catholic history. Augustine
+                    established the amillennialist interpretation that has been dominant in Catholicism
+                    ever since: the &ldquo;1,000 years&rdquo; symbolizes the Church age from the
+                    Incarnation to the Parousia; the &ldquo;first resurrection&rdquo; is spiritual
+                    regeneration (baptism and conversion), not a literal bodily event.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">St. Jerome (d. 420 AD)</h3>
+                  <p className="text-purple-800 text-sm">
+                    Warned against the Millenarians (premillennialists) of his day. His objections,
+                    combined with Augustine&rsquo;s positive alternative, effectively ended mainstream
+                    premillennialism in Catholic theology for over a millennium.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Approved Reading Resources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Approved Reading Resources</h2>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-amber-900 mb-3">Magisterial Documents</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li><em>Catechism of the Catholic Church</em>, 668&ndash;682, 1020&ndash;1060</li>
+                    <li><em>Dei Verbum</em> (Vatican II, 1965)</li>
+                    <li>Pontifical Biblical Commission, <em>The Interpretation of the Bible in the Church</em> (1993)</li>
+                    <li>Augustine, <em>City of God</em>, Book XX</li>
+                  </ul>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-amber-900 mb-3">Scholarly Works</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>Joseph Ratzinger / Benedict XVI, <em>Eschatology: Death and Eternal Life</em> (CUA Press, 1988)</li>
+                    <li>N.T. Wright, <em>Surprised by Hope</em> (HarperOne, 2008)</li>
+                    <li>G.K. Beale, <em>The Book of Revelation</em> (NIGTC, 1999)</li>
+                    <li>Raymond Brown, <em>An Introduction to the New Testament</em> (Doubleday, 1997)</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/eschatology/catholic-vs-protestant/page.tsx
+++ b/src/app/eschatology/catholic-vs-protestant/page.tsx
@@ -1,0 +1,694 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  CheckCircle,
+  Users,
+  BookOpen,
+  XCircle,
+  Clock,
+  Scale,
+  Church,
+  MapPin,
+  Flame,
+  Layers,
+  Heart,
+} from 'lucide-react'
+
+type TabId =
+  | 'common-ground'
+  | 'the-rapture-response'
+  | 'the-millennium'
+  | 'israel-end-times'
+  | 'purgatory-eschatology'
+  | 'different-frameworks'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'common-ground', label: 'Common Ground' },
+  { id: 'the-rapture-response', label: 'The Rapture: Catholic Response' },
+  { id: 'the-millennium', label: 'The Millennium' },
+  { id: 'israel-end-times', label: 'Israel & End Times' },
+  { id: 'purgatory-eschatology', label: 'Purgatory' },
+  { id: 'different-frameworks', label: 'Different Frameworks' },
+]
+
+export default function CatholicVsProtestantPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('common-ground')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Catholic vs. Protestant End Times
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            Catholics and most Protestants share the essential eschatological beliefs: Christ will
+            return, the dead will be raised, there will be a Last Judgment. But on the Rapture,
+            the Millennium, Israel, and Purgatory they differ significantly. This page examines
+            both the common ground and the differences honestly.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: COMMON GROUND ==================== */}
+        {activeTab === 'common-ground' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What All Orthodox Christians Share</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Before exploring the differences, it is vital to affirm the very substantial eschatological
+                confession that Catholics and Protestants share. The Nicene Creed &mdash; &ldquo;He will
+                come again in glory to judge the living and the dead, and his kingdom will have no end&rdquo;
+                &mdash; is recited by both every Sunday.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">Shared Confessions</h3>
+                <ul className="text-green-800 space-y-2">
+                  <li>The Second Coming: Christ will return personally, visibly, bodily (Acts 1:11)</li>
+                  <li>The Resurrection of the Dead: All who have ever lived will be raised
+                  (John 5:28&ndash;29; 1 Cor 15:51&ndash;52)</li>
+                  <li>The Last Judgment: All will be judged by Christ (Matt 25:31&ndash;46; 2 Cor 5:10)</li>
+                  <li>Heaven and Hell as real eternal destinies &mdash; not universal salvation</li>
+                  <li>The defeat of Satan and all evil</li>
+                  <li>A New Heaven and New Earth (Rev 21:1; 2 Pet 3:13)</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This is a very substantial common confession. The differences are real, but they exist
+                within a framework of deep agreement about the ultimate shape of history and its end.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Where Most Protestants and Catholics Agree (Against Dispensationalism)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholics are often surprised to discover that many of their eschatological positions
+                are shared by the mainstream of historic Protestant theology. The real divide is not
+                between Catholics and Protestants as such, but between the Catholic and historic
+                Protestant mainstream on one side and 19th-century Dispensationalism on the other.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-3">
+                  <li><strong>No pre-tribulation Rapture:</strong> Rejected by Catholics, most mainline
+                  Protestants, Lutherans, Anglicans, Reformed Presbyterians, and Orthodox Christians.
+                  Not just a Catholic position.</li>
+                  <li><strong>Amillennialism:</strong> The dominant position of Augustine, the Reformed
+                  tradition, Lutheran theology, and Catholicism. No future literal millennium.</li>
+                  <li><strong>No separate eschatological track for national Israel:</strong> Paul&rsquo;s
+                  teaching in Romans 9&ndash;11 and Ephesians 2 is read as one people of God, not
+                  two parallel tracks.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Critical point: Catholics are not the only ones rejecting Dispensationalism; they share
+                their position with the majority of the world&rsquo;s historical Protestant theologians.
+                The caricature of &ldquo;all Protestants believe in the Rapture&rdquo; is simply false.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 2: THE RAPTURE: CATHOLIC RESPONSE ==================== */}
+        {activeTab === 'the-rapture-response' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Key Text and Catholic Reading</h2>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;For the Lord himself will descend from heaven with a cry of command, with the
+                  voice of an archangel, and with the sound of the trumpet of God. And the dead in Christ
+                  will rise first. Then we who are alive, who are left, will be caught up together with
+                  them in the clouds to meet the Lord in the air, and so we will always be with the
+                  Lord.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; 1 Thessalonians 4:16&ndash;17 (RSV)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholic interpretation: this describes <em>one</em> event &mdash; the Second Coming
+                with the resurrection of the dead. The &ldquo;meeting in the air&rdquo; (Greek:
+                <em> apant&#275;sis</em>) is a technical term for a royal reception. When a king or
+                general arrived at a city, citizens came out to <em>meet</em> him and <em>escort him in</em>.
+                Paul uses this deliberately: we go out to meet the coming Christ and escort him as the
+                victorious King.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                There is no &ldquo;escape from earth&rdquo; &mdash; we go out to meet him and come
+                back with him to the renewed creation. This is not a departure; it is a coronation
+                procession.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <XCircle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">No &ldquo;Secret&rdquo; Rapture in the Text</h2>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <ul className="text-red-800 space-y-3">
+                  <li>1 Thess 4:16 specifies: &ldquo;a cry of command,&rdquo; &ldquo;the voice of an
+                  archangel,&rdquo; &ldquo;the sound of the trumpet of God&rdquo; &mdash; nothing
+                  secret about it.</li>
+                  <li>Matt 24:27: &ldquo;As the lightning comes from the east and shines as far as
+                  the west, so will be the coming of the Son of Man&rdquo; &mdash; visible, unmistakable,
+                  global.</li>
+                  <li>1 Cor 15:51&ndash;52: &ldquo;We shall all be changed, in a moment, in the
+                  twinkling of an eye, at the <em>last</em> trumpet&rdquo; &mdash; the resurrection
+                  happens at &ldquo;the last trumpet,&rdquo; the same trumpet as 1 Thess 4.</li>
+                  <li>There is <em>one</em> coming, <em>one</em> trumpet, <em>one</em> resurrection,
+                  <em> one</em> event in the NT &mdash; not a two-stage process separated by seven years.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Historical Argument</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Every Church Father expected Christians to face tribulation and persecution &mdash; they
+                did not expect a pre-tribulation escape.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-2">
+                  <li>The early Church was martyred under Nero and Domitian; they did not interpret their
+                  suffering as tribulation that &ldquo;true Christians&rdquo; would be spared</li>
+                  <li>Polycarp (~155 AD), Ignatius (~107 AD), Justin Martyr (~165 AD), Irenaeus (~200 AD),
+                  Tertullian (~200 AD), Origen, Athanasius, Augustine &mdash; none taught a pre-tribulation
+                  Rapture</li>
+                  <li>The concept simply did not exist until John Nelson Darby in the 1830s &mdash; this
+                  is the unanimous judgment of church-history scholarship</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Matt 24:40&ndash;41: &ldquo;One Taken, One Left&rdquo;</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This passage is commonly used to support the Rapture: &ldquo;Two men will be in the
+                field; one will be taken and one left.&rdquo;
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Context Reverses the Rapture Reading</h3>
+                <p className="text-blue-800 mb-3">
+                  Jesus compares the coming of the Son of Man to Noah&rsquo;s flood (Matt 24:37&ndash;42).
+                  In the flood, those &ldquo;taken away&rdquo; were the <em>wicked</em> &mdash; they
+                  drowned. The survivors were <em>left</em> (on the ark). The &ldquo;taken&rdquo; in
+                  Matt 24 are taken <em>in judgment</em>; the &ldquo;left&rdquo; are those who survive.
+                  This is the exact opposite of the Rapture reading.
+                </p>
+                <p className="text-blue-800">
+                  Luke 17:37 confirms: when the disciples ask &ldquo;Where?&rdquo; (where are the
+                  taken?), Jesus answers: &ldquo;Where the corpse is, there the vultures will gather&rdquo;
+                  &mdash; the taken go to <em>judgment</em>.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE MILLENNIUM ==================== */}
+        {activeTab === 'the-millennium' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Revelation 20:1&ndash;6: The Text</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The entire doctrine of the literal Millennium rests on this one passage (six verses)
+                in Revelation &mdash; a book written entirely in the apocalyptic genre, where numbers
+                are symbolic throughout.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;Then I saw an angel coming down from heaven&hellip; He seized the dragon,
+                  that ancient serpent, who is the devil and Satan, and bound him for a thousand
+                  years&hellip; Then I saw thrones, and seated on them were those to whom the
+                  authority to judge was committed&hellip; They came to life and reigned with Christ
+                  for a thousand years.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; Revelation 20:1&ndash;4 (RSV)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Key features: an angel binds Satan; a &ldquo;first resurrection&rdquo;; a 1,000-year
+                reign; then Satan is released, defeated, and the Last Judgment follows. The question
+                is whether these elements describe a literal future period or the spiritual reality
+                of the present Church age.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Why 1,000 Years Is Symbolic</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-3">
+                  <li>In apocalyptic literature, numbers are consistently symbolic. &ldquo;1,000&rdquo;
+                  = 10&sup3; = ultimate completeness (cf. Ps 50:10 &ldquo;cattle on a thousand hills&rdquo;
+                  = all cattle; Deut 7:9 &ldquo;to a thousand generations&rdquo; = forever).</li>
+                  <li>In Revelation itself: 144,000 = 12 &times; 12 &times; 1,000 = symbolic fullness
+                  of God&rsquo;s people (not a literal headcount).</li>
+                  <li>&ldquo;A thousand years&rdquo; = a very long, complete period &mdash; the entire
+                  Church age from the Resurrection to the Second Coming.</li>
+                  <li>Taking <em>one</em> number literally (1,000 years in Rev 20) while treating all
+                  other Revelation numbers symbolically is inconsistent hermeneutics.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <XCircle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The CCC Rejection of Millenarianism</h2>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <p className="text-red-800 italic mb-3">
+                  &ldquo;The Antichrist&rsquo;s deception already begins to take shape in the world
+                  every time the claim is made to realize within history that messianic hope which can
+                  only be realized beyond history through the eschatological judgment. The Church has
+                  rejected even modified forms of this falsification of the kingdom to come under the
+                  name of millenarianism.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm">&mdash; <em>Catechism of the Catholic Church</em>, 676</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This is a clear, direct magisterial rejection of literalist premillennialism &mdash;
+                including Dispensationalism. The Church&rsquo;s teaching: there will be no earthly
+                golden age of Church or Kingdom power before the Paro&uuml;sia. The &ldquo;millennium&rdquo;
+                is already happening now &mdash; it is the Church age.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Augustine: The Definitive Catholic Reading</h2>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  <em>City of God</em>, Book XX (~420 AD)
+                </h3>
+                <ul className="text-purple-800 space-y-3">
+                  <li><strong>&ldquo;The thousand years&rdquo;:</strong> The entire period from Christ&rsquo;s
+                  first coming to the final persecution &mdash; the Church age.</li>
+                  <li><strong>&ldquo;Satan bound&rdquo;:</strong> Satan&rsquo;s power to blind the
+                  nations is limited; the Gospel can now spread to all peoples (Matt 12:29).</li>
+                  <li><strong>&ldquo;First resurrection&rdquo;:</strong> The spiritual resurrection of
+                  conversion and baptism &mdash; &ldquo;the hour is coming, and now is, when the dead
+                  will hear the voice of the Son of God&rdquo; (John 5:25).</li>
+                  <li><strong>&ldquo;The second death&rdquo;:</strong> Eternal separation from God, from
+                  which the spiritually resurrected are safe.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Augustine&rsquo;s reading governed Catholicism, Reformed Protestantism, and Lutheran
+                theology from the 5th century onward. It remains the dominant position across all
+                historic Christian traditions today.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 4: ISRAEL & END TIMES ==================== */}
+        {activeTab === 'israel-end-times' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Dispensationalist View of Israel</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Central to classic Dispensationalism is its doctrine of two peoples of God with distinct
+                eternal destinies. This is perhaps its most distinctive and most contested teaching.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-3">
+                  <li>God has two peoples &mdash; Israel (earthly) and the Church (heavenly) &mdash; with
+                  separate covenants and distinct eternal destinies</li>
+                  <li>The Church age is a &ldquo;parenthesis&rdquo; in God&rsquo;s plan for Israel;
+                  after the Rapture, God resumes his direct dealings with Israel</li>
+                  <li>The establishment of the modern State of Israel (1948) = prophetic fulfillment</li>
+                  <li>A rebuilt Temple in Jerusalem is expected; the Antichrist signs and then breaks
+                  a peace treaty with Israel</li>
+                  <li>The 144,000 (Rev 7) = literal Jewish evangelists who convert during the Tribulation</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Catholic and Reformed Protestant View</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">One People of God in Christ</h3>
+                <ul className="text-blue-800 space-y-3">
+                  <li>Paul (Gal 3:28&ndash;29; Rom 4:11&ndash;17; Eph 2:11&ndash;22): Gentile believers
+                  are &ldquo;grafted in&rdquo; to the one olive tree (Israel); there is &ldquo;neither
+                  Jew nor Greek&rdquo; in Christ.</li>
+                  <li>The Church is the fulfillment of Israel&rsquo;s calling &mdash; not a replacement
+                  but an organic completion; the promises to Abraham are fulfilled in Christ and in
+                  those who belong to Christ.</li>
+                  <li>CCC 674: &ldquo;The glorious Messiah&rsquo;s coming is suspended at every moment
+                  of history until his recognition by &lsquo;all Israel&rsquo;&rdquo; &mdash; Romans
+                  11:25&ndash;26 speaks of a future conversion of the Jewish people near the end.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This is not the Dispensationalist scenario; it is an organic fulfillment of Israel&rsquo;s
+                own messianic hope in Jesus Christ, achieved through the same Gospel, not through a
+                separate &ldquo;Israel track&rdquo; that bypasses the Cross.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Romans 11: The Catholic Reading</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Romans 9&ndash;11 is the most sustained NT treatment of Israel&rsquo;s relationship
+                to the Church and to salvation. Paul concludes with a mystery:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;A partial hardening has come upon Israel, until the fullness of the Gentiles
+                  has come in. And in this way all Israel will be saved.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-4">&mdash; Romans 11:25&ndash;26 (RSV)</p>
+                <p className="text-blue-800">
+                  Catholic interpretation: there will be a future conversion of many (perhaps most)
+                  Jewish people to Jesus as their Messiah near the end of history &mdash; not through
+                  a separate &ldquo;Israel track&rdquo; but through the same Gospel that the Church
+                  has always preached. CCC 674 identifies this conversion as the event that precedes
+                  the Paro&uuml;sia.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 5: PURGATORY ==================== */}
+        {activeTab === 'purgatory-eschatology' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Purgatory as Eschatological Stage</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Purgatory is uniquely Catholic (and Orthodox in modified form). Mainstream Protestants
+                rejected it at the Reformation: Luther rejected indulgences and ultimately purgatory as
+                a corruption without sufficient scriptural warrant; Calvin denied it as undermining the
+                sufficiency of Christ&rsquo;s atonement.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Catholic Understanding</h3>
+                <p className="text-amber-800">
+                  Purgatory is not &ldquo;working off&rdquo; punishment from an unsatisfied God. It is
+                  the completion of a sanctification process for those who die in God&rsquo;s friendship
+                  but are &ldquo;not yet&rdquo; fully conformed to Christ. Those in purgatory are
+                  already saved &mdash; they are on the way to heaven, being completed in God&rsquo;s
+                  presence.
+                </p>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Scriptural Basis for Purgatory</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-4">
+                  <li><strong>2 Macc 12:44&ndash;46:</strong> Judas Maccabeus offers prayers and sacrifices
+                  for soldiers who died wearing pagan amulets &mdash; explicitly: &ldquo;he made
+                  atonement for the dead, so that they might be delivered from their sin.&rdquo;</li>
+                  <li><strong>1 Cor 3:15:</strong> &ldquo;If anyone&rsquo;s work is burned up, he will
+                  suffer loss, though he himself will be saved, but only as through fire&rdquo; &mdash;
+                  a clear image of post-death purification.</li>
+                  <li><strong>Matt 12:32:</strong> Jesus says a sin against the Holy Spirit &ldquo;will
+                  not be forgiven, either in this age or in the age to come&rdquo; &mdash; implying
+                  some things <em>can</em> be forgiven in the age to come.</li>
+                  <li><strong>1 Pet 3:18&ndash;20:</strong> Christ &ldquo;preached to the spirits in
+                  prison&rdquo; &mdash; often read as Christ liberating the righteous dead (the
+                  Harrowing of Hell in Catholic tradition).</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Protestant Objections and Catholic Responses</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <div className="space-y-5">
+                  <div>
+                    <p className="text-blue-900 font-semibold mb-1">Objection: &ldquo;It is finished&rdquo; (John 19:30) &mdash; purgatory implies more payment is needed.</p>
+                    <p className="text-blue-800">Response: Purgatory is not a second atonement &mdash; it IS the application of Christ&rsquo;s
+                    finished work. We receive forgiveness immediately; purgatory completes the healing of
+                    sin&rsquo;s effects in the soul.</p>
+                  </div>
+                  <div>
+                    <p className="text-blue-900 font-semibold mb-1">Objection: &ldquo;Absent from the body, present with the Lord&rdquo; (2 Cor 5:8).</p>
+                    <p className="text-blue-800">Response: Those in purgatory <em>are</em> with the Lord &mdash; they are already saved,
+                    on the way to heaven, being completed in his presence, not separated from him.</p>
+                  </div>
+                  <div>
+                    <p className="text-blue-900 font-semibold mb-1">Objection: 2 Maccabees is not in the Protestant canon.</p>
+                    <p className="text-blue-800">Response: The early Church universally used the Septuagint (which included 2 Macc);
+                    Luther removed it precisely because it supported purgatory &mdash; the canonical
+                    argument cuts both ways.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 6: DIFFERENT FRAMEWORKS ==================== */}
+        {activeTab === 'different-frameworks' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Why the Disagreements Are So Deep</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catholic&ndash;Protestant differences on eschatology are not just about individual
+                texts; they reflect fundamentally different frameworks for authority, the Church, and
+                the interpretation of Scripture.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-4">
+                  <li><strong>The Church:</strong> Catholics hold that the visible, hierarchical Church
+                  IS the continuation of Christ&rsquo;s body, with sacraments, apostolic succession,
+                  and definitive teaching authority. Protestant views vary: for Luther and Calvin, the
+                  Church is defined by right preaching and administration of sacraments; for others,
+                  by invisible bonds of faith.</li>
+                  <li><strong>Scripture and Tradition:</strong> Catholics interpret Scripture within
+                  the living Tradition of the Church. Most Protestants hold <em>sola scriptura</em>
+                  &mdash; Scripture alone as the rule of faith.</li>
+                  <li><strong>The Magisterium:</strong> Catholics have a definitive teaching authority
+                  that settles disputed questions (e.g., CCC 676 on millenarianism). Protestants have
+                  no equivalent &mdash; hence the proliferation of end-times systems.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800"><em>Sola Scriptura</em> and Eschatological Diversity</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The proliferation of Protestant end-times views &mdash; over a dozen distinct positions
+                &mdash; is partly the result of <em>sola scriptura</em> without a definitive interpretive
+                authority. Each reader goes directly to the text; different starting assumptions produce
+                different systems from the same passages.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800">
+                  The same passages (1 Thess 4:17; Rev 20) produce: pre-trib/mid-trib/post-trib Rapture,
+                  historic premillennialism, amillennialism, postmillennialism &mdash; depending on
+                  presuppositions about genre, hermeneutics, and the role of Israel.
+                </p>
+                <p className="text-blue-800 mt-3">
+                  The Catholic answer: the Church&rsquo;s Tradition and Magisterium provides a definitive
+                  interpretive framework that rules out certain readings (CCC 676), establishing the
+                  bounds within which Catholics approach these texts.
+                </p>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Points of Genuine Dialogue</h2>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <ul className="text-green-800 space-y-3">
+                  <li><strong>N.T. Wright</strong> (Anglican bishop and NT scholar), <em>Surprised by
+                  Hope</em> (2008): His eschatology is remarkably close to Catholic teaching &mdash;
+                  bodily resurrection, renewed creation, rejection of the Rapture and Dispensationalism;
+                  widely read in Catholic circles.</li>
+                  <li><strong>Most Reformed Protestants</strong> (Presbyterian, Dutch Reformed) agree
+                  with Catholics on amillennialism and rejection of the Rapture.</li>
+                  <li><strong>Many evangelical scholars</strong> (D.A. Carson, Scot McKnight, Kevin
+                  DeYoung) have explicitly distanced themselves from Dispensationalism in recent decades.</li>
+                  <li><strong>Prayer for the dead:</strong> Some Anglican and Lutheran traditions retain
+                  versions of this practice; the doctrine of &ldquo;soul sleep&rdquo; is not universal
+                  among Protestants.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Catholic Invitation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholics can charitably challenge Dispensationalism without being dismissive of the
+                genuine faith of Protestant brothers and sisters. Not all Protestants are Dispensationalists
+                &mdash; most Lutherans, Anglicans, Reformed, and Methodist Christians share Catholic
+                amillennialism and rejection of the Rapture.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-2">
+                  <li>Point to the 19th-century origin of the Rapture doctrine &mdash; no Church Father
+                  taught it</li>
+                  <li>Highlight CCC 676&rsquo;s explicit magisterial rejection of millenarianism</li>
+                  <li>Invite Protestants to the richness of Catholic eschatology: the four last things,
+                  purgatory, the communion of saints, the bodily resurrection, and above all
+                  <em> hope</em> (<em>Spe Salvi</em>)</li>
+                  <li>Engage compassionately with the genuine spiritual longing that Dispensationalism
+                  addresses &mdash; the desire to know that God wins and that history has meaning</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/eschatology/layout.tsx
+++ b/src/app/eschatology/layout.tsx
@@ -1,0 +1,20 @@
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import HistoryNavigation from '@/components/HistoryNavigation'
+
+export default function EschatologyLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-h-screen bg-primary-cream">
+      <Header />
+      <HistoryNavigation />
+      <main className="pb-12">
+        {children}
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/eschatology/overview/page.tsx
+++ b/src/app/eschatology/overview/page.tsx
@@ -1,0 +1,1521 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  AlertTriangle,
+  Scale,
+  Globe,
+  Star,
+  Heart,
+  Users,
+  Flame,
+  Wind,
+  Search,
+  ArrowRight,
+  Compass,
+  Sunrise,
+  Cross,
+} from 'lucide-react'
+
+type TabId =
+  | 'four-last-things'
+  | 'after-death'
+  | 'second-coming'
+  | 'heaven-hell'
+  | 'final-judgment'
+  | 'new-creation'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'four-last-things', label: 'The Four Last Things' },
+  { id: 'after-death', label: 'After Death' },
+  { id: 'second-coming', label: 'The Second Coming' },
+  { id: 'heaven-hell', label: 'Heaven & Hell' },
+  { id: 'final-judgment', label: 'The Final Judgment' },
+  { id: 'new-creation', label: 'The New Creation' },
+]
+
+export default function EschatologyOverviewPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('four-last-things')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Catholic Teaching on End Times
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            Eschatology &mdash; the theology of &ldquo;last things&rdquo; &mdash; is not a peripheral Catholic
+            obsession but the horizon that gives Christian life its ultimate meaning. Death, Judgment,
+            Heaven, Hell, the Second Coming, and the New Creation are not speculation: they are
+            revealed truths that the Church has taught, defended, and refined across two thousand
+            years. This page presents the Catholic understanding of End Times &mdash; grounded in
+            Scripture, the Catechism, the Church Fathers, and modern papal teaching.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: THE FOUR LAST THINGS ==================== */}
+        {activeTab === 'four-last-things' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Church's Eschatological Framework */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Eschatological Framework</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Eschatology is the branch of theology concerned with &ldquo;last things&rdquo; &mdash; from the
+                Greek <em>eschaton</em>, meaning &ldquo;last&rdquo; or &ldquo;final.&rdquo; It encompasses
+                everything that Catholic theology teaches about death, judgment, and ultimate destiny.
+                Rather than a morbid fixation on endings, eschatology is the lens through which the
+                whole of Christian life finds its orientation: every human story has a final chapter,
+                and that chapter is not nothing.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The traditional Catholic summary of eschatology is the <strong>Four Last Things</strong>:
+                Death, Judgment, Heaven, and Hell. To these classical four, Catholic tradition commonly
+                adds Purgatory as the state of those who die in God&rsquo;s grace but still require
+                purification before entering the fullness of heaven. Medieval spiritual directors
+                popularized the maxim drawn from Sirach 7:36: <em>&ldquo;In all your works remember your
+                last end, and you will never sin.&rdquo;</em> The <em>Ars Moriendi</em> tradition
+                &mdash; the &ldquo;Art of Dying Well&rdquo; literature of the 14th and 15th centuries
+                &mdash; turned this into an entire pastoral program for preparing Catholics for a holy
+                death.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Four Last Things
+                </h3>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">1. Death</p>
+                    <p className="text-amber-700 text-sm">The separation of soul from body; the sealing of one&rsquo;s fundamental choice.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">2. Judgment</p>
+                    <p className="text-amber-700 text-sm">Both the particular judgment (at death) and the general judgment (at the Last Day).</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">3. Heaven</p>
+                    <p className="text-amber-700 text-sm">The direct vision of God and perfect communion with the Trinity and all the blessed.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">4. Hell</p>
+                    <p className="text-amber-700 text-sm">The eternal consequence of a definitive, unrevoked rejection of God&rsquo;s love.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catechism of the Catholic Church
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Each man receives his eternal retribution in his immortal soul at the very moment
+                  of his death, in a particular judgment that refers his life to Christ: either entrance
+                  into the blessedness of heaven &mdash; through a purification or immediately &mdash;
+                  or immediate and everlasting damnation.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 1022</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Four Last Things are not meant to terrify but to <em>orient</em>. They remind us
+                that every human life has an eternal destination, that history is not cyclical but
+                linear and purposeful, and that the choices we make in this life carry ultimate weight.
+                Far from producing scrupulosity or fear, a healthy Catholic eschatology produces
+                freedom: when we know where we are going, we know how to live.
+              </p>
+            </div>
+
+            {/* Card 2: Death */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Death: The Gateway, Not the End</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                For the Christian, death is not annihilation. It is a transformation &mdash; the
+                separation of body and soul that opens into eternity. The Catechism teaches: &ldquo;Because
+                of Christ, Christian death has a positive meaning&rdquo; (CCC 1010). Death entered
+                human history through sin (Genesis 3; Romans 5:12), but Christ transformed it by
+                passing through it and rising from the dead. For the baptized, death has become the
+                final conformity to Christ in His Paschal Mystery.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                At death, the soul is separated from the body. The soul retains its individual
+                identity and faces the <strong>Particular Judgment</strong> immediately &mdash; not
+                after a period of &ldquo;soul sleep&rdquo; (a Protestant notion rejected by Catholic
+                teaching), not after some intermediate unconscious state, but at the very moment of
+                death. The body, meanwhile, returns to the earth and awaits the bodily resurrection
+                at the Last Day.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Why Death Is the Critical Moment
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Death &ldquo;seals&rdquo; the fundamental option a person has made for or against God. This is
+                  why the Church has always taken preparation for death seriously. The traditional
+                  practice of receiving the Last Rites &mdash; Confession, Anointing of the Sick, and
+                  Viaticum (final Eucharist) &mdash; exists precisely to prepare the soul for this
+                  decisive passage.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Cf. CCC 1021: &ldquo;Death puts an end to human life as the time open to either
+                  accepting or rejecting the divine grace manifested in Christ.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 1016 reminds us: &ldquo;The Church encourages us to prepare ourselves for the hour of
+                our death&hellip; so that now we may decide and then may act in a way that will give
+                glory to God, and thus obtain the crown of life.&rdquo; The Catholic tradition does not
+                treat death as unmentionable; it treats death as the most important appointment every
+                human being will keep.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The <em>Ars Moriendi</em> Tradition
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  The <em>Ars Moriendi</em> (&ldquo;Art of Dying Well&rdquo;) literature of the late medieval
+                  period &mdash; widely circulated after the Black Death of the 14th century &mdash;
+                  provided ordinary Catholics with spiritual preparation for death. These texts
+                  addressed the five temptations of the dying (against faith, hope, patience,
+                  pride, and avarice) and the corresponding graces. They remain astonishingly
+                  relevant today, recovered by modern spiritual directors as a resource for
+                  contemporary pastoral care of the dying.
+                </p>
+                <p className="text-purple-700 text-sm">
+                  &mdash; Cf. Thomas &agrave; Kempis, <em>The Imitation of Christ</em>, Book I, ch. 23:
+                  &ldquo;Very soon your life here will end; consider, then, what may be in store for
+                  you elsewhere.&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Judgment */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Judgment: Particular and General</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholic theology distinguishes two judgments, both real, both important: the
+                <strong> Particular Judgment</strong> and the <strong>General (Last) Judgment</strong>.
+                These are not redundant but complementary, addressing different dimensions of the
+                moral truth of a human life.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-3">The Particular Judgment</h3>
+                  <p className="text-blue-800 text-sm mb-3">
+                    Occurs at the moment of death for each individual soul. The soul faces Christ
+                    immediately and receives its definitive sentence: heaven (directly or through
+                    Purgatory) or hell. No further opportunity to change one&rsquo;s fundamental
+                    orientation exists after this point.
+                  </p>
+                  <p className="text-blue-700 text-sm italic">
+                    &ldquo;Each man receives his eternal retribution in his immortal soul at the very
+                    moment of his death.&rdquo; &mdash; CCC 1022
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-3">The General (Last) Judgment</h3>
+                  <p className="text-blue-800 text-sm mb-3">
+                    Occurs at the end of history, at the Parousia (Second Coming). The body is
+                    resurrected and reunited with the soul. The full moral truth of every life &mdash;
+                    and of all human history &mdash; is revealed publicly before all creation.
+                  </p>
+                  <p className="text-blue-700 text-sm italic">
+                    &ldquo;The resurrection of all the dead will precede the Last Judgment.&rdquo;
+                    &mdash; CCC 1038
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Why does the Church teach both? The particular judgment is <em>personal and private</em>:
+                it is the moment each soul stands before God. The general judgment is
+                <em> cosmic and public</em>: it is the moment when the complete picture of history is
+                made manifest before all creation, when God&rsquo;s justice and mercy are fully vindicated,
+                and when the hidden good and hidden evil of every life is revealed. The general
+                judgment does not change the verdict of the particular judgment &mdash; it reveals and
+                confirms it before all.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Criterion: Matthew 25
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Matthew 25:31&ndash;46 &mdash; the parable of the sheep and the goats &mdash; is the
+                  New Testament&rsquo;s most explicit description of the Last Judgment. Its criterion is
+                  striking: concrete love for &ldquo;the least of these&rdquo; (the hungry, thirsty, stranger,
+                  naked, sick, imprisoned) is identified with service to Christ Himself. The judgment
+                  is not primarily about religious observance but about whether one&rsquo;s inner life
+                  of charity expressed itself outward in acts of mercy.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Cf. CCC 1039: &ldquo;In the presence of Christ, who is Truth itself, the truth
+                  of each man&rsquo;s relationship with God will be laid bare.&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Card 4: Heaven */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Heaven: The Beatific Vision</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Heaven is not a vague spiritual state of contentment or a metaphor for psychological
+                peace. The Catholic Church teaches that heaven is the direct, unmediated vision of
+                God&rsquo;s very essence &mdash; the <strong>Beatific Vision</strong> (from Latin
+                <em> visio beatifica</em>: &ldquo;the blessed seeing&rdquo;). It is not a vision of a
+                representation of God but of God as He is in Himself, which the intellect of the soul
+                is supernaturally elevated to receive.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  CCC on Heaven
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;Those who die in God&rsquo;s grace and friendship and are perfectly purified live
+                  forever with Christ. They see God face-to-face.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm mb-3">&mdash; CCC 1023</p>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;This perfect life with the Most Holy Trinity &mdash; this communion of life and
+                  love with the Trinity, with the Virgin Mary, the angels and all the blessed &mdash;
+                  is called &lsquo;heaven.&rsquo;&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; CCC 1024</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Heaven includes the Beatific Vision; full communion with the Trinity; the joyful
+                reunion with all those who have died in Christ; the company of the angels and saints;
+                and perfect joy without the possibility of loss. But critically, heaven is also
+                ultimately <em>embodied</em>: after the resurrection of the body at the Last Day, the
+                glorified body is reunited with the soul, and heaven becomes the eternal existence of
+                whole persons &mdash; body and soul &mdash; in God.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Thomas Aquinas, in the <em>Summa Theologiae</em> Supplement (QQ. 69&ndash;72), described
+                the properties of the glorified body: <strong>impassibility</strong> (freedom from
+                suffering, hunger, illness), <strong>subtlety</strong> (the body is fully subject to
+                the soul&rsquo;s direction), <strong>agility</strong> (movement is effortless),
+                and <strong>clarity</strong> (the body radiates the soul&rsquo;s interior glory). These
+                properties are modeled on the appearances of the risen Christ, who could pass through
+                locked doors (John 20:19) yet was genuinely physical (Luke 24:39&ndash;43).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Benedict XVI on Christian Hope
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The present moment is not the totality; the future belongs to God; and therefore
+                  we can bear to live in the present as it is.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; Pope Benedict XVI, <em>Spe Salvi</em> (2007)
+                </p>
+              </div>
+            </div>
+
+            {/* Card 5: Hell */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hell: The Reality of Damnation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Hell is one of the most uncomfortable doctrines in Catholic teaching &mdash; and one
+                of the most consistently attested, both in the New Testament and in the unbroken
+                Tradition of the Church. No speaker in the NT warns of hell more frequently or more
+                vividly than Jesus Himself: Matthew 5:22, 29&ndash;30; 10:28; 13:41&ndash;42; 23:33;
+                25:41, 46; Mark 9:43&ndash;48. To soften or spiritualize these warnings into
+                irrelevance is not to follow Jesus but to edit Him.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  What the Church Teaches About Hell
+                </h3>
+                <ul className="text-red-800 space-y-2 text-sm">
+                  <li><strong>Hell is real</strong> &mdash; CCC 1035: &ldquo;The teaching of the Church affirms the existence of hell and its eternity.&rdquo;</li>
+                  <li><strong>Hell is eternal</strong> &mdash; Matthew 25:46 speaks of &ldquo;eternal punishment&rdquo; in explicit parallel with &ldquo;eternal life.&rdquo;</li>
+                  <li><strong>Hell is freely chosen</strong> &mdash; God predestines no one to hell; damnation requires a willful, unrevoked rejection of God (CCC 1037).</li>
+                  <li><strong>Hell is separation from God</strong> &mdash; &ldquo;The chief punishment of hell is eternal separation from God.&rdquo; (CCC 1035)</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                C.S. Lewis&rsquo;s image from <em>The Great Divorce</em> captures the Catholic
+                understanding well: &ldquo;The door of hell is locked on the inside.&rdquo; Hell is
+                not God&rsquo;s revenge or a sadistic torture chamber; it is the logical consequence of a
+                definitive, final choice to reject the One who is Love itself. The damned do not want
+                heaven &mdash; they have permanently turned away from what heaven IS.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                What hell is <em>not</em>: it is not annihilation (the Catholic teaching firmly
+                rejects <em>annihilationism</em> &mdash; the idea that the soul simply ceases to exist
+                at death or at the Last Judgment). The soul is immortal; the separation is real and
+                permanent. Nor has the Church ever officially declared any specific person to be in
+                hell. The possibility of damnation is real; the actuality for any particular person
+                remains hidden with God.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Hell and Human Freedom
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  CCC 1033: &ldquo;We cannot be united with God unless we freely choose to love him. But
+                  we cannot love God if we sin gravely against him, against our neighbor or against
+                  ourselves.&rdquo; Hell is the serious Catholic answer to the question: Can a
+                  creature really say &ldquo;No&rdquo; to God forever? The Church&rsquo;s answer is yes &mdash;
+                  because genuine love requires genuine freedom, and genuine freedom implies the
+                  terrifying possibility of a final refusal.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Cf. CCC 1037: &ldquo;God predestines no one to go to hell; for this, a willful
+                  turning away from God (a mortal sin) is necessary, and persistence in it until the
+                  end.&rdquo;
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: AFTER DEATH ==================== */}
+        {activeTab === 'after-death' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Purgatory */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Purgatory: The Church&rsquo;s Teaching</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Purgatory is one of the doctrines most misunderstood by non-Catholics &mdash; and
+                sometimes by Catholics themselves. It is neither a &ldquo;second chance&rdquo; for those who
+                definitively rejected God, nor a kind of prolonged hell with an exit. Purgatory is
+                for those who are already saved &mdash; who died in God&rsquo;s grace and friendship &mdash;
+                but who are not yet fully purified to stand in the direct presence of God.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catechism Definition
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;All who die in God&rsquo;s grace and friendship, but still imperfectly purified,
+                  are indeed assured of their eternal salvation; but after death they undergo
+                  purification, so as to achieve the holiness necessary to enter the joy of heaven.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 1030</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Three things are essential to understand: First, those in purgatory are
+                <em> certain</em> of salvation &mdash; they are not in danger of hell. Second, purgatory
+                is not a place of meriting or &ldquo;earning&rdquo; salvation but of completing the
+                transformation that grace has already begun. Third, the living can assist the souls
+                in purgatory through prayer, Mass offerings, and indulgences &mdash; because we are
+                all members of one Body of Christ.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  Scriptural Foundations
+                </h3>
+                <ul className="text-purple-800 space-y-3 text-sm">
+                  <li>
+                    <strong>2 Maccabees 12:44&ndash;46</strong>: Judas Maccabeus orders prayers and
+                    sacrifices for fallen soldiers, &ldquo;for if he were not expecting that those who
+                    had fallen would rise again, it would have been superfluous and foolish to pray
+                    for the dead.&rdquo; (Note: Protestants exclude 2 Maccabees from their canon, which
+                    is partly why they reject purgatory.)
+                  </li>
+                  <li>
+                    <strong>1 Corinthians 3:15</strong>: Paul describes someone whose work is
+                    &ldquo;burned up&rdquo; yet &ldquo;he himself will be saved, but only as through fire.&rdquo;
+                    The Fathers consistently read this as a purgatorial purification.
+                  </li>
+                  <li>
+                    <strong>Matthew 12:32</strong>: Jesus says a certain sin &ldquo;will not be forgiven
+                    either in this age or in the age to come&rdquo; &mdash; implying some sins
+                    <em> can</em> be forgiven in the age to come.
+                  </li>
+                </ul>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Conciliar Definition
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The Council of Florence (1439) and the Council of Trent (1563) formally defined
+                  purgatory as a doctrine of the Church. Trent added that prayers, Masses, and
+                  indulgences for the dead are &ldquo;in accord with Apostolic tradition&rdquo; and
+                  are genuinely beneficial to the souls of the departed. The continuous practice of
+                  praying for the dead, attested in Christian inscriptions from the catacombs onward,
+                  undergirds the theological teaching.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Council of Trent, Session XXV; CCC 1031&ndash;1032
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: The Soul After Death */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Wind className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Soul After Death</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                At death, the soul is separated from the body but continues to exist as the same
+                individual person. This is not, however, the soul&rsquo;s completed or ideal state:
+                the soul without the body is incomplete, which is why the resurrection of the body
+                is not a peripheral doctrine but absolutely central to Christian hope.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  What the Catechism Teaches About the Soul
+                </h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li>The soul is naturally immortal &mdash; not by its own power but by God&rsquo;s design and gift (CCC 366).</li>
+                  <li>The soul retains the identity, memories, and moral character developed in earthly life.</li>
+                  <li>The soul does NOT &ldquo;sleep&rdquo; &mdash; soul sleep (<em>psychopannychism</em>) is a Protestant idea rejected by Catholic teaching.</li>
+                  <li>The soul without the body is genuinely incomplete: &ldquo;the soul is not the whole human being&rdquo; (CCC 997, cf. Aquinas).</li>
+                  <li>The soul awaits the resurrection of the body, when person is fully restored.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A common pastoral question: do the souls in heaven or purgatory know what is
+                happening on earth? The Church does not define this precisely. However, the
+                tradition (and CCC 956 on the intercession of the saints) implies that the saints
+                in heaven are aware of and genuinely engaged in the lives of the faithful on earth,
+                as members of the same Body of Christ.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Benedict XVI: On the Transformed Self
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;There is no self-encounter without an encounter with God&hellip; We need to let
+                  ourselves be touched by God. In death, this encounter with the truth of our
+                  own life cleanses and transforms us.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; Pope Benedict XVI, <em>Spe Salvi</em>, &sect;47 (2007)
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Communion of Saints */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Communion of Saints</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Apostles&rsquo; Creed includes belief in &ldquo;the communion of saints&rdquo; &mdash;
+                one of the most beautiful and consoling doctrines of Catholic Christianity. It teaches
+                that the Church is not merely the living community gathered in parishes on Sunday
+                morning; the Church includes all who belong to Christ, whether they are still living,
+                in purgatory, or fully alive in heaven.
+              </p>
+
+              <div className="grid md:grid-cols-3 gap-4 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">The Church Militant</h3>
+                  <p className="text-green-800 text-sm">
+                    Christians still living on earth, engaged in the spiritual battle of discipleship.
+                    We pray for the dead and ask the saints&rsquo; intercession.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">The Church Suffering</h3>
+                  <p className="text-blue-800 text-sm">
+                    Souls in purgatory, undergoing purification. They can receive the benefit of
+                    our prayers but cannot pray for themselves.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">The Church Triumphant</h3>
+                  <p className="text-amber-800 text-sm">
+                    The blessed in heaven, who intercede for us before God and share in Christ&rsquo;s
+                    eternal priestly intercession.
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This is why Catholic prayer for the dead is not &ldquo;praying to the dead&rdquo; in some
+                occult sense; it is asking God to help our fellow members of the Body of Christ who
+                are in purgatory. Masses, rosaries, and indulgences for the dead are acts of charity
+                within the Body &mdash; consistent with the deepest logic of Christian community.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  November: Month of the Holy Souls
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  The Church&rsquo;s liturgical calendar reflects this theology concretely. November 1
+                  (All Saints Day) celebrates the Church Triumphant; November 2 (All Souls Day)
+                  commemorates the Church Suffering. The entire month of November is traditionally
+                  devoted to prayer for the dead. Catholic cemeteries, eternal rest prayers, and
+                  Mass intentions for the deceased are not morbid customs but acts of love
+                  animated by the doctrine of the communion of saints.
+                </p>
+                <p className="text-purple-700 text-sm">
+                  &mdash; Cf. CCC 954&ndash;959: &ldquo;The union of the wayfarers with the brethren
+                  who sleep in the peace of Christ is not in the least weakened or interrupted.&rdquo;
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE SECOND COMING ==================== */}
+        {activeTab === 'second-coming' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Parousia */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Parousia: What the Church Teaches</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Greek word <em>parousia</em> (meaning &ldquo;presence,&rdquo; &ldquo;arrival,&rdquo; or
+                &ldquo;coming&rdquo;) became the technical New Testament term for the glorious Second Coming
+                of Christ (1 Thess 4:15&ndash;17; 2 Thess 2:1&ndash;8; 1 Cor 15:23; Matt 24:3, 27, 37, 39).
+                The Parousia is not a metaphor for spiritual experience or social progress; it is the
+                personal, visible, glorious return of Jesus Christ to judge the living and the dead
+                and to bring all things to their final completion.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Nicene Creed confesses: <em>&ldquo;He will come again in glory to judge the living and
+                the dead, and his kingdom will have no end.&rdquo;</em> This article of faith is not
+                optional or metaphorical; it is among the most central affirmations of the Christian
+                confession, repeated at every Mass.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Three Characteristics of the Parousia
+                </h3>
+                <div className="space-y-3">
+                  <div>
+                    <p className="font-semibold text-amber-800">1. Personal</p>
+                    <p className="text-amber-700 text-sm">
+                      Jesus Himself returns &mdash; not a spiritual force, not a symbolic event, not
+                      a social movement. &ldquo;This same Jesus, who has been taken from you into heaven,
+                      will come back in the same way you have seen him go.&rdquo; (Acts 1:11)
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800">2. Visible</p>
+                    <p className="text-amber-700 text-sm">
+                      The return will be unmistakable and universal: &ldquo;Every eye will see him,
+                      even those who pierced him.&rdquo; (Rev 1:7); &ldquo;as lightning comes from the
+                      east and flashes to the west, so will be the coming of the Son of Man.&rdquo;
+                      (Matt 24:27)
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800">3. Glorious</p>
+                    <p className="text-amber-700 text-sm">
+                      The First Coming was hidden, humble, and scandalous in its lowliness. The Second
+                      Coming will be &ldquo;in glory&rdquo; (Matt 25:31), with &ldquo;power and great glory&rdquo;
+                      (Matt 24:30) &mdash; a total contrast.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Church&rsquo;s Marana tha!
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  CCC 671: &ldquo;Though already present in his Church, Christ&rsquo;s reign is nevertheless
+                  yet to be fully established with power and great glory by the King&rsquo;s return to earth.
+                  This reign is still under attack by the evil powers.&rdquo; The Church&rsquo;s prayer
+                  &ldquo;Marana tha!&rdquo; (&ldquo;Come, Lord Jesus!&rdquo; &mdash; 1 Cor 16:22; Rev 22:20;
+                  Aramaic) is the oldest Christian prayer, expressing longing for the Parousia.
+                  Far from apocalyptic anxiety, it is an act of love &mdash; the Bride longing for
+                  the Bridegroom.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: The Church's Caution About Dates */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">When? The Church&rsquo;s Caution About Dates</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Perhaps the most important thing to say about the timing of the Parousia is this:
+                no one knows. Mark 13:32 (repeated in Matthew 24:36) is among the clearest statements
+                in the Gospels: <em>&ldquo;But about that day or hour no one knows, not even the angels
+                in heaven, nor the Son, but only the Father.&rdquo;</em> The Church takes this with complete
+                seriousness. It is not a problem to be solved but a mystery to be accepted.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  A History of Failed Predictions
+                </h3>
+                <p className="text-red-800 text-sm mb-3">
+                  Every generation has produced end-times date-setters. Every prediction has failed:
+                </p>
+                <ul className="text-red-800 text-sm space-y-2">
+                  <li><strong>Montanus</strong> (c. 150s AD): Predicted the New Jerusalem would descend in Phrygia (modern Turkey). It did not.</li>
+                  <li><strong>Joachim of Fiore</strong> (c. 1200): Predicted a new &ldquo;Age of the Spirit&rdquo; beginning around 1260. It did not begin.</li>
+                  <li><strong>William Miller</strong> (1844): Predicted Christ&rsquo;s return on October 22, 1844 &mdash; the &ldquo;Great Disappointment&rdquo; that gave rise to Adventism.</li>
+                  <li><strong>Harold Camping</strong> (1994, then 2011): Predicted the rapture twice. Neither occurred.</li>
+                </ul>
+                <p className="text-red-700 text-sm mt-3">
+                  Every failed prediction has damaged faith, discredited Christianity, and caused
+                  real pastoral harm to real people. The Church&rsquo;s consistent reserve on dates is
+                  not timidity but wisdom.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 673: &ldquo;The glorious Messiah&rsquo;s coming is suspended at every moment of history until
+                his recognition by &lsquo;all Israel.&rsquo;&rdquo; This suggests that the timing is not calculable;
+                it involves the mysterious unfolding of the history of salvation in ways that exceed
+                our reckoning.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Christian Response: Readiness, Not Calculation
+                </h3>
+                <p className="text-green-800 mb-3">
+                  Matthew 24:44: &ldquo;So you also must be ready, because the Son of Man will come at
+                  an hour when you do not expect him.&rdquo; The parable of the ten virgins (Matt 25:1&ndash;13)
+                  makes the same point: readiness is the only appropriate response. The Church calls
+                  Christians to live every day as if it could be the last &mdash; not in paralytic
+                  anxiety but in the alert, loving, active watchfulness that is the posture of
+                  faith.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Signs Preceding the Return */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Search className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Signs Preceding the Return</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The New Testament describes certain conditions that will precede or accompany the
+                Parousia. The Church acknowledges these as genuine revelations, without pretending
+                to know their precise timing or application to any specific historical moment.
+                Identifying &ldquo;the signs of the times&rdquo; requires discernment, not calculation.
+              </p>
+
+              <div className="space-y-4 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">1. Evangelization of All Nations</h3>
+                  <p className="text-blue-800 text-sm">
+                    Matthew 24:14: &ldquo;This gospel of the kingdom will be proclaimed throughout the
+                    whole world as a testimony to all nations, and then the end will come.&rdquo;
+                    The missionary mandate is eschatologically charged: the Church&rsquo;s global mission
+                    is, in some sense, part of the preparation for the Parousia.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">2. The Conversion of Israel</h3>
+                  <p className="text-blue-800 text-sm">
+                    Romans 11:25&ndash;26 speaks of &ldquo;the full number of the Gentiles&rdquo; coming in,
+                    after which &ldquo;all Israel will be saved.&rdquo; CCC 674 speaks of &ldquo;a full
+                    inclusion of the Jews in the Messiah&rsquo;s salvation, in the wake of the full number
+                    of the Gentiles.&rdquo; This does not mean forced conversion; it is a mysterious
+                    eschatological event in God&rsquo;s sovereign purpose.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">3. The Final Trial and the Antichrist</h3>
+                  <p className="text-blue-800 text-sm">
+                    CCC 675&ndash;677: Before the Second Coming, the Church will pass through a final
+                    testing that &ldquo;will shake the faith of many believers.&rdquo; This will involve
+                    a deception centered on an &ldquo;Antichrist&rdquo; figure &mdash; a supreme religious
+                    deception offering an apparent solution to human problems at the cost of apostasy.
+                    CCC 676 explicitly warns that this will NOT be the Church&rsquo;s earthly triumph;
+                    it rejects the millennialist idea that the Church will establish a golden age of
+                    political power before the Parousia.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  What CCC 676 Explicitly Rejects
+                </h3>
+                <p className="text-red-800 mb-3">
+                  CCC 676 warns: &ldquo;The Church has rejected even modified forms of this falsification
+                  of the kingdom to come under the name of millenarianism, especially the
+                  &lsquo;intrinsically perverse&rsquo; political form of a secular messianism.&rdquo; This
+                  is a direct rejection of &ldquo;dominionist&rdquo; or &ldquo;Christian nationalist&rdquo;
+                  theologies that expect the Church to seize political control and establish a golden
+                  age before Christ&rsquo;s return. The Church&rsquo;s path to the Parousia passes through
+                  the Cross, not through political triumph.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: HEAVEN & HELL ==================== */}
+        {activeTab === 'heaven-hell' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Heaven More Than We Can Imagine */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Heaven: More Than We Can Imagine</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Every human attempt to describe heaven falls short &mdash; not because heaven is
+                boring or empty but because it surpasses every category of human experience. Paul&rsquo;s
+                word stands: &ldquo;No eye has seen, nor ear heard, nor the heart of man imagined, what
+                God has prepared for those who love him&rdquo; (1 Cor 2:9).
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  What Heaven Contains
+                </h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>The Beatific Vision</strong>: The direct, unmediated knowledge of God as He knows Himself &mdash; not through a mirror, not through an intermediary, but face to face (1 Cor 13:12).</li>
+                  <li><strong>Theosis (Divinization)</strong>: The soul is transformed, made capable of containing the vision of God by being made to share in the divine nature (2 Pet 1:4). &ldquo;God became man so that man might become God&rdquo; (Athanasius).</li>
+                  <li><strong>Communion with the Trinity</strong>: Full participation in the trinitarian life of love between Father, Son, and Holy Spirit.</li>
+                  <li><strong>Reunion with the blessed</strong>: The joy of reunion with all who have died in Christ &mdash; family, friends, all the saints.</li>
+                  <li><strong>The Glorified Body</strong>: After the resurrection, eternal life is not disembodied &mdash; it is the full, transformed life of body and soul together.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 1026: &ldquo;By his death and Resurrection, Jesus Christ has &lsquo;opened&rsquo; heaven to us.
+                The life of the blessed consists in the full and perfect possession of the fruits of
+                the redemption accomplished by Christ.&rdquo;
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  Aquinas on the Glorified Body
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  Thomas Aquinas (<em>Summa Theologiae</em>, Supplement, QQ. 69&ndash;72) identified
+                  four gifts (or &ldquo;endowments&rdquo;) of the glorified body, modeled on the
+                  appearances of the risen Christ: <strong>Impassibility</strong> (freedom from
+                  suffering, fatigue, and death); <strong>Subtlety</strong> (the body fully obeys
+                  the soul&rsquo;s direction); <strong>Agility</strong> (movement is effortless, as when
+                  Christ appeared in the upper room through locked doors); and
+                  <strong> Clarity</strong> (the body radiates the soul&rsquo;s interior glory, as at
+                  the Transfiguration).
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Degrees of Beatitude
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  The Church teaches that while all in heaven possess the Beatific Vision, there
+                  are degrees of its intensity corresponding to the degree of love and holiness
+                  achieved in earthly life. This is not inequality in happiness but the
+                  fulfillment of each person&rsquo;s unique capacity &mdash; like different sized vessels
+                  all filled to the brim. CCC 1024 notes that each person&rsquo;s &ldquo;measure&rdquo; of
+                  heaven is their own.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Is Heaven Certain for Specific People? */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Who Is in Heaven? Canonization and Salvation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catholic Church&rsquo;s unique practice of <strong>canonization</strong> &mdash;
+                formally declaring specific individuals to be in heaven &mdash; is a remarkable
+                exercise of ecclesial authority rooted in the belief that God confirms His saints
+                through miracles. With over 10,000 canonized saints, the Church&rsquo;s declaration is
+                not that only these are in heaven but that these specifically have been recognized.
+                The actual number of the blessed (Rev 7:9: &ldquo;a great multitude that no one could
+                count&rdquo;) is beyond our knowing.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Paths to Salvation
+                </h3>
+                <ul className="text-green-800 space-y-2 text-sm">
+                  <li><strong>Dying in God&rsquo;s grace</strong>: Those who have received baptism and lived in charity with God and neighbor.</li>
+                  <li><strong>Perfect contrition</strong>: Those who, at death, repent with perfect sorrow motivated by love of God rather than fear of punishment.</li>
+                  <li><strong>Baptism of blood</strong>: Martyrs who die for Christ before being able to receive water baptism.</li>
+                  <li><strong>Baptism of desire</strong>: Those who sincerely seek God and intend to do whatever He wills, even without explicit knowledge of Christ.</li>
+                </ul>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Salvation Outside the Church?
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  CCC 847&ndash;848 address the question of those who have never heard the Gospel:
+                  &ldquo;Those who, through no fault of their own, do not know the Gospel of Christ or
+                  his Church, but who nevertheless seek God with a sincere heart, and, moved by grace,
+                  try in their actions to do his will as they know it through the dictates of their
+                  conscience &mdash; those too may achieve eternal salvation.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  This is not universalism (all are automatically saved regardless of their choices);
+                  it is the Church&rsquo;s affirmation that God&rsquo;s grace is not limited to those who
+                  have visibly received the sacraments, while the Church remains the ordinary and
+                  privileged channel of that grace.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Hell - The Logic of Eternal Loss */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hell: The Logic of Eternal Loss</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Why is hell eternal? The philosophical question is not arbitrary. If God is love and
+                desires all to be saved (1 Tim 2:4), why would damnation be permanent? The Catholic
+                answer is: because a fundamental, unrevoked choice for evil becomes permanent at
+                death. The soul has &ldquo;set&rdquo; in its direction. It is not that God refuses to
+                let the damned in; it is that the damned have definitively rejected what heaven IS
+                &mdash; union with the God they have permanently turned away from.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  Key Distinctions
+                </h3>
+                <ul className="text-red-800 space-y-2 text-sm">
+                  <li><strong>Hell is not annihilation</strong>: The soul does not cease to exist. <em>Annihilationism</em> is not Catholic teaching.</li>
+                  <li><strong>Hell is not purgatory</strong>: Those in purgatory are certain of salvation; those in hell are not.</li>
+                  <li><strong>Hell is primarily separation</strong>: &ldquo;The chief punishment of hell is eternal separation from God.&rdquo; (CCC 1035) Physical imagery (&ldquo;fire&rdquo;) may be metaphorical; the separation is real.</li>
+                  <li><strong>Hell requires free choice</strong>: CCC 1037 is explicit that God predestines no one to hell. Damnation requires a mortal sin and &ldquo;persistence in it until the end.&rdquo;</li>
+                  <li><strong>No one confirmed in hell</strong>: The Church has never declared any specific person to be in hell. The possibility is real; the actuality for any individual remains with God&rsquo;s judgment.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Hans Urs von Balthasar&rsquo;s essay &ldquo;<em>Dare We Hope &lsquo;That All Men Be Saved&rsquo;?</em>&rdquo;
+                (Ignatius Press, 1988) argues that while the Church teaches the real possibility of
+                hell, it has never taught that we know any person is actually there. Balthasar
+                distinguishes between believing hell is possible and empty. This is a theologically
+                permissible hope in Catholic teaching &mdash; though not a certainty &mdash; and has
+                been echoed (cautiously) by Pope Francis.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  CCC 1033 &mdash; The Full Text
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;We cannot be united with God unless we freely choose to love him. But we cannot
+                  love God if we sin gravely against him, against our neighbor or against ourselves:
+                  &lsquo;He who does not love remains in death. Anyone who hates his brother is a murderer,
+                  and you know that no murderer has eternal life abiding in him.&rsquo; Our Lord warns us
+                  that we shall be separated from him if we fail to meet the serious needs of the
+                  poor and the little ones who are his brethren. To die in mortal sin without
+                  repenting and accepting God&rsquo;s merciful love means remaining separated from him
+                  for ever by our own free choice. This state of definitive self-exclusion from
+                  communion with God and the blessed is called &lsquo;hell.&rsquo;&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; CCC 1033</p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: THE FINAL JUDGMENT ==================== */}
+        {activeTab === 'final-judgment' && (
+          <div className="space-y-8">
+
+            {/* Card 1: General Resurrection */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Sunrise className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The General Resurrection</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                At the Parousia, all the dead &mdash; both the blessed and the damned &mdash; will be
+                bodily resurrected. This is not metaphor. It is one of the central, non-negotiable
+                affirmations of the Christian Creed: &ldquo;I look for the resurrection of the dead,
+                and the life of the world to come.&rdquo; Christian hope is not the immortality of a
+                disembodied soul; it is the resurrection of the body &mdash; the reunification of
+                the whole person &mdash; body and soul together &mdash; in eternal life.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Resurrection in Paul
+                </h3>
+                <p className="text-green-800 italic mb-2">
+                  &ldquo;But in fact Christ has been raised from the dead, the firstfruits of those who
+                  have fallen asleep. For as by a man came death, by a man has come also the
+                  resurrection of the dead. For as in Adam all die, so also in Christ shall all be
+                  made alive.&rdquo;
+                </p>
+                <p className="text-green-700 text-sm">&mdash; 1 Corinthians 15:20&ndash;22</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Paul&rsquo;s extraordinary 15th chapter of First Corinthians is the most extended New
+                Testament treatment of the resurrection and its meaning. Against those in Corinth
+                who doubted the bodily resurrection (&ldquo;How are the dead raised? With what kind of
+                body?&rdquo; &mdash; 1 Cor 15:35), Paul insists that the resurrection of the body is
+                constitutive of Christian hope: &ldquo;If the dead are not raised, then Christ has not
+                been raised. If Christ has not been raised, your faith is futile.&rdquo; (1 Cor 15:16&ndash;17)
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  What Kind of Body?
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Paul uses the image of a seed: the body that is sown is not the same as the body
+                  that rises (1 Cor 15:36&ndash;44). There is continuity (the same seed; the same
+                  person) and radical transformation (a different kind of existence). The resurrected
+                  body is a &ldquo;spiritual body&rdquo; (<em>soma pneumatikon</em>) &mdash; not immaterial but
+                  fully animated and transformed by the Holy Spirit, incorruptible and glorious.
+                  Christ&rsquo;s own resurrected body &mdash; which ate fish, bore the wounds of the
+                  Cross, yet could appear through locked doors and was often not immediately
+                  recognized &mdash; is the model and first instance.
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; Cf. CCC 999: &ldquo;How? Christ is raised with his own body: &lsquo;See my hands
+                  and my feet, that it is I myself.&rsquo;&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Same Body, Transformed
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  CCC 999: &ldquo;In death, the separation of the soul from the body, the human body
+                  decays and the soul goes to meet God, while awaiting its reunion with its glorified
+                  body. God, in his almighty power, will definitively grant incorruptible life to
+                  our bodies by reuniting them with our souls, through the power of Jesus&rsquo;
+                  Resurrection.&rdquo; The Church has consistently taught (against Gnostic tendencies)
+                  that the body is not a prison from which the soul escapes; the body is part of the
+                  full person that is being saved.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: The Final Judgment Itself */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Final Judgment: The Revelation of History</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Last Judgment is not primarily about sentencing &mdash; the particular judgment
+                has already sealed each person&rsquo;s destiny. It is primarily about <em>revelation</em>:
+                the full, public, cosmic disclosure of the moral truth of every human life and of
+                all of history. Every hidden act of love is revealed; every concealed injustice is
+                brought to light; the complete tapestry of God&rsquo;s providential working through
+                human history &mdash; including its apparent evils and apparent absurdities &mdash;
+                is made intelligible for the first time.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  CCC on the Last Judgment
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Last Judgment will reveal even to its furthest consequences the good each
+                  person has done or failed to do during his earthly life.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; CCC 1040</p>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;At the end of time, the Kingdom of God will come in its fullness. After the
+                  universal judgment, the righteous will reign for ever with Christ, glorified in
+                  body and soul.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 1042</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The criterion of the Last Judgment (Matt 25:31&ndash;46) is not abstract theological
+                correctness but concrete acts of mercy: feeding the hungry, giving drink to the
+                thirsty, welcoming the stranger, clothing the naked, visiting the sick and imprisoned.
+                These acts are identified with service to Christ Himself &mdash; &ldquo;whatever you
+                did for one of the least of these brothers and sisters of mine, you did for me.&rdquo;
+                (Matt 25:40)
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The Vindication of the Just
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  The Last Judgment is not only a terrifying prospect but a consoling hope for the
+                  victims of history. Every martyr whose death seemed pointless, every act of
+                  hidden charity that went unnoticed, every injustice that was never addressed in
+                  this life &mdash; all will be fully disclosed and vindicated. The &ldquo;problem of
+                  evil&rdquo; &mdash; why God permits suffering &mdash; will find its full answer not
+                  in philosophical argument but in the eschatological revelation of how God drew
+                  good from every evil in the vast tapestry of human history.
+                </p>
+                <p className="text-purple-700 text-sm">
+                  &mdash; Cf. CCC 1041: &ldquo;The message of the Last Judgment calls men to conversion
+                  while God is still giving them &lsquo;the acceptable time, the day of salvation.&rsquo;&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: The New Heaven and New Earth */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The New Heaven and New Earth</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation 21:1&ndash;5 describes the final state of all things: &ldquo;Then I saw a new
+                heaven and a new earth, for the first heaven and the first earth had passed away&hellip;
+                And I heard a loud voice from the throne saying, &lsquo;Behold, the dwelling place of God
+                is with man. He will dwell with them, and they will be his people, and God himself
+                will be with them as their God. He will wipe away every tear from their eyes, and
+                death shall be no more, neither shall there be mourning, nor crying, nor pain
+                anymore, for the former things have passed away.&rsquo;&rdquo;
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Renewal, Not Destruction
+                </h3>
+                <p className="text-green-800 mb-3">
+                  The Catholic tradition understands the &ldquo;passing away&rdquo; of the first heaven
+                  and earth (Rev 21:1; 2 Pet 3:10&ndash;13) as a radical transformation and renewal,
+                  not a simple annihilation. Creation is not discarded; it is elevated and brought
+                  to its final purpose. Romans 8:19&ndash;21 speaks of creation &ldquo;groaning as in
+                  the pains of childbirth&rdquo; waiting for &ldquo;liberation from its bondage to decay.&rdquo;
+                  The universe itself is caught up in the redemption.
+                </p>
+                <p className="text-green-700 text-sm">
+                  &mdash; Cf. CCC 1046&ndash;1047: &ldquo;Creation itself will be liberated from its
+                  bondage to decay and brought into the glorious freedom of the children of God.&rdquo;
+                  (Rom 8:21)
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The New Jerusalem: Eden Restored and Surpassed
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Revelation 21&ndash;22 describes the New Jerusalem in images dense with meaning:
+                  God dwelling directly with His people (no temple, because God IS the temple &mdash;
+                  Rev 21:22); no sun or moon (God IS the light &mdash; Rev 21:23); the river of the
+                  water of life flowing from God&rsquo;s throne; the tree of life &mdash; the very tree
+                  lost in Eden &mdash; now freely accessible to all (Rev 22:1&ndash;2). Eden is not
+                  merely restored; the New Creation surpasses the original Garden as the Redeemer
+                  surpasses the first Adam.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: THE NEW CREATION ==================== */}
+        {activeTab === 'new-creation' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Cosmic Eschatology */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Cosmic Eschatology: The Redemption of All Things</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                One of the most important correctives in modern Catholic eschatology is the recovery
+                of its <em>cosmic</em> dimension. Popular imagination often reduces the &ldquo;end times&rdquo;
+                to a drama about individual souls escaping from a doomed material world. But this is
+                more Platonic than Catholic. The salvation Christ brings is not the rescue of
+                disembodied souls from a discarded universe; it is the redemption of <em>all things</em>.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  &ldquo;To Reconcile All Things&rdquo;
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;Through him to reconcile to himself all things, whether on earth or in heaven,
+                  making peace by the blood of his cross.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm mb-3">&mdash; Colossians 1:20</p>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;Creation itself will be liberated from its bondage to decay and brought into
+                  the glorious freedom of the children of God.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; Romans 8:21</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 1046&ndash;1047: &ldquo;For the universe too, the Apostle&rsquo;s vision is a hopeful one.
+                He believes that the universe, which was created and is sustained by God, is indeed
+                being directed by God towards a future destiny which he alone fully knows, but which
+                faith assures us will be one of supreme and unimaginable glory.&rdquo;
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The resurrection of the body means that material reality has eternal significance.
+                We are not waiting to escape the body and the earth; we are waiting for their
+                renewal. This has profound practical implications: care for the poor, care for the
+                environment, human artistic and intellectual work, and all genuine human culture
+                have eschatological weight. &ldquo;Nothing that is truly human fails to find an echo
+                in [the disciples&rsquo;] hearts&rdquo; (Gaudium et Spes, 1). And nothing done &ldquo;in the
+                Lord&rdquo; is wasted: &ldquo;your labor is not in vain in the Lord&rdquo; (1 Cor 15:58).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Implications for Human Work
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Pope John Paul II, drawing on Vatican II&rsquo;s <em>Gaudium et Spes</em>, argued
+                  that human work participates in God&rsquo;s creative and redemptive activity. In
+                  <em> Laborem Exercens</em> (1981), he wrote that the products of human labor
+                  &mdash; art, science, culture, social institutions built in justice &mdash; contribute
+                  to the &ldquo;civilization of love&rdquo; that anticipates the Kingdom of God.
+                  They may not be carried over into the New Creation in their present form,
+                  but the love and fidelity with which they are made is eternal.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Scripture's Great Arc */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ArrowRight className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Scripture&rsquo;s Great Arc: Creation &rarr; Fall &rarr; Redemption &rarr; New Creation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The entire Bible can be read as a single narrative arc moving from creation to new
+                creation. Catholic eschatology is not appended to Christian theology as a frightening
+                postscript; it is the culmination of the whole story that Scripture tells.
+              </p>
+
+              <div className="space-y-4 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Creation (Genesis 1&ndash;2)</h3>
+                  <p className="text-blue-800 text-sm">
+                    God creates the heavens and the earth and declares it &ldquo;very good.&rdquo; Humanity is
+                    placed in the Garden, in direct relationship with God. The material world is
+                    inherently good &mdash; this is the starting point from which Catholic theology
+                    of creation, body, and resurrection flows.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">The Fall (Genesis 3)</h3>
+                  <p className="text-blue-800 text-sm">
+                    Humanity&rsquo;s rejection of God&rsquo;s order brings death, suffering, alienation from God,
+                    from each other, and from the natural world. The cherubim bar the return to the
+                    Garden and the Tree of Life. History becomes the story of exile and longing for
+                    return.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Redemption (The Whole OT and NT)</h3>
+                  <p className="text-blue-800 text-sm">
+                    God enters His own creation in the Incarnation. The Cross is the supreme act
+                    of redemptive love. The Resurrection is the first instance of the New Creation
+                    &mdash; the &ldquo;firstfruits&rdquo; (1 Cor 15:20). The Church is the community of those
+                    already living in the &ldquo;already but not yet&rdquo; of the Kingdom.
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">New Creation (Revelation 21&ndash;22)</h3>
+                  <p className="text-green-800 text-sm">
+                    The River of Life, the Tree of Life (once barred in Genesis), God dwelling
+                    with humanity face-to-face &mdash; no temple, no sun, no night. Eden is not
+                    merely restored but surpassed. The whole story ends not in destruction but
+                    in consummation: &ldquo;Behold, I am making all things new.&rdquo; (Rev 21:5)
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The &ldquo;Already but Not Yet&rdquo;
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  Catholic theology uses the phrase &ldquo;already but not yet&rdquo; to describe the Church&rsquo;s
+                  present situation in salvation history. The Kingdom of God has already arrived
+                  in Christ; it is already present in the Church, the sacraments, and the lives
+                  of the saints. Yet it is not yet fully revealed; the Parousia and the New Creation
+                  are still awaited. The Holy Spirit is the &ldquo;down payment&rdquo;
+                  (<em>arrabon</em> &mdash; 2 Cor 1:22; 5:5; Eph 1:14): a real foretaste and pledge
+                  of the fullness still to come.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Hope */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hope: The Distinctively Eschatological Virtue</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                If eschatology is rightly understood, its primary emotional register is not fear
+                but <em>hope</em>. The theological virtue of hope is, in fact, the distinctively
+                eschatological virtue: it orients the Christian toward the future God has promised
+                and sustains faithful action in the present. Hope is not optimism (a natural
+                temperament), not wishful thinking (self-deception), and not certainty (which would
+                eliminate faith). It is a supernatural virtue &mdash; a God-given capacity to trust
+                in what God has revealed about the end of the story.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  CCC on Christian Hope
+                </h3>
+                <p className="text-green-800 italic mb-2">
+                  &ldquo;Hope is the theological virtue by which we desire the kingdom of heaven and
+                  eternal life as our happiness, placing our trust in Christ&rsquo;s promises and relying
+                  not on our own strength, but on the help of the grace of the Holy Spirit.&rdquo;
+                </p>
+                <p className="text-green-700 text-sm">&mdash; CCC 1817</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Pope Benedict XVI devoted his second encyclical &mdash; <em>Spe Salvi</em> (&ldquo;Saved
+                by Hope&rdquo;) &mdash; entirely to this theme. Writing in 2007, he diagnosed the crisis
+                of modern Western culture as fundamentally a crisis of hope: secular utopianism
+                (the belief that human progress can build paradise on earth) has repeatedly failed
+                and left people in despair; scientific materialism offers only an indifferent
+                universe with no ultimate meaning; individualism atomizes community. Against all
+                these, Benedict offers Christian hope &mdash; not as sentimental comfort but as a
+                rationally grounded confidence in the God who raised Christ from the dead.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Benedict XVI: <em>Spe Salvi</em> (2007)
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The one who has hope lives differently; the one who hopes has been granted the
+                  gift of a new life.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; <em>Spe Salvi</em>, &sect;2</p>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;It is not science that redeems man: man is redeemed by love&hellip; the one who
+                  loves wants to exist forever, for the person he loves; and, on the other hand,
+                  there must be someone who loves him for him to be able to exist forever.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Spe Salvi</em>, &sect;26</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                &ldquo;We have been saved by hope&rdquo; (Rom 8:24 &mdash; the Greek <em>t&emacr; elpidi</em>
+                literally: &ldquo;by hope&rdquo;). The proper Christian response to eschatology is not
+                paralytic fear, not obsessive calculation of end-times signs, not passive waiting
+                for an escape from a burning world &mdash; but active, hopeful engagement in the
+                present, working for justice, peace, and love, confident that &ldquo;your labor is not
+                in vain in the Lord&rdquo; (1 Cor 15:58), because history is headed somewhere real,
+                somewhere good, somewhere that God Himself has promised.
+              </p>
+            </div>
+
+            {/* Card 4: Sources & Further Reading */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sources &amp; Further Reading</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The following primary sources and scholarly works underlie this page.
+                Readers who wish to go deeper will find these indispensable.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">Magisterial &amp; Official</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;988&ndash;1060 (Eschatology overview)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;668&ndash;682 (Parousia and Kingdom)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;1020&ndash;1041 (Particular and Last Judgment)</li>
+                    <li>Council of Florence (1439): Decree for the Greeks &mdash; on purgatory</li>
+                    <li>Council of Trent, Session XXV (1563): Decree on Purgatory</li>
+                    <li>Vatican II, <em>Lumen Gentium</em>, ch. VII: &ldquo;The Eschatological Character of the Pilgrim Church&rdquo;</li>
+                    <li>Vatican II, <em>Gaudium et Spes</em>, &sect;&sect;38&ndash;39 (earthly progress and the Kingdom)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Papal Documents</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Pope Benedict XVI, <em>Spe Salvi</em> (2007) &mdash; on Christian hope</li>
+                    <li>Pope John Paul II, <em>Laborem Exercens</em> (1981) &mdash; human work and the Kingdom</li>
+                    <li>Pope John Paul II, <em>Tertio Millennio Adveniente</em> (1994) &mdash; eschatological dimensions of the Jubilee</li>
+                    <li>Pope Francis, <em>Laudato Si&rsquo;</em> (2015), &sect;&sect;243&ndash;246 &mdash; cosmic eschatology</li>
+                  </ul>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-3">Scholarly Works</h3>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>Joseph Ratzinger (Benedict XVI), <em>Eschatology: Death and Eternal Life</em> (Catholic University of America Press, 1988) &mdash; the definitive modern Catholic eschatology text</li>
+                    <li>Hans Urs von Balthasar, <em>Dare We Hope &ldquo;That All Men Be Saved&rdquo;?</em> (Ignatius Press, 1988)</li>
+                    <li>Frank J. Sheed, <em>Theology and Sanity</em>, chs. on Heaven, Hell, and Purgatory</li>
+                    <li>Thomas Aquinas, <em>Summa Theologiae</em>, Supplement, QQ. 69&ndash;99 (resurrection and Last Things)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-3">Additional Reading</h3>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>N.T. Wright, <em>Surprised by Hope</em> (HarperOne, 2008) &mdash; Protestant but widely used by Catholic theologians; excellent on bodily resurrection</li>
+                    <li>Jerry L. Walls, <em>Heaven, Hell, and Purgatory</em> (Brazos, 2015) &mdash; ecumenical philosophical treatment</li>
+                    <li>Peter Kreeft, <em>Everything You Always Wanted to Know About Heaven</em> (Ignatius, 1990) &mdash; accessible popular Catholic treatment</li>
+                    <li>Augustine of Hippo, <em>City of God</em>, Books XIX&ndash;XXII &mdash; the first systematic Christian eschatology</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/eschatology/protestant-views/page.tsx
+++ b/src/app/eschatology/protestant-views/page.tsx
@@ -1,0 +1,767 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Globe,
+  Users,
+  Layers,
+  Calendar,
+  Scale,
+  Clock,
+  ArrowRight,
+  XCircle,
+  BookOpen,
+  AlertTriangle,
+  Church,
+  Sunrise,
+  MapPin,
+} from 'lucide-react'
+
+type TabId =
+  | 'overview'
+  | 'dispensationalism'
+  | 'the-rapture'
+  | 'millennium-views'
+  | 'amillennialism'
+  | 'left-behind'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'dispensationalism', label: 'Dispensationalism' },
+  { id: 'the-rapture', label: 'The Rapture' },
+  { id: 'millennium-views', label: 'Millennial Views' },
+  { id: 'amillennialism', label: 'Amillennialism & Postmillennialism' },
+  { id: 'left-behind', label: 'Left Behind & Popular Culture' },
+]
+
+export default function ProtestantViewsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('overview')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Protestant End Times Views
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The theology of the Rapture, the Great Tribulation, the Millennial Kingdom, and Dispensationalism
+            is a distinctly modern Protestant development. This page presents these views accurately and
+            charitably, explains their origins, and examines them critically.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: OVERVIEW ==================== */}
+        {activeTab === 'overview' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Landscape of Protestant Eschatology</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Protestant Christianity has no single authoritative teaching body &mdash; so eschatological
+                views vary widely across denominations, traditions, and individual theologians. The major
+                positions differ on: the timing of Christ&rsquo;s return, a literal &ldquo;Rapture,&rdquo;
+                the Millennium (Rev 20), the role of national Israel, and the Great Tribulation.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Main Systems</h3>
+                <ul className="text-amber-800 space-y-3">
+                  <li><strong>Dispensationalism:</strong> Pre-tribulation Rapture, literal 7-year Tribulation,
+                  literal 1,000-year reign of Christ from Jerusalem. A 19th-century innovation.</li>
+                  <li><strong>Historic Premillennialism:</strong> Christ returns before the millennium; no
+                  pre-trib Rapture; millennium is literal but not dispensationalist.</li>
+                  <li><strong>Amillennialism:</strong> No literal future millennium; the 1,000 years symbolizes
+                  the Church age. Common among Reformed Protestants and Catholics.</li>
+                  <li><strong>Postmillennialism:</strong> The Church gradually Christianizes the world;
+                  Christ returns after the millennium.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                A crucial distinction: the Rapture + 7-year Tribulation + Millennium sequence is uniquely
+                <em> Dispensationalist</em> &mdash; it is <strong>not</strong> the common heritage of all
+                Protestants. Many mainline, Reformed, and Lutheran Protestants reject Dispensationalism
+                as firmly as Catholics do.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Why This Matters for Catholic&ndash;Protestant Dialogue</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                When Catholics hear &ldquo;Protestant End Times theology,&rdquo; they are often encountering
+                Dispensationalism &mdash; but many mainline, Reformed, and Lutheran Protestants reject
+                Dispensationalism as firmly as Catholics do. The <em>Left Behind</em> series by LaHaye
+                and Jenkins represents popular Dispensationalism, not historic Protestant eschatology.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Common Ground Across the Divide</h3>
+                <ul className="text-blue-800 space-y-2">
+                  <li>Christ will return personally and visibly</li>
+                  <li>The dead will be resurrected bodily</li>
+                  <li>There will be a final judgment for all</li>
+                  <li>Heaven and Hell are real eternal destinies</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Understanding these distinctions allows for much more productive dialogue. Catholics and
+                most historic Protestants are not as far apart on eschatology as the popular evangelical
+                end-times industry would suggest.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 2: DISPENSATIONALISM ==================== */}
+        {activeTab === 'dispensationalism' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Is Dispensationalism?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Dispensationalism is a theological system that divides history into distinct &ldquo;dispensations&rdquo;
+                &mdash; periods in which God deals with humanity differently. It originated with
+                <strong> John Nelson Darby</strong> (1800&ndash;1882) of the Plymouth Brethren in Ireland
+                and England.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Darby&rsquo;s Key Innovations (c. 1830s)</h3>
+                <ul className="text-amber-800 space-y-2">
+                  <li>A sharp distinction between Israel (God&rsquo;s earthly people) and the Church (God&rsquo;s
+                  heavenly people)</li>
+                  <li>The Pre-Tribulation Rapture &mdash; the Church is secretly removed before the 7-year
+                  Tribulation</li>
+                  <li>A future literal earthly kingdom for national Israel</li>
+                  <li>A literal 1,000-year reign of Christ from Jerusalem</li>
+                </ul>
+              </div>
+
+              <div className="bg-red-50 p-5 rounded-lg">
+                <h4 className="font-semibold text-red-900 mb-2">A 19th-Century Innovation</h4>
+                <p className="text-red-800 text-sm">
+                  Before Darby (c. 1830s), <strong>no</strong> Protestant theologian, Catholic theologian,
+                  or Church Father taught the pre-tribulation Rapture. It is a 19th-century innovation
+                  with no precedent in two thousand years of Christian theology.
+                </p>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Spread of Dispensationalism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Darby traveled to the United States multiple times (1862&ndash;1877), finding receptive
+                audiences among American evangelicals. From there, Dispensationalism spread through
+                several key channels.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Key Milestones</h3>
+                <ul className="text-blue-800 space-y-3">
+                  <li><strong>Cyrus I. Scofield</strong> (<em>Scofield Reference Bible</em>, 1909): Put
+                  Dispensationalist interpretation directly into Bible footnotes; became the
+                  &ldquo;study Bible&rdquo; of American evangelicalism for decades.</li>
+                  <li><strong>Dallas Theological Seminary</strong> (founded 1924): The institutional home
+                  of academic Dispensationalism; produced Chafer, Walvoord, and Ryrie.</li>
+                  <li><strong>Hal Lindsey</strong>, <em>The Late, Great Planet Earth</em> (1970): Over
+                  35 million copies; popularized end-times date-setting for a mass audience.</li>
+                  <li><strong>Tim LaHaye &amp; Jerry Jenkins</strong>, <em>Left Behind</em> series
+                  (1995&ndash;2007): Over 65 million copies; the most successful Christian fiction
+                  series in history.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Classic Dispensationalist Timetable</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Dispensationalist sequence of end-time events is one of the most elaborate
+                prophetic systems ever constructed. Its key feature throughout is that national Israel
+                &mdash; not the Church &mdash; is central to God&rsquo;s plan.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ol className="text-blue-800 space-y-3 list-decimal list-inside">
+                  <li>The Church Age ends with the <strong>Pre-Tribulation Rapture</strong> (all Christians
+                  suddenly disappear mid-sentence; cars crash, planes fall)</li>
+                  <li><strong>7-Year Tribulation:</strong> The Antichrist rises; signs a peace treaty with
+                  Israel; breaks it after 3.5 years (&ldquo;Abomination of Desolation&rdquo;)</li>
+                  <li><strong>The Great Tribulation</strong> (second half): Bowls of wrath (Rev 16); 144,000
+                  Jewish evangelists; global persecution of those who refused the mark</li>
+                  <li><strong>Battle of Armageddon</strong> in the Valley of Jezreel; Christ returns at
+                  its climax to rescue Israel</li>
+                  <li><strong>The Millennium:</strong> Christ reigns literally from Jerusalem for 1,000
+                  years; Temple rebuilt; (controversially) animal sacrifices resume</li>
+                  <li>Final Rebellion, Last Judgment, New Heaven and New Earth</li>
+                </ol>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Theological Criticisms of Dispensationalism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Dispensationalism faces serious objections not only from Catholic theology but from the
+                mainstream of Protestant biblical scholarship. The following criticisms are widely shared
+                across traditions.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <ul className="text-red-800 space-y-4">
+                  <li><strong>Two peoples of God:</strong> Paul (Gal 3:28&ndash;29; Eph 2:11&ndash;22)
+                  insists on the <em>one</em> people of God in Christ &mdash; the Church/Israel distinction
+                  is rejected by most biblical scholars.</li>
+                  <li><strong>The &ldquo;gap&rdquo; in Daniel 9:</strong> Dispensationalism requires a
+                  2,000-year gap between the 69th and 70th &ldquo;week&rdquo; of Daniel 9 &mdash; a reading
+                  not supported by the text itself.</li>
+                  <li><strong>Two second comings:</strong> A secret Rapture <em>plus</em> a visible
+                  Paro&uuml;sia requires essentially two second comings &mdash; no historical precedent
+                  before Darby.</li>
+                  <li><strong>Animal sacrifices in the Millennium:</strong> The idea that OT sacrifices
+                  resume is rejected by most Protestant theologians; Hebrews 9&ndash;10 is definitive
+                  on their abolition.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Most Reformed, Lutheran, Anglican, and Methodist theologians reject Dispensationalism.
+                Its dominance is largely an American evangelical phenomenon, not the historic mainstream
+                of Protestantism.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE RAPTURE ==================== */}
+        {activeTab === 'the-rapture' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <ArrowRight className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Pre-Tribulation Rapture: The Doctrine</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The central distinctive of Dispensationalism is the pre-tribulation Rapture: before the
+                7-year Tribulation, all true Christians are suddenly and secretly removed from the earth.
+                The classic text is 1 Thessalonians 4:16&ndash;17:
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;For the Lord himself will descend from heaven with a cry of command&hellip; and
+                  the dead in Christ will rise first. Then we who are alive, who are left, will be caught
+                  up together with them in the clouds to meet the Lord in the air.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; 1 Thessalonians 4:16&ndash;17 (RSV)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                &ldquo;Caught up&rdquo; translates the Latin <em>raptus</em> &mdash; hence &ldquo;the
+                Rapture.&rdquo; In the Dispensationalist scenario, Christians disappear mid-sentence;
+                cars crash, planes fall from the sky; the world descends into chaos; non-Christians
+                are &ldquo;left behind&rdquo; to face the Antichrist and Tribulation.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Rapture in Historical Perspective</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The pre-tribulation Rapture has no precedent in the history of Christian theology before
+                the 19th century. This is not a disputed claim &mdash; it is the consensus of
+                church-history scholarship across Catholic, Orthodox, and mainline Protestant traditions.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Historical Record</h3>
+                <ul className="text-blue-800 space-y-2">
+                  <li>No Church Father, medieval theologian, or Reformer ever taught a pre-tribulation Rapture</li>
+                  <li>Luther, Calvin, Zwingli, Wesley: all expected persecution and tribulation before Christ&rsquo;s
+                  return; none envisioned a secret departure</li>
+                  <li><strong>John Nelson Darby</strong> (c. 1830s): First systematic proponent; some scholars
+                  trace the idea to a prophetic utterance by Margaret MacDonald (1830, Port Glasgow, Scotland)</li>
+                  <li>The concept&rsquo;s rapid spread was driven largely by the Scofield Reference Bible
+                  and American evangelical networks</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The early Church was martyred under Nero and Domitian. Those Christians did not interpret
+                their suffering as a &ldquo;tribulation that Christians would be spared.&rdquo; They
+                endured it as participation in the Cross.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Variants: Pre-, Mid-, Post-Tribulation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Even within Dispensationalism, the timing of the Rapture is contested. The following
+                positions reflect internal debates within the system:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-3">
+                  <li><strong>Pre-Tribulation Rapture:</strong> Christians removed before the 7 years begin
+                  (Darby, Scofield, LaHaye, Dallas Seminary position)</li>
+                  <li><strong>Mid-Tribulation Rapture:</strong> Christians removed at the 3.5-year midpoint
+                  (a minority Dispensationalist position)</li>
+                  <li><strong>Pre-Wrath Rapture:</strong> Christians removed before the final &ldquo;bowl
+                  judgments&rdquo; but after the Tribulation proper (Marvin Rosenthal, 1990)</li>
+                  <li><strong>Post-Tribulation Rapture:</strong> Christians go through the Tribulation and
+                  are &ldquo;caught up&rdquo; to escort the returning Christ &mdash; not an escape but a
+                  royal reception (Historic Premillennialism; George Eldon Ladd)</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <XCircle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Catholic (and Most Protestant) Objection</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catholic objection to the pre-tribulation Rapture is rooted in a careful reading of
+                the very texts Dispensationalists cite.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">Key Arguments</h3>
+                <ul className="text-red-800 space-y-3">
+                  <li>The &ldquo;meeting in the air&rdquo; (1 Thess 4:17) draws on a Roman custom:
+                  when a dignitary arrived, citizens came out to <em>meet</em> him and escort him
+                  <em> into</em> the city &mdash; not to escape with him. This is a <em>parousia</em>
+                  reception, not an evacuation.</li>
+                  <li>1 Thess 4:16 describes &ldquo;a cry of command, the voice of an archangel, and
+                  the sound of the trumpet of God&rdquo; &mdash; <em>nothing</em> secret about it.</li>
+                  <li>Matt 24:27: &ldquo;As the lightning comes from the east and shines to the west,
+                  so will be the coming of the Son of Man&rdquo; &mdash; visible, not hidden.</li>
+                  <li>There is <em>one</em> coming, <em>one</em> trumpet, <em>one</em> resurrection,
+                  <em> one</em> event in the NT &mdash; not a two-stage process.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 4: MILLENNIAL VIEWS ==================== */}
+        {activeTab === 'millennium-views' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Three Main Views</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The millennium (Rev 20:1&ndash;6) is the most contested text in Revelation. The entire
+                doctrine of the literal Millennium rests on this one passage &mdash; six verses in a book
+                written in the apocalyptic genre, where numbers are symbolic throughout.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-3">
+                  <li><strong>Premillennialism:</strong> Christ returns <em>before</em> the millennium;
+                  he reigns on earth for 1,000 years. Subdivided into Dispensational and Historic forms.</li>
+                  <li><strong>Amillennialism:</strong> No future literal millennium; the &ldquo;1,000
+                  years&rdquo; symbolizes the current Church age; Christ reigns spiritually through the
+                  Church and the Eucharist.</li>
+                  <li><strong>Postmillennialism:</strong> The Church progressively Christianizes the world;
+                  Christ returns <em>after</em> a golden age (the &ldquo;millennium&rdquo;) achieved through
+                  the Gospel&rsquo;s spread.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Sunrise className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Historic Premillennialism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Historic Premillennialism is distinct from Dispensationalism: it has no special role for
+                national Israel, no pre-tribulation Rapture, and no temple rebuilding. The Church goes
+                through the Tribulation; Christ returns at the end to inaugurate a millennial kingdom.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Key Advocates</h3>
+                <ul className="text-blue-800 space-y-2">
+                  <li>Early proponents: Justin Martyr (2nd c.), Irenaeus (<em>Against Heresies</em>, c. 180)</li>
+                  <li>These early Fathers had a literal reading of Rev 20 &mdash; but their premillennialism
+                  was firmly rejected by Augustine and has not been the mainstream Catholic or Reformed
+                  Protestant reading since</li>
+                  <li>Modern Protestant advocates: George Eldon Ladd (Fuller Seminary), Wayne Grudem,
+                  Craig Blomberg</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Postmillennialism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Postmillennialism holds that the kingdom of God gradually expands through the preaching
+                of the Gospel until most of the world is Christianized &mdash; this long period of
+                Christian dominion is the &ldquo;millennium.&rdquo; Christ then returns at its end.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <ul className="text-green-800 space-y-2">
+                  <li>Historical advocates: Jonathan Edwards (18th c.), Charles Hodge, B.B. Warfield
+                  (Princeton School)</li>
+                  <li>Associated with &ldquo;Christian Reconstruction&rdquo; (Rushdoony, North) and
+                  Dominionism in some forms</li>
+                  <li>Challenged by: two World Wars, the Holocaust, and 20th-century atrocities, which
+                  made optimistic postmillennialism difficult to sustain; declined sharply after 1914</li>
+                  <li>Still held by some Reformed Presbyterians (theonomists) and some charismatic
+                  / NAR circles today</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Catholic Position</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Church&rsquo;s position on the millennium is clear and explicit. Amillennialism &mdash;
+                the reading that the &ldquo;1,000 years&rdquo; symbolizes the Church age &mdash; is the
+                Catholic position, established by Augustine and confirmed by the Magisterium.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">CCC 676 &mdash; The Church&rsquo;s Direct Teaching</h3>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;The Antichrist&rsquo;s deception already begins to take shape in the world every
+                  time the claim is made to realize within history that messianic hope which can only be
+                  realized beyond history through the eschatological judgment. The Church has rejected
+                  even modified forms of this falsification of the kingdom to come under the name of
+                  millenarianism.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Catechism of the Catholic Church</em>, 676</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This rejection of millenarianism is shared by Augustine (dominant since ~400 AD), the
+                Reformed tradition (Calvin, Hodge, Vos), Lutheran theology, and Eastern Orthodoxy.
+                The Catholic and Reformed Protestant traditions are remarkably united on this point.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 5: AMILLENNIALISM & POSTMILLENNIALISM ==================== */}
+        {activeTab === 'amillennialism' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Amillennialism: A Positive Account</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                &ldquo;Amillennialism&rdquo; is a confusing label (literally: &ldquo;no millennium&rdquo;)
+                but is better described as &ldquo;already-realized&rdquo; or &ldquo;spiritual&rdquo;
+                millennialism. The Kingdom of God is present <em>now</em> &mdash; in the Church, in the
+                sacraments, in the reign of Christ through the Spirit.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Amillennial Reading of Revelation 20</h3>
+                <ul className="text-amber-800 space-y-3">
+                  <li><strong>&ldquo;The thousand years&rdquo;:</strong> A symbolic period representing
+                  the era between Christ&rsquo;s first and second comings &mdash; the entire Church age.</li>
+                  <li><strong>&ldquo;Satan bound&rdquo;:</strong> Not perfectly (he still tempts and
+                  persecutes) but in the sense that the Gospel can now go to all nations (cf. Matt 12:29
+                  &mdash; the strong man is bound).</li>
+                  <li><strong>&ldquo;First resurrection&rdquo;:</strong> Spiritual resurrection &mdash;
+                  baptism, conversion, regeneration. John 5:25: &ldquo;The hour is coming, and now is,
+                  when the dead will hear the voice of the Son of God.&rdquo;</li>
+                  <li><strong>&ldquo;The second death&rdquo;:</strong> Eternal separation from God, from
+                  which the spiritually resurrected are safe.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Augustine established this reading in <em>City of God</em> (Book XX, ~420 AD), and it
+                has governed Catholicism, Reformed Protestantism, and Lutheran theology ever since.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Biblical Foundations of Amillennialism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The amillennial reading is not a retreat from the Bible; it rests on extensive New
+                Testament evidence that the Kingdom of God is both <em>already</em> present and
+                <em> not yet</em> fully revealed.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Already</h3>
+                <ul className="text-blue-800 space-y-2 mb-4">
+                  <li>&ldquo;I saw Satan fall like lightning from heaven&rdquo; (Luke 10:18 &mdash; during
+                  Jesus&rsquo; ministry)</li>
+                  <li>&ldquo;Now is the ruler of this world cast out&rdquo; (John 12:31)</li>
+                  <li>&ldquo;He disarmed the rulers and authorities&rdquo; (Col 2:15)</li>
+                  <li>&ldquo;The kingdom of God has come upon you&rdquo; (Matt 12:28)</li>
+                  <li>&ldquo;God seated him at his right hand&hellip; far above all rule and
+                  authority&rdquo; (Eph 1:20&ndash;21)</li>
+                </ul>
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Not Yet</h3>
+                <ul className="text-blue-800 space-y-2">
+                  <li>The full visible manifestation awaits the Parousia</li>
+                  <li>&ldquo;We groan inwardly waiting for the redemption of our bodies&rdquo;
+                  (Rom 8:23)</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Postmillennial Critique and Catholic Response</h2>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">Postmillennialism&rsquo;s Genuine Strengths</h3>
+                <ul className="text-green-800 space-y-2">
+                  <li>Takes seriously the power of the Gospel to transform societies</li>
+                  <li>Encourages vigorous cultural engagement and social reform</li>
+                  <li>Has a robust theology of history as moving toward a goal</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Where postmillennialism has been challenged: World War I devastated Christian Europe and
+                killed postmillennial optimism; the Holocaust, Gulags, and mass atrocities of the
+                20th century made progressive Christianization less plausible. Many postmillennialists
+                have moderated their position, allowing for setbacks within an overall positive trajectory.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Catholic approach is broadly positive about the Church&rsquo;s transforming mission
+                in history (Catholic Social Teaching, <em>Laudato Si&rsquo;</em>) but without the
+                expectation of a millennial golden age before the Second Coming. The Kingdom grows
+                quietly, like a mustard seed (Matt 13:31&ndash;32), until the Lord&rsquo;s return.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 6: LEFT BEHIND & POPULAR CULTURE ==================== */}
+        {activeTab === 'left-behind' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The <em>Left Behind</em> Series</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <em>Left Behind</em> (1995&ndash;2007): a 16-volume series by Tim LaHaye (theologian)
+                and Jerry Jenkins (novelist), with total sales over 65 million copies, multiple films,
+                and a cultural footprint that made it the most successful Christian fiction series in
+                history.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Premise</h3>
+                <p className="text-amber-800">
+                  A pre-tribulation Rapture; the &ldquo;Tribulation Force&rdquo; of converts who missed
+                  the Rapture must survive and resist the Antichrist (Nicolae Carpathia, Secretary-General
+                  of a UN-like organization) and the global false religion (&ldquo;Enigma Babylon One
+                  World Faith&rdquo;). The series popularized Dispensationalist eschatology for millions
+                  who might never read John Walvoord&rsquo;s theology.
+                </p>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Theological Problems in <em>Left Behind</em></h2>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <ul className="text-red-800 space-y-3">
+                  <li><strong>The secret Rapture:</strong> No biblical or historical basis before Darby
+                  (1830s); contradicted by every major Church Father and Reformer.</li>
+                  <li><strong>The Church as &ldquo;parenthetical&rdquo;:</strong> True believers escape
+                  history while &ldquo;secular&rdquo; humanity faces consequences &mdash; a profoundly
+                  un-Catholic and un-historic Protestant view of the Church&rsquo;s mission.</li>
+                  <li><strong>The Antichrist as political figure:</strong> The Antichrist in the NT
+                  (1 John 2:18&ndash;22; 2 Thess 2:1&ndash;12) is primarily a theological category;
+                  the series hyper-literalizes it as a single world politician.</li>
+                  <li><strong>The UN/EU as Beast:</strong> Long tradition of mapping current institutions
+                  onto prophetic figures &mdash; always fails when the institution changes.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hal Lindsey: <em>The Late, Great Planet Earth</em> (1970)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Hal Lindsey&rsquo;s <em>The Late, Great Planet Earth</em> (1970, with Carole C. Carlson)
+                sold over 35 million copies and launched the modern evangelical end-times publishing
+                industry.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-2">
+                  <li>Applied Dispensationalism to 1970s current events: Soviet Union = Gog and Magog;
+                  China = the 200-million-man army of Rev 9; Common Market = Revived Roman Empire</li>
+                  <li>Israel&rsquo;s 1967 Six-Day War as prophetic fulfillment; strongly implied the
+                  end within a generation (40 years) of 1948 &mdash; i.e., by 1988</li>
+                  <li>1988 passed; Lindsey revised his calculations, but the pattern of failed predictions
+                  continued &mdash; as it always does</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">A Catholic Assessment</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The immense popularity of <em>Left Behind</em> and similar works reflects a genuine
+                human longing: to make sense of history, to know that God wins, to find meaning in
+                current chaos. These are legitimate spiritual needs. The Catholic tradition has better
+                answers &mdash; but must engage compassionately, not dismissively.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Catholic Alternative</h3>
+                <ul className="text-amber-800 space-y-2">
+                  <li>Revelation as liturgical drama: Scott Hahn, <em>The Lamb&rsquo;s Supper</em></li>
+                  <li>Eschatology rooted in hope, not fear: Benedict XVI, <em>Spe Salvi</em> (2007)</li>
+                  <li>The four last things: Death, Judgment, Heaven, Hell &mdash; immediate and concrete</li>
+                  <li>The Eucharist as the already-present foretaste of the Kingdom</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Pope Francis: &ldquo;Christians must not become paralyzed by apocalyptic fears. We must
+                act now, in this world, as those who know that God is faithful to his promises.&rdquo;
+              </p>
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/eschatology/revelation/page.tsx
+++ b/src/app/eschatology/revelation/page.tsx
@@ -1,0 +1,935 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Clock,
+  Calendar,
+  MapPin,
+  Layers,
+  ArrowRight,
+  Mail,
+  Globe,
+  Crown,
+  Landmark,
+  AlertTriangle,
+  Star,
+  Quote,
+  ScrollText,
+  Heart,
+  Church,
+} from 'lucide-react'
+
+type TabId =
+  | 'authorship-date'
+  | 'structure'
+  | 'seven-churches'
+  | 'symbolic-language'
+  | 'catholic-reading'
+  | 'revelation-today'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'authorship-date', label: 'Authorship & Date' },
+  { id: 'structure', label: 'Structure of Revelation' },
+  { id: 'seven-churches', label: 'The Seven Churches' },
+  { id: 'symbolic-language', label: 'Symbolic Language' },
+  { id: 'catholic-reading', label: 'Catholic Interpretation' },
+  { id: 'revelation-today', label: 'Revelation & Today' },
+]
+
+export default function RevelationPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('authorship-date')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            The Book of Revelation
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The Apocalypse of St. John is the most symbolic, most misread, and most misused book
+            in the Bible. This page presents its historical context, structure, symbolic language,
+            and the Catholic interpretive tradition that has guided the Church&rsquo;s reading of
+            it for twenty centuries.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: AUTHORSHIP & DATE ==================== */}
+        {activeTab === 'authorship-date' && (
+          <div className="space-y-8">
+            {/* John of Patmos */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Author: John of Patmos</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation opens with a direct self-identification: &ldquo;I, John, your brother
+                and fellow partaker in the tribulation and kingdom and patient endurance that are in
+                the Christ, was on the island called Patmos on account of the word of God and the
+                testimony of Jesus&rdquo; (Rev 1:9). The author is John &mdash; exiled to Patmos
+                for his faith &mdash; writing to seven churches in the Roman province of Asia
+                (modern western Turkey).
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Question of Apostolic Authorship
+                </h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li>
+                    <strong>Early tradition (Justin Martyr, Irenaeus, Tertullian):</strong> identified
+                    this John with the Apostle John, son of Zebedee, author of the Fourth Gospel
+                  </li>
+                  <li>
+                    <strong>Dionysius of Alexandria (3rd c.):</strong> noted significant linguistic and
+                    stylistic differences between Revelation and the Gospel/Letters of John, and proposed
+                    a distinct author, &ldquo;John the Elder&rdquo;
+                  </li>
+                  <li>
+                    <strong>Current scholarly discussion:</strong> Most scholars today distinguish the
+                    author of Revelation from the author of the Fourth Gospel; he may have been a
+                    Jewish-Christian prophet in the Johannine tradition
+                  </li>
+                  <li>
+                    <strong>Catholic position:</strong> The Church has never dogmatically defined the
+                    precise human authorship; what matters is the book&rsquo;s divine inspiration and
+                    canonical status, which are certain
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Dating */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Date: Domitian (~95 AD) or Nero (~65 AD)?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Two main dates are proposed for the composition of Revelation, each with significant
+                consequences for interpretation. The date affects how much of the book&rsquo;s
+                prophetic content was &ldquo;predictive&rdquo; (speaking of events yet to come when
+                written) versus &ldquo;contemporaneous description&rdquo; (using symbolic language
+                to describe the current Roman situation).
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-3">
+                    Domitianic Dating (~95 AD) &mdash; Traditional Consensus
+                  </h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Irenaeus (c. 180 AD) states explicitly that the Apocalypse was seen &ldquo;at the end of Domitian&rsquo;s reign&rdquo;</li>
+                    <li>Domitian (r. 81&ndash;96 AD) demanded divine honors, requiring the titles <em>Dominus et Deus</em> (&ldquo;Lord and God&rdquo;)</li>
+                    <li>The imperial cult pressure would explain the book&rsquo;s intense focus on emperor worship and economic exclusion</li>
+                    <li>Most widely accepted by Catholic and mainline scholarship</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-3">
+                    Neronian Dating (~65 AD)
+                  </h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Proposed by scholars including Kenneth Gentry and J.A.T. Robinson</li>
+                    <li>Would place composition before the fall of Jerusalem (70 AD), making Rev primarily a prophecy of that event</li>
+                    <li>&ldquo;666&rdquo; as Nero Caesar (<em>gematria</em>) fits both dates; Nero was the first major persecutor of Christians</li>
+                    <li>Less widely accepted but not without scholarly support</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* Patmos */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Island of Patmos</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Patmos is a small volcanic island (approximately 13 km / 8 miles long) in the
+                Dodecanese Islands, off the western coast of modern Turkey. In the Roman period it
+                was used as a place of exile for political and religious troublemakers.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Patmos Today</h3>
+                <p className="text-amber-800 mb-3">
+                  The Cave of the Apocalypse &mdash; a grotto on the slope below the Monastery of
+                  St. John the Theologian &mdash; is the traditional site where John received his
+                  visions. The monastery and the cave are now a UNESCO World Heritage Site and a
+                  major destination for Christian pilgrimage. The Greek Orthodox Church maintains
+                  active liturgical life there to this day.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                John likely wrote or dictated his visions while still on Patmos, addressing them
+                to the seven churches of Asia Minor (modern western Turkey): Ephesus, Smyrna,
+                Pergamum, Thyatira, Sardis, Philadelphia, and Laodicea &mdash; communities he
+                knew and was responsible for as a prophetic leader.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 2: STRUCTURE OF REVELATION ==================== */}
+        {activeTab === 'structure' && (
+          <div className="space-y-8">
+            {/* Overall Structure */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Overall Structure of Revelation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation is not a random collection of visions. It has a careful literary
+                structure, shaped by the repeated use of the number seven, by liturgical patterns,
+                and by extensive quotation and allusion to the Old Testament (especially Ezekiel,
+                Daniel, Isaiah, and Zechariah). Understanding the structure is the first step
+                toward responsible interpretation.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Chapter-by-Chapter Overview</h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>Rev 1:</strong> Prologue; Vision of the Risen Christ among seven golden lampstands</li>
+                  <li><strong>Rev 2&ndash;3:</strong> The Seven Letters to the Seven Churches of Asia Minor</li>
+                  <li><strong>Rev 4&ndash;5:</strong> The Heavenly Throne Room; the Scroll with Seven Seals; the Lamb who was slain</li>
+                  <li><strong>Rev 6&ndash;7:</strong> Opening of the Seven Seals; the Four Horsemen; the 144,000</li>
+                  <li><strong>Rev 8&ndash;11:</strong> The Seven Trumpets; the Two Witnesses; the Seventh Trumpet</li>
+                  <li><strong>Rev 12&ndash;14:</strong> The Woman and the Dragon; the Beast from the Sea (666); the Beast from the Land; the Harvest</li>
+                  <li><strong>Rev 15&ndash;16:</strong> The Seven Bowls of God&rsquo;s Wrath</li>
+                  <li><strong>Rev 17&ndash;18:</strong> The Judgment of Babylon the Great (Rome)</li>
+                  <li><strong>Rev 19&ndash;20:</strong> The Victory of Christ; the Millennium; the Final Battle; the Last Judgment</li>
+                  <li><strong>Rev 21&ndash;22:</strong> The New Jerusalem; the New Creation; the Epilogue and final blessing</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Recapitulation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ArrowRight className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Key Structural Principle: Recapitulation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The single most important insight for reading Revelation is that it is not a
+                chronological sequence. Reading the seals, trumpets, and bowls as successive
+                chapters of a future timeline produces endless confusion and irreconcilable
+                contradictions within the text itself (multiple apparent &ldquo;end of the
+                world&rdquo; moments, recurring cosmic catastrophes, etc.).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Recapitulation Explained
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  The dominant Catholic and scholarly reading &mdash; established by Tyconius
+                  (4th c.) and Augustine (*City of God*, Book XX) &mdash; holds that the three
+                  great seven-fold sequences (seals, trumpets, bowls) are <em>parallel</em>,
+                  not successive. Each covers the same period &mdash; the whole Church age from
+                  the Resurrection to the Parousia &mdash; from a different angle or perspective.
+                  Each sequence ends at the final judgment before a new sequence begins. This
+                  is &ldquo;recapitulation.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Modern scholar G.K. Beale (<em>The Book of Revelation</em>, NIGTC, 1999) provides
+                the most thorough scholarly defense of the recapitulationist reading. His work
+                demonstrates how deeply Revelation draws on Old Testament prophetic texts and
+                how the recapitulationist structure is embedded in the book&rsquo;s own literary
+                architecture.
+              </p>
+            </div>
+
+            {/* The Lamb and the Scroll */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Lamb and the Scroll (Rev 4&ndash;5)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The central theological vision of Revelation, and its interpretive key, comes in
+                chapters 4&ndash;5. Everything that follows flows from and depends on this vision.
+                If one misunderstands chapters 4&ndash;5, one will misread the rest.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Vision&rsquo;s Theological Content
+                </h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li>
+                    <strong>Rev 4: The Heavenly Throne Room</strong> &mdash; God enthroned in glory,
+                    surrounded by 24 elders and 4 living creatures in ceaseless praise: &ldquo;Holy,
+                    holy, holy, Lord God Almighty, who was and is and is to come&rdquo; (echoing
+                    Isaiah 6 and Ezekiel 1)
+                  </li>
+                  <li>
+                    <strong>Rev 5: The Scroll Sealed Seven Times</strong> &mdash; no one in all
+                    creation is worthy to open it; John weeps; then &ldquo;the Lion of Judah, the
+                    Root of David&rdquo; is announced &mdash; and appears as &ldquo;a Lamb standing,
+                    as though it had been slain&rdquo;
+                  </li>
+                  <li>
+                    <strong>The Theological Point:</strong> Christ is sovereign over all of history;
+                    he has <em>already</em> won the decisive victory through the cross; the entire
+                    book of Revelation is the Lamb&rsquo;s unfolding of what is already accomplished
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The paradox of the Lion/Lamb &mdash; announced as conquering Lion, revealed as
+                slaughtered Lamb &mdash; is the heart of Revelation&rsquo;s theology. It declares
+                that God&rsquo;s sovereign power operates through self-giving love, not coercive
+                force. The Lamb conquers by being slain.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE SEVEN CHURCHES ==================== */}
+        {activeTab === 'seven-churches' && (
+          <div className="space-y-8">
+            {/* Letters to Real Churches */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Mail className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Letters to Real Historical Churches</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation 2&ndash;3 contains seven letters to seven actual Christian communities
+                in the Roman province of Asia (modern western Turkey). These are not allegorical
+                placeholders; they are addressed to real congregations with real problems that
+                John knew from pastoral experience.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Recurring Pattern of Each Letter
+                </h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>Description of Christ:</strong> drawn from the vision in Rev 1, tailored to each church&rsquo;s situation</li>
+                  <li><strong>Commendation:</strong> what the church is doing right (&ldquo;I know your works&hellip;&rdquo;)</li>
+                  <li><strong>Criticism:</strong> what needs to change (absent in Smyrna and Philadelphia)</li>
+                  <li><strong>Warning or encouragement:</strong> consequence of faithfulness or failure</li>
+                  <li><strong>Promise:</strong> &ldquo;to the one who conquers&rdquo; &mdash; a distinct eschatological reward for each church</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The letters reveal the actual pressures on first-century Christians: emperor
+                worship (required by the imperial cult), economic exclusion (trade guilds in Asia
+                Minor required acknowledgment of patron deities as a condition of doing business),
+                false teaching from within, wealth-induced complacency, and violent persecution.
+              </p>
+            </div>
+
+            {/* The Seven Churches */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Seven Churches and Their Messages</h2>
+              </div>
+
+              <div className="space-y-4">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Ephesus &mdash; Rev 2:1&ndash;7</h3>
+                  <p className="text-blue-800 text-sm">
+                    Commended for doctrinal soundness and rejection of false apostles. Criticized:
+                    &ldquo;You have abandoned the love you had at first.&rdquo; Warning: repent
+                    or the lampstand will be removed. Promise: the tree of life.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Smyrna &mdash; Rev 2:8&ndash;11</h3>
+                  <p className="text-blue-800 text-sm">
+                    No criticism. Suffering community; materially poor but spiritually rich.
+                    &ldquo;Be faithful unto death, and I will give you the crown of life.&rdquo;
+                    The paradigmatic church under persecution.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Pergamum &mdash; Rev 2:12&ndash;17</h3>
+                  <p className="text-blue-800 text-sm">
+                    Located where &ldquo;Satan&rsquo;s throne is&rdquo; (the great altar of Zeus
+                    and the imperial cult temple). Some have compromised with false teaching
+                    (the Nicolaitan doctrine) and idol food. Call to repentance.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Thyatira &mdash; Rev 2:18&ndash;29</h3>
+                  <p className="text-blue-800 text-sm">
+                    Commended for growth in love and service. Criticized for tolerating
+                    &ldquo;Jezebel,&rdquo; a prophetess leading members into sexual immorality
+                    and the eating of food sacrificed to idols (a common trade-guild compromise).
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Sardis &mdash; Rev 3:1&ndash;6</h3>
+                  <p className="text-blue-800 text-sm">
+                    &ldquo;You have a reputation for being alive, but you are dead.&rdquo;
+                    Spiritually complacent; good reputation with no substance. Only a small
+                    remnant has not soiled its garments.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Philadelphia &mdash; Rev 3:7&ndash;13</h3>
+                  <p className="text-blue-800 text-sm">
+                    No criticism. Small but faithful; &ldquo;I have set before you an open door,
+                    which no one is able to shut.&rdquo; Commended for keeping Christ&rsquo;s
+                    word and not denying his name under pressure.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-2">Laodicea &mdash; Rev 3:14&ndash;22</h3>
+                  <p className="text-blue-800 text-sm">
+                    The famous &ldquo;lukewarm&rdquo; church. Wealthy, self-sufficient, spiritually
+                    blind. &ldquo;I am about to spit you out of my mouth.&rdquo; Christ stands at
+                    the door knocking: &ldquo;If anyone hears my voice and opens the door, I will
+                    come in to him and eat with him, and he with me.&rdquo;
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Universal Application */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Universal Application</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The seven churches represent the whole Church (7 = completeness) in every age and
+                culture. This is the reason the letters are addressed to &ldquo;the seven
+                churches,&rdquo; not to the wider Roman Empire or to humanity in general: they
+                are addressed to <em>us</em>.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">Questions for Every Generation</h3>
+                <ul className="text-green-800 space-y-2 text-sm">
+                  <li>Do we have the first love of Ephesus &mdash; or have we become merely orthodox without fire?</li>
+                  <li>Do we bear the suffering witness of Smyrna without compromise?</li>
+                  <li>Have we accommodated ourselves to the &ldquo;Pergamum&rdquo; pressure of cultural idol worship?</li>
+                  <li>Do we have the &ldquo;Sardis&rdquo; reputation for life while being spiritually dead?</li>
+                  <li>Are we the &ldquo;Laodicea&rdquo; of our age &mdash; wealthy, comfortable, and oblivious?</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 4: SYMBOLIC LANGUAGE ==================== */}
+        {activeTab === 'symbolic-language' && (
+          <div className="space-y-8">
+            {/* Throne Room Imagery */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Crown className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Throne Room Imagery (Rev 4&ndash;5)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation&rsquo;s heavenly throne room in chapters 4&ndash;5 is built almost
+                entirely from Old Testament imagery, which original readers saturated in the
+                Hebrew Scriptures would have recognized immediately. Modern readers who do not
+                know Ezekiel 1, Isaiah 6, and Daniel 7 will inevitably misread Revelation.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Key Symbols Decoded</h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li>
+                    <strong>24 Elders:</strong> Likely the 12 patriarchs of Israel + the 12 apostles &mdash;
+                    the whole people of God, Old and New Covenants together before the throne
+                  </li>
+                  <li>
+                    <strong>4 Living Creatures</strong> (lion, ox, man, eagle): Draw on Ezekiel 1 and
+                    Isaiah 6; traditionally interpreted as the four evangelists (Matthew/man, Mark/lion,
+                    Luke/ox, John/eagle) and as all of creation in worship before God
+                  </li>
+                  <li>
+                    <strong>The Sea of Glass:</strong> The separation between God&rsquo;s holiness and
+                    creation; at the end (Rev 21:1) &ldquo;the sea was no more&rdquo; &mdash; direct
+                    access restored
+                  </li>
+                  <li>
+                    <strong>&ldquo;Holy, Holy, Holy&rdquo;:</strong> The <em>Trisagion</em> from
+                    Isaiah 6:3, woven into the Church&rsquo;s liturgy as the Sanctus of the Mass
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Babylon / The Whore */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Landmark className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Babylon / The Whore (Rev 17&ndash;18)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation 17&ndash;18 presents one of the book&rsquo;s most powerful symbolic
+                figures: the Great Whore Babylon, seated on the Beast, on &ldquo;seven
+                mountains&rdquo; (17:9), drunk with &ldquo;the blood of the saints and the blood
+                of the witnesses to Jesus&rdquo; (17:6). For original readers, this figure needed
+                no decoding: it is Rome.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">
+                  Rome as &ldquo;Babylon&rdquo;
+                </h3>
+                <ul className="text-red-800 space-y-2 text-sm">
+                  <li><strong>&ldquo;Seven mountains&rdquo; (Rev 17:9):</strong> Rome was universally known as the city on seven hills; ancient sources routinely use this description</li>
+                  <li><strong>&ldquo;Drunk with the blood of saints&rdquo;:</strong> Rome had murdered Peter, Paul, and thousands of Christians in the arenas under Nero</li>
+                  <li><strong>&ldquo;Babylon&rdquo; as a cipher for Rome:</strong> Also used in 1 Peter 5:13 (&ldquo;She who is at Babylon&hellip; greets you&rdquo;), confirming it was a common early Christian code</li>
+                  <li><strong>Universal application:</strong> Any empire or culture that oppresses God&rsquo;s people and demands ultimate allegiance inherits the &ldquo;Babylon&rdquo; symbol</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Mark of the Beast */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Mark of the Beast (666)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Rev 13:16&ndash;18 describes a mark on the right hand or forehead, without which
+                &ldquo;no one can buy or sell,&rdquo; and identifies it with the number 666, &ldquo;the
+                number of a man.&rdquo; This passage has generated more speculation and fear than
+                almost any other in the Bible. Understanding its historical context dissolves
+                most of that speculation.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">What 666 Meant to Original Readers</h3>
+                <p className="text-red-800 mb-3">
+                  <em>Gematria</em> is the ancient practice of assigning numerical values to letters.
+                  The Hebrew letters of &ldquo;Nero Caesar&rdquo; (NRWN QSR) sum to exactly 666:
+                  N(50) + R(200) + W(6) + N(50) + Q(100) + S(60) + R(200) = 666. This
+                  is now the strong scholarly consensus. The &ldquo;mark&rdquo; itself refers to
+                  participation in the Roman imperial cult &mdash; the economic and religious system
+                  that excluded those who refused to acknowledge the emperor as divine.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">What 666 Does NOT Refer To</h3>
+                <p className="text-amber-800 mb-3">
+                  Despite recurring claims, there is no credible scholarly or magisterial basis for
+                  identifying the &ldquo;mark of the Beast&rdquo; with: Universal Product Code
+                  (UPC) barcodes, RFID microchips, Social Security numbers, credit cards, COVID-19
+                  vaccines, or any current technology. Each generation has proposed its own
+                  candidate; each has been wrong. The mark&rsquo;s deeper application is to any
+                  system that demands ultimate loyalty against God &mdash; a category that applies
+                  to many situations across history.
+                </p>
+              </div>
+            </div>
+
+            {/* The New Jerusalem */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The New Jerusalem (Rev 21&ndash;22)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The climax of Revelation is not judgment but renewal &mdash; the descent of the
+                New Jerusalem from heaven, the dwelling of God with humanity, and the restoration
+                of creation. This is not a retreat from the earth but its transformation.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The New Jerusalem: Key Symbols
+                </h3>
+                <ul className="text-green-800 space-y-2 text-sm">
+                  <li><strong>A city descending from heaven:</strong> The New Creation comes as God&rsquo;s gift, not human achievement</li>
+                  <li><strong>Dimensions (12,000 stadia, perfectly cubical):</strong> Symbolic completeness; the cube shape echoes the Holy of Holies in Solomon&rsquo;s Temple &mdash; the whole city is God&rsquo;s presence</li>
+                  <li><strong>12 gates (named for the 12 tribes), 12 foundations (named for the 12 apostles):</strong> The whole people of God, Old and New Testaments, constitute the city</li>
+                  <li><strong>No temple:</strong> &ldquo;The Lord God Almighty and the Lamb are its temple&rdquo; &mdash; the separation is ended; direct access</li>
+                  <li><strong>No sun or moon:</strong> &ldquo;The Lamb is its lamp&rdquo; &mdash; God&rsquo;s own light fills everything</li>
+                  <li><strong>The River of Life and the Tree of Life (Rev 22:1&ndash;2):</strong> Eden restored; the curse of Genesis 3 is reversed; death is no more</li>
+                </ul>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Final Promise
+                </h3>
+                <p className="text-green-800 italic mb-3">
+                  &ldquo;The throne of God and of the Lamb will be in it, and his servants will
+                  worship him. They will see his face, and his name will be on their foreheads.
+                  And night will be no more. They will need no light of lamp or sun, for the
+                  Lord God will be their light, and they will reign forever and ever.&rdquo;
+                </p>
+                <p className="text-green-700 text-sm">&mdash; Revelation 22:3&ndash;5</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 5: CATHOLIC INTERPRETATION ==================== */}
+        {activeTab === 'catholic-reading' && (
+          <div className="space-y-8">
+            {/* Recapitulationist Reading */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Recapitulationist Reading (Amillennial)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The dominant reading in Catholic tradition goes back to Tyconius (c. 380 AD) and
+                Augustine (<em>City of God</em>, Book XX, c. 420 AD). It is broadly called
+                &ldquo;amillennialism&rdquo; &mdash; not because it denies the millennium, but
+                because it reads the &ldquo;1,000 years&rdquo; as the present Church age rather
+                than a literal future period.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Key Elements of the Catholic Reading</h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>The three septets (seals, trumpets, bowls) recapitulate:</strong> they are parallel coverages of the same Church-age period, not successive future chapters</li>
+                  <li><strong>The &ldquo;1,000 years&rdquo; (Rev 20):</strong> symbolizes the current Church age between Christ&rsquo;s Resurrection and the Parousia</li>
+                  <li><strong>Satan is &ldquo;bound&rdquo;:</strong> in the sense that the Gospel can now spread to all nations (cf. Matt 12:29 &mdash; the strong man is bound)</li>
+                  <li><strong>The &ldquo;first resurrection&rdquo;:</strong> baptism and spiritual regeneration; the &ldquo;second resurrection&rdquo; is the bodily resurrection at the Last Day</li>
+                  <li><strong>Grounding in the whole NT:</strong> Christ has <em>already</em> conquered (Col 2:15); we are <em>already</em> &ldquo;seated with him in heavenly places&rdquo; (Eph 2:6)</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Key Fathers and Theologians */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Quote className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Key Church Fathers and Theologians</h2>
+              </div>
+
+              <div className="space-y-4">
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">Tyconius (~380 AD)</h3>
+                  <p className="text-purple-800 text-sm">
+                    A Donatist scholar whose <em>Liber Regularum</em> (Book of Rules) established the
+                    symbolic, recapitulationist reading of Revelation. Although Donatist, his biblical
+                    hermeneutic was so sound that Augustine incorporated it wholesale, and it became
+                    the foundation of mainstream Catholic Revelation interpretation.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">St. Augustine, <em>City of God</em> Book XX (~420 AD)</h3>
+                  <p className="text-purple-800 text-sm">
+                    The most influential Catholic reading of Revelation in Church history. Augustine
+                    argues that the &ldquo;1,000 years&rdquo; of Rev 20 represents the Church age;
+                    the &ldquo;first resurrection&rdquo; is the conversion and baptism of sinners;
+                    the &ldquo;city of God&rdquo; versus the &ldquo;city of man&rdquo; is the
+                    fundamental eschatological tension of all history. This reading prevailed and
+                    has been the standard Catholic approach ever since.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-purple-900 mb-2">Cardinal Joseph Ratzinger / Pope Benedict XVI, <em>Eschatology</em> (1977)</h3>
+                  <p className="text-purple-800 text-sm">
+                    A comprehensive Catholic eschatology; skeptical of all literalistic end-times
+                    readings; focused on the theological content of Christian hope: the resurrection,
+                    purgatory, heaven, and the final consummation. The most rigorous modern Catholic
+                    treatment of the subject.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* CCC on Revelation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The CCC on Revelation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catechism does not comment verse-by-verse on Revelation, but uses it
+                extensively in presenting Catholic teaching on eschatology and the New Creation.
+                The key texts are concentrated in CCC 668&ndash;682 and 1020&ndash;1060.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Key Catechism Uses of Revelation</h3>
+                <ul className="text-blue-800 space-y-2 text-sm">
+                  <li><strong>Rev 1:8 (&ldquo;Alpha and Omega&rdquo;):</strong> Cited in CCC 2 on God&rsquo;s eternal nature and purpose in creation</li>
+                  <li><strong>Rev 7:9 (the great multitude):</strong> Cited in CCC 1045 on the New Jerusalem as the goal of all history</li>
+                  <li><strong>Rev 20:12 (the books opened at judgment):</strong> Cited in CCC 1040 on the Last Judgment</li>
+                  <li><strong>Rev 21:1&ndash;5 (all things new):</strong> Cited in CCC 1042&ndash;1043 on the renewal of the universe</li>
+                </ul>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">CCC 676: The Definitive Rejection of Millenarianism</h3>
+                <p className="text-red-800 italic mb-3">
+                  &ldquo;The Antichrist&rsquo;s deception already begins to take shape in the world
+                  every time the claim is made to realize within history that messianic hope which
+                  can only be realized beyond history through the eschatological judgement. The
+                  Church has rejected even modified forms of this falsification of the kingdom
+                  to come under the name of millenarianism, especially the &lsquo;intrinsically
+                  perverse&rsquo; political form of a secular messianism.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm">&mdash; CCC 676</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 6: REVELATION & TODAY ==================== */}
+        {activeTab === 'revelation-today' && (
+          <div className="space-y-8">
+            {/* Revelation as Pastoral Document */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Revelation as Pastoral Document</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Revelation was written to encourage suffering Christians. Its primary purpose is
+                not prediction &mdash; it is encouragement. Understanding this pastoral purpose
+                transforms how we read the book.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Central Message of Revelation
+                </h3>
+                <p className="text-green-800 italic mb-3">
+                  &ldquo;I know your tribulation and your poverty (but you are rich) and the slander
+                  of those who say that they are Jews and are not, but are a synagogue of Satan.
+                  Do not fear what you are about to suffer. Behold, the devil is about to throw
+                  some of you into prison, that you may be tested, and for ten days you will have
+                  tribulation. Be faithful unto death, and I will give you the crown of life.&rdquo;
+                </p>
+                <p className="text-green-700 text-sm">&mdash; Revelation 2:9&ndash;10 (to Smyrna)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Every generation since the 1st century has been tempted to identify its own
+                political crises as the &ldquo;final tribulation&rdquo; and its own persecutors
+                as &ldquo;the Antichrist.&rdquo; Every such identification has eventually been
+                proven wrong. But the message &mdash; God is sovereign; the Lamb has conquered;
+                bear up in faithfulness &mdash; has proven true in every generation and remains
+                directly applicable to Christians under pressure today.
+              </p>
+            </div>
+
+            {/* Liturgical Reading */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Liturgical Reading of Revelation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A characteristically Catholic way to read Revelation is through the lens of the
+                Mass. Scott Hahn&rsquo;s <em>The Lamb&rsquo;s Supper</em> (Doubleday, 1999) argues
+                &mdash; drawing on patristic and liturgical tradition &mdash; that the best
+                commentary on Revelation is not a prophecy handbook but the Order of the Mass
+                itself. The Catholic liturgy is the earthly participation in the heavenly liturgy
+                of Revelation 4&ndash;5.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Revelation in the Mass</h3>
+                <ul className="text-amber-800 space-y-2 text-sm">
+                  <li><strong>Sanctus (&ldquo;Holy, Holy, Holy&rdquo;):</strong> Directly from Rev 4:8 and Isaiah 6:3 &mdash; the ceaseless hymn of the four living creatures</li>
+                  <li><strong>The Gloria:</strong> Echoes the hymns of praise in Rev 4&ndash;5</li>
+                  <li><strong>The Eucharistic Prayer:</strong> Contains elements of the heavenly liturgy &mdash; the incense of prayers, the altar, the Lamb who was slain</li>
+                  <li><strong>The Communion rite:</strong> Prefigures the Wedding Feast of the Lamb (Rev 19:9)</li>
+                </ul>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;In the earthly liturgy we take part in a foretaste of that heavenly liturgy
+                  which is celebrated in the holy city of Jerusalem toward which we journey as
+                  pilgrims, where Christ is sitting at the right hand of God.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; CCC 1090, citing <em>Sacrosanctum Concilium</em> 8</p>
+              </div>
+            </div>
+
+            {/* Already but Not Yet */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ArrowRight className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Living in the &ldquo;Already but Not Yet&rdquo;</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The entire New Testament is shaped by a fundamental eschatological tension:
+                the Kingdom of God has <em>already</em> come in Christ&rsquo;s death and
+                resurrection; it has <em>not yet</em> come in its fullness. Revelation gives
+                this tension its most dramatic expression.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-6 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-green-900 mb-3">Already</h3>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>Christ has risen from the dead</li>
+                    <li>The Spirit has been poured out on the Church</li>
+                    <li>Satan has been &ldquo;cast down&rdquo; (Rev 12:9; John 12:31)</li>
+                    <li>Death has been conquered in principle (1 Cor 15:54&ndash;55)</li>
+                    <li>We are &ldquo;already&rdquo; seated with Christ in heavenly places (Eph 2:6)</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-blue-900 mb-3">Not Yet</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>We still suffer, die, and experience evil</li>
+                    <li>Christ has not yet returned in glory</li>
+                    <li>The dead have not yet been raised in body</li>
+                    <li>Creation has not yet been renewed</li>
+                    <li>God&rsquo;s Kingdom has not yet been fully manifested</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Revelation&rsquo;s Final Prayer
+                </h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;He who testifies to these things says, &lsquo;Surely I am coming
+                  soon.&rsquo; Amen. Come, Lord Jesus!&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Revelation 22:20</p>
+                <p className="text-blue-800 text-sm mt-3">
+                  <em>Maranatha</em> (&ldquo;Come, Lord&rdquo;; 1 Cor 16:22) &mdash; the earliest
+                  Christian prayer, preserved in Aramaic, expressing the Church&rsquo;s perennial
+                  longing for the fullness of God&rsquo;s Kingdom. This is the final word of
+                  Revelation and of the entire New Testament: not fear, not calculation, but
+                  longing.
+                </p>
+              </div>
+            </div>
+
+            {/* Approved Resources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Approved Resources</h2>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-amber-900 mb-3">Magisterial Documents</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li><em>Catechism of the Catholic Church</em>, 668&ndash;682, 1020&ndash;1060 (especially 1042&ndash;1044 on the New Creation)</li>
+                    <li>Augustine, <em>City of God</em>, Book XX &mdash; the classic Catholic reading</li>
+                    <li><em>Sacrosanctum Concilium</em> 8 (CCC 1090 on liturgy as foretaste of heaven)</li>
+                  </ul>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="text-base font-semibold text-amber-900 mb-3">Scholarly Works</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>Joseph Ratzinger / Benedict XVI, <em>Eschatology: Death and Eternal Life</em> (CUA Press, 1988)</li>
+                    <li>Scott Hahn, <em>The Lamb&rsquo;s Supper</em> (Doubleday, 1999)</li>
+                    <li>G.K. Beale, <em>The Book of Revelation</em> (NIGTC, 1999)</li>
+                    <li>Michael Gorman, <em>Reading Revelation Responsibly</em> (Cascade, 2011)</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/eschatology/signs-of-times/page.tsx
+++ b/src/app/eschatology/signs-of-times/page.tsx
@@ -1,0 +1,752 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Eye,
+  Scale,
+  Church,
+  Layers,
+  AlertTriangle,
+  Waves,
+  Star,
+  XCircle,
+  Clock,
+  Heart,
+  Sunrise,
+  BookOpen,
+  Users,
+  CheckCircle,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-are-signs'
+  | 'matthew-24'
+  | 'marian-apparitions'
+  | 'avoiding-date-setting'
+  | 'hope-virtue'
+  | 'practical-living'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-are-signs', label: 'What Are “Signs of the Times”?' },
+  { id: 'matthew-24', label: 'Matthew 24 Revisited' },
+  { id: 'marian-apparitions', label: 'Marian Apparitions & End Times' },
+  { id: 'avoiding-date-setting', label: 'Avoiding Date-Setting' },
+  { id: 'hope-virtue', label: 'Hope as Eschatological Virtue' },
+  { id: 'practical-living', label: 'Practical Living' },
+]
+
+export default function SignsOfTimesPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('what-are-signs')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Signs of the Times
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            How does the Church approach current events in light of eschatology? What does Jesus mean
+            by &ldquo;signs of the times&rdquo;? How do we avoid both false alarm and blind complacency?
+            This page presents the Catholic framework for reading history and current events.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: WHAT ARE "SIGNS OF THE TIMES"? ==================== */}
+        {activeTab === 'what-are-signs' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Eye className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Source: Matthew 16:3</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Jesus rebukes the Pharisees: &ldquo;You know how to interpret the appearance of the sky,
+                but you cannot interpret the signs of the times&rdquo; (Matt 16:3). Also: &ldquo;When
+                you see these things happening, you know that the kingdom of God is near&rdquo;
+                (Luke 21:31).
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Phrase in Catholic Tradition</h3>
+                <p className="text-amber-800 mb-3">
+                  Pope John XXIII used &ldquo;signs of the times&rdquo; in his 1961 apostolic constitution
+                  <em> Humanae Salutis</em> convening Vatican II: &ldquo;In the present order of things,
+                  Divine Providence is leading us to a new order of human relations.&rdquo;
+                </p>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;The Church has always had the duty of scrutinizing the signs of the times and
+                  of interpreting them in the light of the Gospel.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Gaudium et Spes</em> 4 (Vatican II)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This is a call to <em>discernment</em>, not calculation; attentiveness to history, not
+                alarm. The Church reads history not to predict the hour of the end but to understand
+                what God is calling his people to do <em>now</em>.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Two Kinds of &ldquo;Signs&rdquo;</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <div className="space-y-4">
+                  <div>
+                    <h4 className="font-semibold text-blue-900 mb-1">Eschatological Signs (pointing to the end)</h4>
+                    <p className="text-blue-800">Evangelization of all nations; the conversion of Israel;
+                    the final trial; the Antichrist &mdash; CCC 673&ndash;677. These are real future
+                    events whose fulfillment only God knows.</p>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-blue-900 mb-1">Signs of the Times (reading present history)</h4>
+                    <p className="text-blue-800">Social, cultural, political, and spiritual developments
+                    that illuminate the Church&rsquo;s mission in the present. These call for discernment
+                    and response, not prophetic calculation.</p>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Confusion of these two categories leads to either:
+              </p>
+              <ul className="text-gray-700 space-y-2 ml-4">
+                <li><em>Over-reading:</em> Every earthquake = the end is near; every political crisis =
+                the Antichrist has arrived.</li>
+                <li><em>Under-reading:</em> Spiritual blindness to genuine challenges that require the
+                Church&rsquo;s response &mdash; climate crisis, poverty, persecution of Christians.</li>
+              </ul>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Role in History</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Church is not a passive observer waiting for the end; she is the Body of Christ
+                actively working in history for the Kingdom.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;The Church, by reason of her role and competence, is not identified in any way
+                  with the political community nor bound to any political system&hellip; At the same time,
+                  she serves as a leaven and as a kind of soul for human society.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Gaudium et Spes</em> 40</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Eschatology does not license quietism or withdrawal from the world; it calls for
+                <em> deeper</em> engagement. We act in history knowing that history is heading toward
+                God&rsquo;s kingdom, and that nothing done in love will be wasted (1 Cor 15:58).
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 2: MATTHEW 24 REVISITED ==================== */}
+        {activeTab === 'matthew-24' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Double-Horizon Structure</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Matthew 24 has a &ldquo;double horizon&rdquo; &mdash; addressing both the destruction
+                of Jerusalem in 70 AD and the final end of history. Understanding which verses belong
+                to which horizon is essential to reading the chapter correctly.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <div className="space-y-4">
+                  <div>
+                    <h4 className="font-semibold text-amber-900 mb-1">Signs Already Fulfilled (70 AD)</h4>
+                    <p className="text-amber-800">False messiahs (there were many in the Jewish War);
+                    wars and rumors of wars; the Temple&rsquo;s destruction (v. 2: &ldquo;not one stone
+                    will be left on another&rdquo;); the spread of the Gospel to all nations before the
+                    end of the apostolic generation.</p>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-amber-900 mb-1">Signs That Remain</h4>
+                    <p className="text-amber-800">Cosmic disturbances (sun darkened, stars falling);
+                    the visible Paro&uuml;sia of the Son of Man; the general resurrection and gathering
+                    of the elect.</p>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Key pastoral insight: the fall of Jerusalem in 70 AD was a <em>type</em> or preview of
+                the final judgment. History has already shown us what divine judgment looks like &mdash;
+                and it is both terrible and redemptive.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">&ldquo;Wars and Rumors of Wars&rdquo;</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Matt 24:6&ndash;7: &ldquo;You will hear of wars and rumors of wars&hellip; nation will
+                rise against nation.&rdquo; Jesus explicitly says: <strong>&ldquo;See that you are not
+                alarmed, for this must take place, but the end is not yet.&rdquo;</strong>
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-2">
+                  <li>The Church&rsquo;s call: do <em>not</em> interpret every war as a sign of the end.
+                  These are normal features of fallen human history.</li>
+                  <li>The 20th century had two World Wars; neither was &ldquo;the end.&rdquo; The
+                  end-times industry produced countless books identifying each conflict as the final
+                  one &mdash; all were wrong.</li>
+                  <li>Catholic response to war: prayer, peacemaking, solidarity with victims &mdash;
+                  not calculation of eschatological timetables.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Waves className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Natural Disasters</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Matt 24:7: &ldquo;there will be famines and earthquakes in various places. All these
+                are but the beginning of the birth pains.&rdquo; &ldquo;Beginning of birth pains&rdquo;
+                &mdash; these are not signs of the end but normal features of the creation awaiting
+                redemption.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;The whole creation has been groaning together in the pains of childbirth
+                  until now.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-4">&mdash; Romans 8:22</p>
+                <p className="text-blue-800">
+                  Pope Francis, <em>Laudato Si&rsquo;</em> (2015): Climate change and the ecological
+                  crisis are signs of the times calling for conversion and care for creation &mdash;
+                  not an end-times trigger but a present moral call. The Catholic response is compassion,
+                  relief work, and structural change, not eschatological calculation.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 3: MARIAN APPARITIONS & END TIMES ==================== */}
+        {activeTab === 'marian-apparitions' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Fatima and Eschatological Language</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Fatima (1917) is the most prominent approved apparition with eschatological elements:
+                Russia&rsquo;s errors spreading, wars, the &ldquo;annihilation of nations&rdquo; if
+                people do not repent, and the promise of the Triumph of the Immaculate Heart.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Third Secret and Its Interpretation</h3>
+                <p className="text-amber-800 mb-3">
+                  The Third Secret (revealed by the Vatican in 2000): a vision of a bishop in white
+                  (widely interpreted as a past or future Pope) being killed amid a ruined city. The
+                  Vatican&rsquo;s official interpretation is that it refers to 20th-century persecutions
+                  &mdash; not a future event.
+                </p>
+                <p className="text-amber-800">
+                  The &ldquo;conversion of Russia&rdquo; and the Triumph of the Immaculate Heart are
+                  read by many in the Church as fulfilled in the fall of Soviet communism &mdash; not
+                  a future millennial scenario.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Church&rsquo;s teaching: Private revelations (even approved ones like Fatima) do
+                not add to the deposit of faith; they are calls to prayer, conversion, and penance &mdash;
+                not timetables for the end.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Approved Apparitions Say (and Don&rsquo;t Say)</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;Throughout the ages, there have been so-called &lsquo;private&rsquo;
+                  revelations&hellip; It is not their role to improve or complete Christ&rsquo;s
+                  definitive Revelation, but to help live more fully by it in a certain period
+                  of history.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-4">&mdash; <em>Catechism of the Catholic Church</em>, 67</p>
+                <ul className="text-blue-800 space-y-2">
+                  <li>Approved apparitions (Fatima, Lourdes, Guadalupe, Kibeho): Calls to prayer,
+                  penance, and conversion; acknowledgment of present crises; hope in Mary&rsquo;s
+                  intercession.</li>
+                  <li><strong>None</strong> of the approved apparitions gives a specific date for
+                  the end of the world.</li>
+                  <li>The Church&rsquo;s consistent teaching: the message of Marian apparitions is
+                  always the same &mdash; pray, repent, trust in God; not end-times chronologies.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Unapproved Apparitions and Sensationalism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Many claimed apparitions that have <em>not</em> been approved by the Church contain
+                sensational end-times predictions, specific dates, and catastrophic scenarios.
+              </p>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <ul className="text-red-800 space-y-3">
+                  <li>Examples: Bayside (New York, condemned by the Diocese of Brooklyn), Garabandal
+                  (not approved), Medjugorje (under investigation; messages not approved for public
+                  devotion)</li>
+                  <li>The pattern: unapproved apparitions tend to create dependency, fear, and
+                  distraction from the sacramental life of the Church</li>
+                  <li>The Catholic test: Does the message draw people closer to the Church, the
+                  sacraments, and prayer? Or does it create fear, schism, or dependency on the
+                  visionary?</li>
+                  <li>The Church&rsquo;s discernment process is precisely designed to protect the
+                  faithful from exploitation of eschatological fear</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 4: AVOIDING DATE-SETTING ==================== */}
+        {activeTab === 'avoiding-date-setting' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <XCircle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Clear Prohibition</h2>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <p className="text-red-800 italic mb-2">
+                  &ldquo;But about that day or hour no one knows, not even the angels in heaven,
+                  nor the Son, but only the Father.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm mb-4">&mdash; Matthew 24:36 / Mark 13:32</p>
+                <p className="text-red-800 italic mb-2">
+                  &ldquo;It is not for you to know times or seasons that the Father has fixed by
+                  his own authority.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm mb-4">&mdash; Acts 1:7</p>
+                <p className="text-red-800 italic mb-2">
+                  &ldquo;The day of the Lord will come like a thief in the night.&rdquo;
+                </p>
+                <p className="text-red-700 text-sm">&mdash; 1 Thessalonians 5:2</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Jesus&rsquo; statement is categorical: no human being can know the timing of the end.
+                These texts are not suggestions; they are direct prohibitions on end-times calculation.
+                Every teacher who has set a date has violated these texts directly.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">A Brief History of Failed Predictions</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Every single end-times prediction in 2,000 years of Christianity has been wrong.
+                This is not a coincidence; it is a direct consequence of violating Jesus&rsquo;
+                explicit teaching.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-3">
+                  <li><strong>Montanus</strong> (~156 AD): Proclaimed the New Jerusalem would descend
+                  in Phrygia; the church condemned Montanism as heresy.</li>
+                  <li><strong>Hippolytus of Rome</strong> (~235 AD): Calculated the end in 500 AD
+                  based on the dimensions of the Ark.</li>
+                  <li><strong>Martin Luther</strong> (~1520): Believed the end was approximately
+                  50 years away.</li>
+                  <li><strong>William Miller</strong> (Baptist): Predicted Christ&rsquo;s return on
+                  October 22, 1844; the &ldquo;Great Disappointment&rdquo; shattered his movement;
+                  the Adventist movement emerged from this failure.</li>
+                  <li><strong>Charles Russell</strong> (JW founder): Predicted the end in 1914;
+                  the organization has revised its predictions multiple times since.</li>
+                  <li><strong>Hal Lindsey</strong>: <em>The Late, Great Planet Earth</em> (1970)
+                  strongly implied the end by 1988; it did not happen.</li>
+                  <li><strong>Harold Camping</strong>: Predicted May 21, 2011, then October 21,
+                  2011; both failed; he died in 2013.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Spiritual Danger of Date-Setting</h2>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg mb-6">
+                <ul className="text-red-800 space-y-3">
+                  <li><strong>Immediate harm:</strong> People sell possessions, abandon schooling,
+                  damage relationships, and withdraw from civic life.</li>
+                  <li><strong>Long-term harm:</strong> When the prediction fails, faith collapses;
+                  vulnerable people are devastated and sometimes abandon Christianity entirely.</li>
+                  <li><strong>Theological harm:</strong> Each failed prediction makes the Gospel
+                  look foolish; it is a gift to atheists and skeptics.</li>
+                  <li><strong>Personal harm to the teacher:</strong> Living under self-imposed
+                  eschatological pressure; the need to constantly revise and explain away failures.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Virtue of Eschatological Humility</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Church&rsquo;s posture is constant readiness without anxious calculation. This
+                readiness is not a burden; it is a gift &mdash; the freedom to live fully in the
+                present, engaged with the world, trusting God with the future.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <ul className="text-green-800 space-y-3">
+                  <li>St. Francis of Assisi (attributed): &ldquo;If I knew the world would end
+                  tomorrow, I would plant an apple tree today&rdquo; &mdash; engagement with the
+                  present, trust in God&rsquo;s timing.</li>
+                  <li>St. Thomas More (hours before execution): Calmly declared he was the king&rsquo;s
+                  good servant, but God&rsquo;s first &mdash; the eschatological perspective gives
+                  equanimity, not paralysis.</li>
+                  <li>Benedict XVI, <em>Spe Salvi</em> &sect;15: &ldquo;We must accept that what
+                  awaits us is not something we can reach by our own efforts &mdash; it is a gift,
+                  and this is why we can say that hope is not just a human virtue; it is a
+                  theological virtue.&rdquo;</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 5: HOPE AS ESCHATOLOGICAL VIRTUE ==================== */}
+        {activeTab === 'hope-virtue' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sunrise className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hope: The Theological Virtue of the Future</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The three theological virtues (1 Cor 13:13): Faith, Hope, Love. Hope is specifically
+                <em> eschatological</em> &mdash; oriented toward the future, toward what God has promised.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;Hope is the theological virtue by which we desire the kingdom of heaven and
+                  eternal life as our happiness, placing our trust in Christ&rsquo;s promises and
+                  relying not on our own strength, but on the help of the grace of the Holy Spirit.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Catechism of the Catholic Church</em>, 1817</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Hope is not optimism (a temperament) or wishful thinking; it is a theological virtue
+                grounded in God&rsquo;s promises, made possible by grace. It is the distinctive
+                Christian response to the future &mdash; neither anxiety nor complacency.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Benedict XVI&rsquo;s <em>Spe Salvi</em> (2007)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                One of the most important papal documents of the 21st century; a sustained meditation
+                on Christian hope and its relevance to the present age.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-3">
+                  <li>&ldquo;We have been saved by hope&rdquo; (Rom 8:24) &mdash; the past tense
+                  paradox: saved <em>already</em> in hope, but not yet in full possession.</li>
+                  <li>The great temptations: materialism (salvation through technology and progress);
+                  nihilism (no future, no meaning); individualism (private afterlife without cosmic
+                  dimension).</li>
+                  <li>The Catholic alternative: a hope that is personal but also cosmic; individual
+                  but also ecclesial; present but also future.</li>
+                  <li>&ldquo;The darkness of the next day&rsquo;s journey is pierced by the certainty
+                  that God is good, and that death has been conquered&rdquo; &mdash; the resurrection
+                  as the unshakeable ground of hope.</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                True hope relativizes present suffering without denying it. It makes action possible
+                without making it desperate. It is the secret of the saints&rsquo; joy in the midst
+                of tribulation.
+              </p>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Eschatological Hope and Social Action</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The coming Kingdom does not render present action meaningless &mdash; it gives it
+                ultimate meaning. Everything done in love will be taken up into the renewed creation.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <p className="text-green-800 italic mb-3">
+                  &ldquo;Therefore, my beloved brothers, be steadfast, immovable, always abounding
+                  in the work of the Lord, knowing that in the Lord your labor is not in vain.&rdquo;
+                </p>
+                <p className="text-green-700 text-sm mb-4">&mdash; 1 Corinthians 15:58</p>
+                <ul className="text-green-800 space-y-2">
+                  <li>Justice now, because the Kingdom demands justice</li>
+                  <li>Care for creation, because creation will be renewed (not discarded)</li>
+                  <li>Dignity of every person, because all are destined for eternity</li>
+                  <li>The Kingdom is both &ldquo;already&rdquo; (present in the Church, the Eucharist,
+                  acts of charity) and &ldquo;not yet&rdquo; (awaiting final manifestation)</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Marana Tha: The Church&rsquo;s Prayer</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The oldest Christian prayer: &ldquo;Marana tha!&rdquo; &mdash; Aramaic for &ldquo;Come,
+                Lord!&rdquo; or &ldquo;Our Lord, come!&rdquo; (1 Cor 16:22; Rev 22:20; <em>Didache</em> 10).
+                The final prayer of Revelation: &ldquo;Come, Lord Jesus!&rdquo;
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 mb-3">
+                  This prayer does <em>not</em> mean: &ldquo;Bring catastrophe as soon as possible.&rdquo;
+                  It means: &ldquo;Let Your kingdom come in its fullness; complete what You have begun
+                  in us and in your creation.&rdquo;
+                </p>
+                <p className="text-amber-800">
+                  The Eucharist: Every Mass is an anticipation of the heavenly banquet; in the Mass,
+                  the &ldquo;already&rdquo; and &ldquo;not yet&rdquo; meet. &ldquo;Until he comes&rdquo;
+                  (1 Cor 11:26) &mdash; every Eucharist is a proclamation of his death AND his coming;
+                  time is oriented toward the Paro&uuml;sia.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 6: PRACTICAL LIVING ==================== */}
+        {activeTab === 'practical-living' && (
+          <div className="space-y-8">
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Christian Response to Eschatology</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Not fear, not obsession, not withdrawal from the world &mdash; but readiness, engagement,
+                and hope. The three great parables of Matthew 25 define what eschatological readiness
+                looks like:
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-4">
+                  <li><strong>The parable of the talents</strong> (Matt 25:14&ndash;30): We are judged
+                  on what we <em>did</em> with what we were given &mdash; faithful stewardship, not
+                  passivity or hoarding.</li>
+                  <li><strong>The parable of the ten virgins</strong> (Matt 25:1&ndash;13): Readiness
+                  = keeping the lamp burning (the life of prayer and the sacraments), not calculating
+                  the hour of arrival.</li>
+                  <li><strong>The parable of the sheep and goats</strong> (Matt 25:31&ndash;46):
+                  Judgment is based on concrete acts of mercy &mdash; feeding the hungry, clothing the
+                  naked, visiting the imprisoned. Eschatological readiness is love in action.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Sacramental Life as Eschatological Preparation</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <ul className="text-blue-800 space-y-3">
+                  <li><strong>Regular Mass:</strong> Each Eucharist is a foretaste of the heavenly
+                  banquet; participating keeps our orientation correct and our hope alive.</li>
+                  <li><strong>Regular Confession:</strong> Readiness requires being in a state of grace
+                  &mdash; the particular judgment can come at any moment, for any of us.</li>
+                  <li><strong>Lectio Divina and prayer:</strong> Nourishing the &ldquo;lamp&rdquo;
+                  (Matt 25:4) &mdash; the life of prayer that keeps the soul awake and oriented.</li>
+                  <li><strong>The Liturgy of the Hours:</strong> The Church&rsquo;s daily rhythm of
+                  prayer structures time itself around the coming Kingdom.</li>
+                  <li><strong>Preparation for death:</strong> The Church&rsquo;s traditional practice
+                  of a good final Confession, the Anointing of the Sick, and Viaticum (final Communion)
+                  &mdash; practical eschatological readiness that every Catholic can make.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Signs of the Times: A Discernment Checklist</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                When facing a claimed &ldquo;sign of the times&rdquo; or end-times prediction, ask
+                these questions:
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <ul className="text-green-800 space-y-3">
+                  <li>&#10003; Does this align with what the Church&rsquo;s Magisterium has taught?
+                  (CCC 673&ndash;677)</li>
+                  <li>&#10003; Is this drawing me closer to prayer, the sacraments, and charity &mdash;
+                  or into fear and anxiety?</li>
+                  <li>&#10003; Is the source seeking financial gain or unhealthy spiritual dependency?</li>
+                  <li>&#10003; Has this apparition or teaching been approved by the local bishop or
+                  the Holy See?</li>
+                  <li>&#10003; Am I treating it as a supplement to the Gospel &mdash; or as a
+                  replacement for ordinary Catholic life?</li>
+                  <li>&#10007; If any source sets a specific date, reject it immediately &mdash; Jesus
+                  said explicitly that no one knows the hour.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Recommended Resources</h2>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <ul className="text-amber-800 space-y-2">
+                  <li><em>Catechism of the Catholic Church</em>, 668&ndash;682 (The Last Things,
+                  Paro&uuml;sia)</li>
+                  <li>Pope Benedict XVI, <em>Spe Salvi</em> (2007) &mdash; on Christian hope</li>
+                  <li>Joseph Ratzinger, <em>Eschatology: Death and Eternal Life</em> (CUA Press, 1988)</li>
+                  <li>Frank Sheed, <em>Theology and Sanity</em>, chapters on the Four Last Things</li>
+                  <li><em>Gaudium et Spes</em> 4, 38&ndash;45 (Vatican II on signs of the times)</li>
+                  <li>N.T. Wright, <em>Surprised by Hope</em> (HarperOne, 2008)</li>
+                  <li>Scott Hahn, <em>The Lamb&rsquo;s Supper</em> (Doubleday, 1999) &mdash; the
+                  Eucharist and Revelation</li>
+                  <li>For contrast: Tim LaHaye &amp; Jerry Jenkins, <em>Left Behind</em> (1995) &mdash;
+                  read critically to understand the Dispensationalist worldview</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/history/church-tree/page.tsx
+++ b/src/app/history/church-tree/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { ShieldCheck, AlertTriangle, GitBranch, Landmark, Cross, Sparkles } from 'lucide-react'
+import { ShieldCheck, AlertTriangle, GitBranch, Landmark, Cross, Sparkles, BookOpen, ChevronRight } from 'lucide-react'
+import Link from 'next/link'
 
 type NodeType = 'church' | 'council' | 'heresy' | 'division' | 'event' | 'saint' | 'movement'
 
@@ -9,19 +10,21 @@ interface TreeNode {
   id: string
   label: string
   summary?: string
+  detail?: string
   year?: string
   type?: NodeType
+  divisionLink?: boolean
   children?: TreeNode[]
 }
 
-const TYPE_BADGE: Record<NodeType, { text: string; cls: string; icon?: any; pad?: string }> = {
-  church:   { text: 'Church',    cls: 'bg-green-100 text-green-800', icon: Landmark, pad: '' },
-  council:  { text: 'Council',   cls: 'bg-amber-100 text-amber-800', icon: ShieldCheck, pad: 'pl-4' },
-  heresy:   { text: 'Heresy',    cls: 'bg-red-100 text-red-800', icon: AlertTriangle, pad: 'pl-8' },
-  division: { text: 'Division',  cls: 'bg-gray-200 text-gray-800', icon: GitBranch, pad: 'pl-6' },
-  event:    { text: 'Event',     cls: 'bg-blue-100 text-blue-800', icon: Sparkles, pad: '' },
-  saint:    { text: 'Saint',     cls: 'bg-emerald-100 text-emerald-800', icon: Cross, pad: '' },
-  movement: { text: 'Movement',  cls: 'bg-indigo-100 text-indigo-800', icon: Sparkles, pad: '' },
+const TYPE_BADGE: Record<NodeType, { text: string; cls: string; icon?: React.ComponentType<{className?: string}>; borderCls: string }> = {
+  church:   { text: 'Church',    cls: 'bg-green-100 text-green-800',   icon: Landmark,      borderCls: 'border-green-300' },
+  council:  { text: 'Council',   cls: 'bg-amber-100 text-amber-800',   icon: ShieldCheck,   borderCls: 'border-amber-300' },
+  heresy:   { text: 'Heresy',    cls: 'bg-red-100 text-red-800',       icon: AlertTriangle, borderCls: 'border-red-300' },
+  division: { text: 'Division',  cls: 'bg-gray-200 text-gray-700',     icon: GitBranch,     borderCls: 'border-gray-300' },
+  event:    { text: 'Event',     cls: 'bg-blue-100 text-blue-800',     icon: Sparkles,      borderCls: 'border-blue-200' },
+  saint:    { text: 'Saint',     cls: 'bg-emerald-100 text-emerald-800', icon: Cross,       borderCls: 'border-emerald-200' },
+  movement: { text: 'Movement',  cls: 'bg-indigo-100 text-indigo-800', icon: BookOpen,      borderCls: 'border-indigo-200' },
 }
 
 const TREE: TreeNode[] = [
@@ -29,61 +32,300 @@ const TREE: TreeNode[] = [
     id: 'trunk',
     label: 'Catholic Church — One, Holy, Catholic, Apostolic',
     type: 'church',
-    summary: 'Single trunk: continuity from Christ and the Apostles to today.',
+    summary: 'Founded by Jesus Christ; continuous from Pentecost to today through apostolic succession.',
+    detail: 'The Catholic Church traces its origin to Jesus Christ and the Apostles. Through an unbroken chain of apostolic succession — bishops ordained by bishops going back to the Apostles — the Church has maintained unity of faith, sacraments, and governance. She is one (united in faith and communion), holy (set apart for God), catholic (universal in mission and scope), and apostolic (founded on the Apostles).',
     children: [
       {
         id: 'apostolic',
         label: 'Apostolic Era (33–100)',
-        summary: 'Birth of the Church; missionary expansion; foundational doctrine.',
+        summary: 'Birth of the Church; missionary expansion; foundational writings.',
+        detail: 'The Apostolic Era spans from Pentecost (~33 AD) to the death of the last Apostle (~100 AD). During this period the Church was founded, spread through the Roman Empire, weathered early persecution, and produced the foundational New Testament writings. The canon was not yet formally defined, but the essential deposit of faith — Scripture and Tradition — was being laid down.',
         children: [
-          { id: 'pentecost', label: 'Pentecost (33)', summary: 'Descent of the Holy Spirit; birth of the Church.', year: '33', type: 'event' },
-          { id: 'jerusalem', label: 'Council of Jerusalem (c. 49)', summary: 'Resolved Gentile admission; unity preserved.', year: 'c. 49', type: 'council' },
-          { id: 'peter-rome', label: 'Peter in Rome (~42)', summary: 'Primacy of the Roman See established.', year: '~42', type: 'event' },
-          { id: 'pauline', label: 'Pauline Missions (40s–60s)', summary: 'Gospel spreads across the Mediterranean.', year: '40s–60s', type: 'event' },
+          {
+            id: 'pentecost', label: 'Pentecost (33)', year: '33', type: 'event',
+            summary: 'Descent of the Holy Spirit; birth of the Church; 3,000 baptized.',
+            detail: 'On the Jewish feast of Pentecost (~33 AD), the Holy Spirit descended upon the Apostles and disciples gathered in Jerusalem. St. Peter preached the first homily; about 3,000 were baptized. The Church was publicly born. This event fulfils Joel 2:28-32 and Jesus\'s promise in John 14-16. The Church immediately began communal life: prayer, breaking of bread (Eucharist), teaching, and fellowship (Acts 2:42).',
+          },
+          {
+            id: 'jerusalem-council', label: 'Council of Jerusalem (c. 49)', year: 'c. 49', type: 'council',
+            summary: 'First council; resolved Gentile admission without full Mosaic observance.',
+            detail: 'The Council of Jerusalem (Acts 15) was the first authoritative gathering of Church leadership to resolve a doctrinal dispute: whether Gentile converts must be circumcised and observe the Mosaic law. The council, led by Peter and James, decided that Gentiles are saved through grace without full Mosaic observance. This established the precedent of conciliar authority for settling doctrine — a pattern continued through all subsequent ecumenical councils.',
+          },
+          {
+            id: 'peter-rome', label: 'Peter in Rome (~42–64)', year: '~42–64', type: 'event',
+            summary: 'Peter establishes the Roman See; martyred under Nero (~64–68).',
+            detail: 'Peter arrived in Rome approximately around 42 AD and eventually founded the Roman Church with Paul. Both were martyred under Emperor Nero around 64–68 AD: Peter crucified upside down on Vatican Hill, Paul beheaded on the Ostian Way. The tombs of both became the centres of Roman pilgrimage. Peter\'s presence in Rome and his martyrdom there established the unique authority of the Roman See over all other churches.',
+          },
+          {
+            id: 'pauline-missions', label: 'Pauline Missions (48–67)', year: '48–67', type: 'event',
+            summary: 'Three missionary journeys; churches planted across the Mediterranean.',
+            detail: 'St. Paul undertook three major missionary journeys (~48–57 AD) across Asia Minor, Greece, and the Aegean. He founded churches in Galatia, Corinth, Philippi, Thessalonica, Ephesus, and Rome, among others. His letters (the earliest NT writings) defined core doctrine: justification, the Body of Christ, the Eucharist (1 Cor 11), the resurrection (1 Cor 15). Paul was martyred in Rome under Nero (~67 AD).',
+          },
+          {
+            id: 'destruction-temple', label: 'Destruction of Jerusalem Temple (70)', year: '70', type: 'event',
+            summary: 'Romans destroy the Temple; decisive separation of Christianity from Judaism.',
+            detail: 'In 70 AD, the Roman general Titus sacked Jerusalem and destroyed the Second Temple, fulfilling Jesus\'s prophecy (Matt 24:2). Jewish Christians had already fled to Pella (following Jesus\'s instruction in Matt 24:16). The destruction ended the Temple sacrificial system, vindicating the Christian understanding of the Eucharist as the new and final sacrifice. It also accelerated the definitive separation of the Church from synagogue Judaism.',
+          },
+          {
+            id: 'johannine', label: 'Johannine Writings (c. 85–100)', year: 'c. 85–100', type: 'event',
+            summary: 'Gospel of John, Letters, Revelation written; deep theological reflection.',
+            detail: 'The Johannine writings — the Gospel of John, three Letters, and Revelation — were composed in Ephesus around 85–100 AD, completing the New Testament. The Gospel of John provides the deepest theological reflection on the Incarnation (John 1:1-14) and the Last Supper discourses (John 13-17). The Book of Revelation addresses persecuted Christians under Domitian (~95 AD) with a vision of God\'s ultimate victory.',
+          },
         ],
       },
       {
         id: 'patristic',
-        label: 'Patristic Era (100–451)',
-        summary: 'Church Fathers and ecumenical councils clarify doctrine.',
+        label: 'Patristic Era (100–500)',
+        summary: 'Church Fathers define doctrine; ecumenical councils refute heresies.',
+        detail: 'The Patristic Era produced the great theologians (Fathers of the Church) who defended and developed Christian doctrine against numerous heresies. Seven ecumenical councils were held between 325 and 787 AD, defining the Trinity, the Person of Christ, and the role of images. This period also saw the Christianization of the Roman Empire under Constantine and the production of authoritative biblical canon lists.',
         children: [
-          { id: 'arianism', label: 'Arianism', summary: 'Denied the Son’s full divinity; grave doctrinal error.', type: 'heresy' },
-          { id: 'nicaea', label: 'Council of Nicaea (325)', summary: 'Affirmed divinity of the Son; issued Nicene Creed.', year: '325', type: 'council' },
-          { id: 'athanasius', label: 'St. Athanasius', summary: 'Defender of Nicene orthodoxy against Arianism.', type: 'saint' },
-          { id: 'chalcedon', label: 'Council of Chalcedon (451)', summary: 'Defined two natures of Christ in one Person.', year: '451', type: 'council' },
+          {
+            id: 'gnosticism', label: 'Gnosticism (2nd c.)', type: 'heresy',
+            summary: 'Claimed secret knowledge; denied the Incarnation and goodness of creation.',
+            detail: 'Gnosticism (Greek: gnosis = knowledge) was a complex of 2nd-century movements claiming that salvation comes through secret spiritual knowledge rather than faith, sacraments, or moral life. Gnostics typically taught that the material world was evil (created by an inferior "demiurge"), that Christ only appeared to be human (Docetism), and that salvation was for an elite spiritual class. St. Irenaeus of Lyon (Against Heresies, ~180 AD) wrote the definitive refutation.',
+          },
+          {
+            id: 'montanism', label: 'Montanism (c. 156)', type: 'heresy', year: 'c. 156',
+            summary: 'Claimed new prophecies superseding the Apostles; excessive rigourism.',
+            detail: 'Montanus (c. 156 AD, Phrygia) claimed the Holy Spirit spoke directly through him and two prophetesses, announcing a new age of the Spirit that superseded apostolic teaching. Montanists were rigorist (no second repentance for serious sins, mandatory fasting), and announced the imminent end of the world at Pepuza. Tertullian (~200 AD) eventually joined the movement. The Church rejected Montanism because it undermined the sufficiency of the Apostolic deposit.',
+          },
+          {
+            id: 'arianism', label: 'Arianism (c. 318)', type: 'heresy', year: 'c. 318',
+            summary: 'Taught the Son is a creature, not fully divine — "there was a time when he was not."',
+            detail: 'Arius of Alexandria (~318 AD) taught that the Son of God was the greatest of all creatures — created by the Father before time — but not co-eternal or co-equal with the Father. His slogan: "There was a time when he was not." This was the most dangerous heresy of the early Church; at one point most bishops in the East had been won over. The Council of Nicaea (325) condemned Arianism and defined the Son as homoousios (of the same substance) with the Father.',
+          },
+          {
+            id: 'edict-milan', label: 'Edict of Milan (313)', year: '313', type: 'event',
+            summary: 'Constantine grants legal tolerance to Christianity; persecution ends.',
+            detail: 'In 313 AD, Emperor Constantine I and co-emperor Licinius issued the Edict of Milan, granting legal tolerance and protection to Christianity (and all religions) throughout the Roman Empire. Persecution of Christians ended; confiscated Church property was restored. Constantine later favoured Christianity, convened the Council of Nicaea (325), and built major basilicas in Rome and Jerusalem. The relationship between Church and Empire — later called Christendom — began here.',
+          },
+          {
+            id: 'nicaea', label: 'Council of Nicaea I (325)', year: '325', type: 'council',
+            summary: 'Defined the Son as homoousios (same substance) with the Father; rejected Arianism.',
+            detail: 'Convened by Emperor Constantine in Nicaea (modern Iznik, Turkey), the First Ecumenical Council gathered ~318 bishops in 325 AD. It defined the full divinity of the Son (homoousios — "of the same substance" as the Father), rejected Arianism, and issued the first version of the Nicene Creed. The Council also settled the date of Easter and addressed clerical discipline. St. Athanasius, then a young deacon, was the crucial defender of Nicene orthodoxy.',
+          },
+          {
+            id: 'athanasius', label: 'St. Athanasius (296–373)', year: '296–373', type: 'saint',
+            summary: '"Athanasius contra mundum" — alone against the world in defence of Nicaea.',
+            detail: 'Bishop of Alexandria from 328 AD, Athanasius spent most of his episcopate defending the Nicene faith against Arianism — five times exiled by emperors sympathetic to Arian bishops. His phrase "Athanasius contra mundum" (Athanasius against the world) describes his lonely stand. His key works: On the Incarnation (defending Christ\'s full humanity and divinity), the Letters (defining the biblical canon), and Festal Letters. He was vindicated at the Council of Constantinople (381).',
+          },
+          {
+            id: 'donatism', label: 'Donatism (c. 311)', type: 'heresy', year: 'c. 311',
+            summary: 'Taught the validity of sacraments depends on the minister\'s holiness.',
+            detail: 'Donatism arose in North Africa (~311 AD) when Donatus and his followers refused to accept bishops who had handed over (tradidere) Scripture to Roman authorities during the Diocletianic persecution. They taught that sacraments performed by sinful clergy were invalid — a position St. Augustine refuted brilliantly: sacraments are valid by the power of Christ, not the holiness of the minister (ex opere operato). The Council of Arles (314) condemned Donatism.',
+          },
+          {
+            id: 'constantine-2', label: 'Constantinople I (381)', year: '381', type: 'council',
+            summary: 'Defined divinity of the Holy Spirit; completed the Trinitarian definition.',
+            detail: 'The Second Ecumenical Council (Constantinople, 381 AD) was convened by Emperor Theodosius I. It definitively condemned Arianism (again), condemned the Pneumatomachi who denied the full divinity of the Holy Spirit, and expanded the Nicene Creed to its familiar form — including the clause on the Holy Spirit: "who proceeds from the Father, who with the Father and the Son together is worshipped and glorified." This completed the Trinitarian definition.',
+          },
+          {
+            id: 'pelagianism', label: 'Pelagianism (c. 410)', type: 'heresy', year: 'c. 410',
+            summary: 'Denied original sin; taught humans can achieve salvation by free will alone.',
+            detail: 'Pelagius (a British monk, ~410 AD) taught that humans are born without original sin, have full free will to choose good or evil, and can achieve salvation through their own moral effort — grace is helpful but not strictly necessary. St. Augustine wrote extensively against Pelagianism, defending original sin, the necessity of grace, and the priority of God\'s action in salvation. Condemned at the Council of Carthage (418) and confirmed by the Council of Ephesus (431).',
+          },
+          {
+            id: 'nestorianism', label: 'Nestorianism (c. 428)', type: 'heresy', year: 'c. 428',
+            summary: 'Divided Christ into two persons; denied Mary the title Theotokos.',
+            detail: 'Nestorius of Constantinople (~428 AD) objected to calling Mary Theotokos (God-bearer) on the grounds that she bore the human Christ, not God. His theology effectively divided Christ into two persons — one divine, one human — loosely united. St. Cyril of Alexandria championed the unity of Christ\'s person. The Council of Ephesus (431) condemned Nestorianism, defined Mary as Theotokos, and affirmed that Christ is one divine Person in one nature. A remnant formed the "Church of the East."',
+            divisionLink: true,
+          },
+          {
+            id: 'chalcedon', label: 'Council of Chalcedon (451)', year: '451', type: 'council',
+            summary: 'Defined Christ as one Person in two natures — divine and human, without confusion or separation.',
+            detail: 'The Fourth Ecumenical Council (Chalcedon, 451 AD) was the largest council of antiquity (~600 bishops). It defined the Chalcedonian Definition: Jesus Christ is one Person in two natures — divine and human — "without confusion, without change, without division, without separation." This definitively refuted both Nestorianism (two persons) and Monophysitism (one nature). Those who rejected Chalcedon (Copts, Ethiopians, Armenians, Syrians) are today called Oriental Orthodox.',
+            divisionLink: true,
+          },
+          {
+            id: 'augustine', label: 'St. Augustine of Hippo (354–430)', year: '354–430', type: 'saint',
+            summary: 'Greatest theologian of the West; shaped Catholic understanding of grace, sin, and history.',
+            detail: 'Augustine, Bishop of Hippo (North Africa), is the most influential theologian in Western Christianity. Converted from Manichaeism through the prayers of his mother Monica and the preaching of Ambrose of Milan, he wrote 232 books including: Confessions (spiritual autobiography), City of God (theology of history), and De Trinitate (on the Trinity). He definitively refuted Pelagianism and Donatism and shaped Catholic teaching on original sin, grace, free will, and the just war theory.',
+          },
+          {
+            id: 'jerome', label: 'St. Jerome & the Vulgate (382–405)', year: '382–405', type: 'saint',
+            summary: 'Translated the Bible into Latin (the Vulgate); standard Western text for 1,000 years.',
+            detail: 'St. Jerome, commissioned by Pope Damasus I, translated the entire Bible from Hebrew and Greek into Latin — the Vulgate (meaning "common" text). Completed around 405 AD, the Vulgate became the standard biblical text of the Western Church for over a millennium and was officially confirmed at the Council of Trent (1546). Jerome also produced important biblical commentaries and correspondence, and lived as a monk in Bethlehem.',
+          },
         ],
       },
       {
         id: 'medieval',
         label: 'Medieval Era (500–1500)',
-        summary: 'Monasticism, evangelization, scholasticism, East–West relations.',
+        summary: 'Monasticism, Christianization of Europe, scholasticism, and the Great Schism.',
+        detail: 'The Medieval period saw the Christianization of Europe, the flowering of monastic culture, the synthesis of faith and reason in scholastic theology, and the Crusades. It also saw growing tensions between Rome and Constantinople culminating in the Great Schism of 1054, and internal reform movements responding to clerical corruption and doctrinal drift.',
         children: [
-          { id: 'benedict', label: 'Rule of St. Benedict (~530)', summary: 'Framework for Western monastic life.', year: '~530', type: 'movement' },
-          { id: 'schism', label: 'Great Schism (1054)', summary: 'Separation of Eastern and Western Churches.', year: '1054', type: 'division' },
-          { id: 'francis', label: 'St. Francis & Mendicants', summary: 'Renewal through poverty and preaching.', year: '13th c.', type: 'saint' },
-          { id: 'scholastic', label: 'Scholastic Theology', summary: 'Synthesis of faith and reason (Aquinas, Bonaventure).', type: 'movement' },
+          {
+            id: 'benedict', label: 'Rule of St. Benedict (~530)', year: '~530', type: 'movement',
+            summary: 'Framework for Western monastic life; "pray and work" (ora et labora).',
+            detail: 'St. Benedict of Nursia (~480–547 AD) wrote the Rule of Saint Benedict for his monastery at Monte Cassino. This moderate, humane rule structured monastic life around the Divine Office (eight daily prayer times), manual labour, and communal reading. Benedictine monasteries became the great centres of learning, manuscript preservation, agriculture, and hospitality in medieval Europe. The Rule is still followed by tens of thousands of monks and nuns today.',
+          },
+          {
+            id: 'gregory-great', label: 'Gregory the Great (590–604)', year: '590–604', type: 'event',
+            summary: 'Greatest early medieval pope; Gregorian chant; missions to England.',
+            detail: 'Pope Gregory I ("the Great") was one of the most formative popes in history. He reformed the liturgy (Gregorian chant is associated with his name), sent Augustine of Canterbury to evangelise England (596 AD), wrote extensively on pastoral theology (Pastoral Rule) and biblical commentary (Moralia in Job), and managed the defence of Rome when civil authorities had collapsed. He established the model of the papacy as a servant-leader — "servant of the servants of God."',
+          },
+          {
+            id: 'iconoclasm', label: 'Iconoclasm (726–843)', type: 'heresy', year: '726–843',
+            summary: 'Imperial campaign to destroy sacred images; rejected by Nicaea II (787).',
+            detail: 'Byzantine Emperor Leo III began destroying sacred images (icons) in 726 AD, claiming they promoted idolatry. Two periods of iconoclasm (726–787 and 815–843) saw the destruction of countless mosaics, paintings, and sculptures. Pope Gregory II and III resisted iconoclasm; the Seventh Ecumenical Council (Nicaea II, 787) definitively affirmed the veneration (not worship) of icons as legitimate. The final restoration of icons (843 AD) is celebrated as the "Triumph of Orthodoxy" in the Eastern Church.',
+          },
+          {
+            id: 'charlemagne', label: 'Charlemagne crowned (800)', year: '800', type: 'event',
+            summary: 'Pope Leo III crowns Charlemagne; birth of the Holy Roman Empire.',
+            detail: 'On Christmas Day 800 AD, Pope Leo III crowned Charlemagne (Charles the Great) as Emperor of the Romans in St. Peter\'s Basilica. This created the Holy Roman Empire and established a new model of Christian political order in the West. Charlemagne promoted education, scriptoria, and the Carolingian Renaissance. The coronation also deepened the tension between the papacy and Eastern Byzantium, which saw itself as the continuation of the Roman Empire.',
+          },
+          {
+            id: 'east-west-schism', label: 'Great Schism (1054)', year: '1054', type: 'division',
+            summary: 'Mutual excommunications between Rome and Constantinople; Eastern Orthodoxy separates.',
+            detail: 'The Great Schism of 1054 formalised the break between Rome and Constantinople that had been building for centuries over theological disputes (the Filioque — whether the Holy Spirit proceeds from the Father alone, or from the Father "and the Son"), canonical disputes (jurisdiction over newly Christianised Bulgaria), and cultural-political tensions. Cardinal Humbert placed a bull of excommunication on the altar of Hagia Sophia; Patriarch Michael Cerularius excommunicated the Roman legates. Both excommunications were lifted in 1964 by Pope Paul VI and Patriarch Athenagoras.',
+            divisionLink: true,
+          },
+          {
+            id: 'crusades', label: 'The Crusades (1095–1291)', year: '1095–1291', type: 'event',
+            summary: 'Military campaigns to defend and recover Christian holy sites; complex legacy.',
+            detail: 'Pope Urban II called the First Crusade at the Council of Clermont (1095) in response to Byzantine requests for aid against Seljuk Turks who had conquered Jerusalem. Eight major Crusades followed over two centuries. The Crusades recovered Jerusalem (briefly) and established Crusader states. The Fourth Crusade\'s sack of Constantinople (1204) further damaged Catholic-Orthodox relations. The Crusades have a complex legacy: genuine religious motivation, defence of Christians, but also violence, the sack of Constantinople, and persecution of Jews. Pope John Paul II asked forgiveness for excesses committed in the Church\'s name.',
+          },
+          {
+            id: 'catharism', label: 'Catharism (12th–13th c.)', type: 'heresy',
+            summary: 'Neo-Manichaean dualism; rejected the material world, Church, and sacraments.',
+            detail: 'The Cathars (also called Albigensians in southern France) were a neo-Manichaean movement that rejected the material world as evil and the Catholic Church as corrupt. They rejected marriage, eating meat, and the Incarnation. Pope Innocent III launched the Albigensian Crusade (1209) against them in southern France, and the Inquisition was established partly to address Catharism. The movement was largely extinguished by the mid-14th century.',
+            divisionLink: true,
+          },
+          {
+            id: 'francis', label: 'St. Francis of Assisi (1182–1226)', year: '1182–1226', type: 'saint',
+            summary: 'Founded the Franciscans; renewal through radical poverty, joy, and love of creation.',
+            detail: 'Francis of Assisi renounced his wealthy family\'s inheritance, embraced radical poverty, and preached the Gospel through joyful witness. He founded the Order of Friars Minor (Franciscans, 1209), which became the largest religious order of the medieval period. The Poor Clares (women\'s branch, founded with Clare of Assisi) followed. Francis\'s Canticle of the Sun expressed his theology of creation as gift; Pope Francis chose his name in honour of Francis\'s witness to poverty and care for creation.',
+          },
+          {
+            id: 'thomas-aquinas', label: 'St. Thomas Aquinas (1225–1274)', year: '1225–1274', type: 'saint',
+            summary: '"Doctor Angelicus"; synthesised Aristotle and Christian faith in the Summa Theologiae.',
+            detail: 'Thomas Aquinas, Dominican friar, is the greatest theologian of the scholastic period and one of the most influential thinkers in Western history. His Summa Theologiae is the definitive synthesis of Christian philosophy and theology. He demonstrated that faith and reason are not in conflict — that Aristotelian philosophy can serve Christian theology. Named "Doctor of the Church" and "Common Doctor." Pope Leo XIII\'s Aeterni Patris (1879) mandated Thomism as the basis of Catholic philosophical education.',
+          },
+          {
+            id: 'lateran4', label: 'Fourth Lateran Council (1215)', year: '1215', type: 'council',
+            summary: 'Defined transubstantiation; annual confession and Communion mandated.',
+            detail: 'The Fourth Lateran Council (1215), convened by Pope Innocent III, was the largest and most influential medieval council. It formally defined transubstantiation as the term for the Eucharistic change; required annual confession and Easter Communion; issued decrees on clerical reform; and addressed the Cathar heresy. It also unfortunately included discriminatory measures against Jews (requiring distinctive clothing) — a historical blot later repudiated by the Church.',
+          },
+          {
+            id: 'avignon', label: 'Avignon Papacy (1309–1377)', year: '1309–1377', type: 'event',
+            summary: 'Seven popes resided in Avignon, France; perception of French royal control.',
+            detail: 'From 1309 to 1377, the papal court resided in Avignon (southern France) rather than Rome — a period sometimes called the "Babylonian Captivity of the Church." Seven successive popes reigned from Avignon, creating the impression of French royal domination. St. Catherine of Siena famously urged Pope Gregory XI to return to Rome, which he did in 1377. The Avignon period was followed by the Western Schism (1378–1417), in which rival claimants to the papacy created further crisis.',
+          },
+          {
+            id: 'great-western-schism', label: 'Western Schism (1378–1417)', year: '1378–1417', type: 'event',
+            summary: 'Two (then three) rival claimants to the papacy; resolved at Constance.',
+            detail: 'After Gregory XI returned to Rome and died (1378), a disputed conclave elected two rival popes — one in Rome, one in Avignon. For 39 years the Church was divided between two (later three) obediences. The Council of Constance (1414–18) resolved the crisis by accepting the resignation of one pope, deposing the others, and electing Martin V. The crisis severely damaged papal prestige and fuelled the conciliarist movement (claiming council authority supersedes the pope), which the Church later rejected.',
+          },
+          {
+            id: 'hussites', label: 'Hussites (1415–)', year: '1415–', type: 'division',
+            summary: 'Jan Hus burned at Constance; Hussite Wars; forerunner of Reformation.',
+            detail: 'Jan Hus, a Czech priest and reformer influenced by John Wycliffe, preached against clerical corruption and indulgences. Despite a safe-conduct promise, he was condemned and burned at the Council of Constance (1415). His martyrdom ignited the Hussite Wars in Bohemia (1419–36). The Hussite movement anticipated the Protestant Reformation by a century and left a lasting Czech Protestant tradition. Pope John Paul II expressed regret for Hus\'s execution in 1999.',
+            divisionLink: true,
+          },
         ],
       },
       {
         id: 'reformation',
         label: 'Reformation & Renewal (1500–1700)',
-        summary: 'Reformation and Catholic renewal; global missions.',
+        summary: 'Protestant separations; Catholic Counter-Reformation; global missions.',
+        detail: 'The 16th century saw the Church face her most severe internal crisis since the Arian controversy. The Protestant Reformations of Luther, Calvin, Zwingli, and Henry VIII resulted in permanent separations. The Church\'s response — the Catholic Reformation (Counter-Reformation) — produced genuine renewal through the Council of Trent, new religious orders, and missionary expansion across Asia, Africa, and the Americas.',
         children: [
-          { id: 'luther', label: 'Luther (1517)', summary: 'Sparked separations from the Catholic Church.', year: '1517', type: 'division' },
-          { id: 'trent', label: 'Council of Trent (1545–63)', summary: 'Clarified doctrine; reformed discipline.', year: '1545–63', type: 'council' },
-          { id: 'jesuits', label: 'Jesuits Founded (1540)', summary: 'Education, missions, and reform.', year: '1540', type: 'movement' },
-          { id: 'missions', label: 'Global Missions', summary: 'Evangelization across continents.', type: 'movement' },
+          {
+            id: 'lutheranism', label: 'Lutheran Separation (1517–)', year: '1517–', type: 'division',
+            summary: 'Luther\'s 95 Theses; sola scriptura, sola fide; excommunicated 1521.',
+            detail: 'Martin Luther\'s posting of the 95 Theses (1517) challenging indulgences led to a break that went far beyond indulgence reform. Luther developed sola scriptura (Scripture alone as authority), sola fide (faith alone for justification), and rejected papal primacy, most sacraments, and the sacrificial nature of the Mass. Excommunicated by Pope Leo X (1521). The Lutheran church spread through Germany and Scandinavia. The Joint Declaration on the Doctrine of Justification (1999) between Lutherans and Catholics was a significant step toward reconciliation.',
+            divisionLink: true,
+          },
+          {
+            id: 'reformed', label: 'Reformed/Calvinist Separation (1536–)', year: '1536–', type: 'division',
+            summary: 'Calvin\'s Institutes; predestination; Reformed churches in Switzerland, France, Scotland.',
+            detail: 'John Calvin\'s Institutes of the Christian Religion (1536) became the systematic foundation of Reformed theology. Calvin\'s distinctive doctrines included double predestination, the spiritual (not bodily) presence of Christ in the Eucharist, and rejection of episcopal governance. Reformed churches spread through Switzerland (Zwingli, Calvin), France (Huguenots), Scotland (Knox/Presbyterians), and the Netherlands. The Heidelberg Catechism (1563) and Westminster Confession (1647) are key confessional standards.',
+            divisionLink: true,
+          },
+          {
+            id: 'anglicanism', label: 'Anglican Separation (1534–)', year: '1534–', type: 'division',
+            summary: 'Henry VIII declares himself head of the Church of England; driven by dynastic politics.',
+            detail: 'King Henry VIII severed the Church of England from Rome in 1534 primarily to obtain a divorce that Pope Clement VII refused to grant, given political pressure from Holy Roman Emperor Charles V (Catherine of Aragon\'s nephew). Henry declared himself "Supreme Head of the Church of England." Unlike Luther or Calvin, Henry maintained most Catholic doctrine and practice; the doctrinal direction of the Church of England varied dramatically between Edward VI (Protestant), Mary I (Catholic), and Elizabeth I (via media). The Anglican Communion today is a worldwide body with ~85 million members.',
+            divisionLink: true,
+          },
+          {
+            id: 'trent', label: 'Council of Trent (1545–1563)', year: '1545–63', type: 'council',
+            summary: 'Defined Catholic doctrine against Protestantism; reformed clerical discipline.',
+            detail: 'The Council of Trent (1545–1563, with interruptions) was the Church\'s comprehensive response to the Reformation. It defined: Scripture and Tradition as co-sources of revelation; justification by faith and works (against sola fide); seven sacraments; transubstantiation; the sacrificial nature of the Mass; the Vulgate as the authoritative biblical text; purgatory and prayers for the dead; and the veneration of saints. It also mandated seminary education for priests and addressed clerical corruption. Trent shaped Catholicism for four centuries.',
+          },
+          {
+            id: 'jesuits', label: 'Society of Jesus Founded (1540)', year: '1540', type: 'movement',
+            summary: 'Ignatius of Loyola founds Jesuits; education, missions, and papal service.',
+            detail: 'St. Ignatius of Loyola (1491–1556), a Spanish soldier turned mystic, founded the Society of Jesus in 1540 with the approval of Pope Paul III. The Jesuits were characterised by intense spiritual formation (the Spiritual Exercises), high educational standards, and absolute obedience to the Pope ("the fourth vow"). They became the most effective instruments of the Counter-Reformation: founding hundreds of colleges and universities, evangelising Japan (Xavier), India, China (Ricci), and the Americas, and combating Protestantism in Europe.',
+          },
+          {
+            id: 'teresa-avila', label: 'St. Teresa of Ávila (1515–1582)', year: '1515–82', type: 'saint',
+            summary: 'Reformer of Carmelites; "Doctor of the Church"; Interior Castle on contemplative prayer.',
+            detail: 'Teresa of Ávila, a Spanish Carmelite nun, reformed her order (founding the Discalced Carmelites with St. John of the Cross) and wrote the greatest Spanish mystical literature: The Interior Castle, The Way of Perfection, and her Autobiography. Named a Doctor of the Church in 1970 (one of the first two women so designated). Her mystical theology of prayer as a relationship — not technique — has shaped Catholic contemplative tradition. St. John of the Cross (1542–1591), her collaborator, wrote Dark Night of the Soul.',
+          },
+          {
+            id: 'missions', label: 'Global Catholic Missions (1500–1700)', type: 'movement',
+            summary: 'Evangelisation of the Americas, Africa, India, Japan, and China.',
+            detail: 'The 16th–17th centuries saw an unprecedented expansion of the Church through missionary activity accompanying European exploration. Francis Xavier evangelised India and Japan (~1542–52). Matteo Ricci developed inculturation in China (~1583–1610). The martyrs of Japan (Paul Miki and companions, 1597) and Vietnam are from this period. The Americas saw mass baptisms but also the tragedy of forced conversions and cultural destruction, which later popes have acknowledged as requiring repentance. The Church today in Latin America, Africa, and Asia is the fruit of this period.',
+          },
+          {
+            id: 'jansenism', label: 'Jansenism (c. 1640–)', year: 'c. 1640–', type: 'heresy',
+            summary: 'Rigorist Catholic movement; overstated Augustine on grace; rejected by Unigenitus (1713).',
+            detail: 'Cornelius Jansen (Jansenius), a Dutch bishop, published Augustinus (1640) posthumously, arguing that Augustine taught: the irresistibility of grace, the impossibility of obeying all God\'s commands, and a very narrow path to salvation. Jansenism infected French Catholicism (especially Port-Royal monastery) and produced an austere, fearful piety. Pope Clement XI condemned five Jansenist propositions in Cum Occasione (1653) and Unigenitus (1713). Pascal\'s Pensées reflect Jansenist influence.',
+          },
         ],
       },
       {
         id: 'modern',
         label: 'Modern Era (1700–Present)',
-        summary: 'Councils, social doctrine, global Church.',
+        summary: 'Enlightenment challenges; social doctrine; two Vatican Councils; global Church.',
+        detail: 'The Modern era has seen the Church navigate the Enlightenment, the French Revolution, the loss of the Papal States, two World Wars, the rise and fall of communism, and the Second Vatican Council. The Church has grown from a predominantly European institution to a global communion with its centre of gravity shifting to Africa, Asia, and Latin America.',
         children: [
-          { id: 'vatican1', label: 'Vatican I (1869–70)', summary: 'Papal primacy and infallibility.', year: '1869–70', type: 'council' },
-          { id: 'vatican2', label: 'Vatican II (1962–65)', summary: 'Renewal of liturgy; ecumenism; laity.', year: '1962–65', type: 'council' },
-          { id: 'ecumenism', label: 'Ecumenical Dialogue', summary: 'Pursuit of Christian unity.', type: 'movement' },
-          { id: 'social', label: 'Catholic Social Teaching', summary: 'Human dignity, solidarity, subsidiarity, common good.', type: 'movement' },
+          {
+            id: 'rerum-novarum', label: 'Rerum Novarum (1891)', year: '1891', type: 'event',
+            summary: 'Pope Leo XIII\'s encyclical on labour rights; birth of Catholic Social Teaching.',
+            detail: 'Pope Leo XIII\'s Rerum Novarum (1891, "On New Things") is the foundational document of Catholic Social Teaching. Written in response to industrialisation and the spread of Marxism, it defended workers\' right to just wages, safe conditions, and association (trade unions), while rejecting both Marxist class warfare and laissez-faire capitalism. The encyclical established the Catholic principle of the common good, solidarity, and subsidiarity. It has been updated at every major anniversary: Quadragesimo Anno (1931), Mater et Magistra (1961), Laborem Exercens (1981), Centesimus Annus (1991).',
+          },
+          {
+            id: 'immaculate-conception', label: 'Marian Dogmas (1854 & 1950)', year: '1854, 1950', type: 'event',
+            summary: 'Immaculate Conception (1854) and Assumption (1950) defined as dogmas.',
+            detail: 'Pope Pius IX defined the dogma of the Immaculate Conception in 1854 (Ineffabilis Deus): Mary was preserved from original sin from the moment of her conception. This was the first exercise of formal papal infallibility before Vatican I (1870) officially defined it. Pope Pius XII defined the Assumption in 1950 (Munificentissimus Deus): Mary was assumed body and soul into heavenly glory. These definitions drew on centuries of liturgical tradition and theological reflection, not new revelation.',
+          },
+          {
+            id: 'vatican1', label: 'Vatican Council I (1869–1870)', year: '1869–70', type: 'council',
+            summary: 'Defined papal primacy and papal infallibility; interrupted by Franco-Prussian War.',
+            detail: 'The First Vatican Council (1869–70) was the 20th Ecumenical Council. Its most significant definition: papal infallibility — when the Pope speaks ex cathedra (from the Chair of Peter) on matters of faith and morals, intending to bind the whole Church, he is preserved from error by the Holy Spirit. This is a carefully limited charism: it has been formally invoked only once since Vatican I (in 1950, for the Assumption). The Council was interrupted when Italian troops seized Rome, and it was formally closed only in 1962 (by Vatican II).',
+          },
+          {
+            id: 'lourdes-fatima', label: 'Lourdes & Fátima (1858 & 1917)', year: '1858, 1917', type: 'event',
+            summary: 'Marian apparitions approved by the Church; major pilgrimage sites.',
+            detail: 'Our Lady of Lourdes (1858): Mary appeared to Bernadette Soubirous 18 times in Lourdes, France. The spring water at the site has been associated with documented miraculous cures investigated by the Lourdes Medical Bureau. Our Lady of Fátima (1917): Mary appeared to three shepherd children in Fátima, Portugal, delivering messages calling for prayer, penance, and consecration of Russia. The Miracle of the Sun (October 13, 1917) was witnessed by ~70,000 people. Both apparitions are formally approved by the Church as worthy of belief (not required by faith).',
+          },
+          {
+            id: 'wwii-pius12', label: 'WWII & Pius XII (1939–1945)', year: '1939–45', type: 'event',
+            summary: 'Church under Nazism and Communism; role of Pius XII remains debated.',
+            detail: 'World War II and the Holocaust present complex questions about the Church\'s response. Pius XII used diplomatic channels to protect Jews, sheltered tens of thousands in Church institutions (especially in Rome), and helped thousands flee after the war. He was praised by Jewish leaders at the time. The debate over whether he could or should have spoken more boldly continues among historians. The Church officially confronted her historical failures in We Remember: A Reflection on the Shoah (1998), acknowledging that anti-Jewish prejudice in Christian history contributed to an environment in which the Holocaust became possible.',
+          },
+          {
+            id: 'vatican2', label: 'Vatican Council II (1962–1965)', year: '1962–65', type: 'council',
+            summary: 'Renewed liturgy, laity, ecumenism, and the Church\'s dialogue with the modern world.',
+            detail: 'The Second Vatican Council (1962–65), called by Pope John XXIII and concluded by Paul VI, was the 21st Ecumenical Council and the most recent. Its key documents: Lumen Gentium (the Church as the People of God), Dei Verbum (divine revelation), Sacrosanctum Concilium (liturgical reform leading to the Novus Ordo Mass), Gaudium et Spes (the Church in the modern world), Nostra Aetate (relations with non-Christian religions), Unitatis Redintegratio (ecumenism). Vatican II did not change defined dogma but gave the Church\'s perennial teaching a new pastoral expression.',
+          },
+          {
+            id: 'jpii', label: 'St. John Paul II (1978–2005)', year: '1978–2005', type: 'saint',
+            summary: 'Longest modern pontificate; helped end communism; World Youth Day; Theology of the Body.',
+            detail: 'Karol Wojtyła (John Paul II) was the first non-Italian pope in 455 years. His pontificate (1978–2005) was one of the most consequential in modern history: his support for Solidarity in Poland was pivotal in the fall of communism; he travelled to 129 countries; he launched World Youth Day; he apologised for historical sins of the Church; he was the most prolific pope in history (14 encyclicals, 15 apostolic exhortations, numerous letters). His Theology of the Body revolutionised Catholic understanding of human sexuality. Canonised in 2014.',
+          },
+          {
+            id: 'ecumenism', label: 'Ecumenical Dialogue (1964–)', year: '1964–', type: 'movement',
+            summary: 'Joint Declaration on Justification (1999); Catholic-Orthodox dialogue; healing of 1054.',
+            detail: 'Since Vatican II, the Catholic Church has engaged in formal ecumenical dialogue with most major Christian traditions. Key milestones: lifting of the 1054 excommunications by Paul VI and Patriarch Athenagoras (1964); the Joint Declaration on the Doctrine of Justification with Lutherans (1999, also signed by Methodists and Anglicans); ongoing Catholic-Orthodox theological dialogue. Full visible unity has not been achieved, but relations have been transformed from centuries of hostility into respectful engagement.',
+          },
+          {
+            id: 'francis-pope', label: 'Pope Francis (2013–)', year: '2013–', type: 'event',
+            summary: 'First Jesuit and first Latin American pope; Laudato Si\' on ecology; synodality.',
+            detail: 'Jorge Mario Bergoglio (Francis), elected March 2013, is the first Jesuit, the first pope from the Americas, and the first to take the name Francis (in honour of Francis of Assisi). His pontificate has emphasised mercy (the Jubilee of Mercy, 2015–16), care for creation (Laudato Si\', 2015; Laudate Deum, 2023), accompaniment of the poor, and synodality — a renewed emphasis on listening and consultation within the Church. He has also addressed the clergy sex abuse crisis with structural and disciplinary reforms.',
+          },
         ],
       },
     ],
@@ -115,7 +357,7 @@ function TypeBadge({ type }: { type?: NodeType }) {
 
 function filterTree(nodes: TreeNode[], show: Record<NodeType, boolean>): TreeNode[] {
   const accept = (n: TreeNode): boolean => {
-    if (!n.type) return true // keep structural nodes
+    if (!n.type) return true
     return show[n.type]
   }
   const walk = (n: TreeNode): TreeNode | null => {
@@ -130,15 +372,15 @@ function filterTree(nodes: TreeNode[], show: Record<NodeType, boolean>): TreeNod
   return nodes.map(walk).filter(Boolean) as TreeNode[]
 }
 
-function Branch({ node, depth = 0, onSelect }: { node: TreeNode; depth?: number; onSelect: (n: TreeNode) => void }) {
+function Branch({ node, depth = 0, onSelect, selectedId }: { node: TreeNode; depth?: number; onSelect: (n: TreeNode) => void; selectedId: string | null }) {
   const [open, setOpen] = useState(true)
   const hasChildren = node.children && node.children.length > 0
   const type = node.type
   const meta = type ? TYPE_BADGE[type] : undefined
-  const borderCls = type === 'division' ? 'border-red-300' : type === 'heresy' ? 'border-red-400' : type === 'council' ? 'border-amber-300' : 'border-gray-300'
-  const padType = meta?.pad ?? ''
+  const borderCls = meta?.borderCls ?? 'border-gray-300'
+  const isSelected = node.id === selectedId
   return (
-    <div className={`relative pl-6 ${padType}`}>
+    <div className={`relative pl-6`}>
       {depth > 0 && (
         <span className={`absolute left-0 top-3 h-full border-l ${borderCls}`} />
       )}
@@ -147,28 +389,35 @@ function Branch({ node, depth = 0, onSelect }: { node: TreeNode; depth?: number;
           <span className={`absolute left-0 top-3 w-4 border-t ${borderCls}`} />
         )}
         <button
-          onClick={() => (hasChildren ? setOpen(!open) : onSelect(node))}
-          className={`mt-1 inline-flex items-center px-2 py-1 rounded text-sm border ${
-            hasChildren ? 'bg-white hover:bg-gray-50' : type==='division' ? 'bg-red-50' : type==='heresy' ? 'bg-red-50' : type==='council' ? 'bg-amber-50' : 'bg-gray-50 hover:bg-gray-100'
+          onClick={() => {
+            if (hasChildren) setOpen(!open)
+            onSelect(node)
+          }}
+          className={`mt-1 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded text-sm border transition-colors ${
+            isSelected
+              ? 'bg-amber-50 border-amber-400 text-amber-900'
+              : hasChildren
+                ? 'bg-white hover:bg-gray-50 border-gray-200'
+                : type === 'division' || type === 'heresy'
+                  ? 'bg-red-50 border-red-200 hover:bg-red-100'
+                  : type === 'council'
+                    ? 'bg-amber-50 border-amber-200 hover:bg-amber-100'
+                    : type === 'saint'
+                      ? 'bg-emerald-50 border-emerald-200 hover:bg-emerald-100'
+                      : 'bg-gray-50 border-gray-200 hover:bg-gray-100'
           }`}
         >
           {hasChildren && (
-            <span className="mr-1 text-gray-500">{open ? '▾' : '▸'}</span>
+            <span className="text-gray-400 text-xs">{open ? '▾' : '▸'}</span>
           )}
-          <span className="text-gray-800">{node.label}</span>
-          <span className="ml-2"><TypeBadge type={type} /></span>
+          <span className="text-gray-800 font-medium">{node.label}</span>
+          <TypeBadge type={type} />
         </button>
       </div>
-      {node.summary && (
-        <div className="ml-6 mt-1 text-[12px] text-gray-600">
-          {node.summary}
-          <button className="ml-2 text-amber-700 underline" onClick={()=>onSelect(node)}>More</button>
-        </div>
-      )}
       {hasChildren && open && (
-        <div className="mt-2 space-y-2">
+        <div className="mt-2 space-y-2 ml-2">
           {node.children!.map((child) => (
-            <Branch key={child.id} node={child} depth={depth + 1} onSelect={onSelect} />
+            <Branch key={child.id} node={child} depth={depth + 1} onSelect={onSelect} selectedId={selectedId} />
           ))}
         </div>
       )}
@@ -177,7 +426,7 @@ function Branch({ node, depth = 0, onSelect }: { node: TreeNode; depth?: number;
 }
 
 export default function ChurchHistoryTree() {
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>('trunk')
   const [show, setShow] = useState<Record<NodeType, boolean>>({
     church: true,
     council: true,
@@ -193,78 +442,119 @@ export default function ChurchHistoryTree() {
 
   return (
     <div className="py-8">
-      {/* Development Progress Notification */}
-      <div className="container mx-auto px-4 mb-6">
-        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse"></div>
-            <span className="text-amber-800 font-medium text-sm">Development in Progress</span>
-          </div>
-          <p className="text-amber-700 text-sm mt-1">
-            This Church History Tree is under active development. Content, filters, and interactions are being refined.
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">Church History Tree</h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The Catholic Church as a living tree: one continuous trunk from Pentecost, strengthened
+            by councils, challenged by heresies, enriched by saints, and branching into new missions.
+            Click any node for detail; use the filters to focus on what interests you.
           </p>
         </div>
-      </div>
-      
-      <div className="container mx-auto px-4 grid lg:grid-cols-4 gap-6">
-        {/* Left Sidebar Filters */}
-        <div className="bg-white rounded-lg border p-4 h-fit">
-          <h3 className="text-sm font-semibold text-gray-800 mb-3">Filter by Type</h3>
-          <div className="space-y-2">
-            {(Object.keys(TYPE_BADGE) as Array<NodeType>).map((t) => (
-              <label key={t} className="flex items-center gap-2 text-xs cursor-pointer hover:bg-gray-50 p-1 rounded">
-                <input
-                  type="checkbox"
-                  checked={show[t]}
-                  onChange={(e)=>setShow({ ...show, [t]: e.target.checked })}
-                  className="rounded"
-                />
-                <span className={`px-2 py-1 rounded text-[10px] font-medium ${TYPE_BADGE[t].cls}`}>
-                  {TYPE_BADGE[t].text}
-                </span>
-              </label>
-            ))}
-          </div>
-          <div className="mt-4 pt-3 border-t border-gray-200">
-            <button 
-              onClick={() => setShow({ church: true, council: true, heresy: true, division: true, event: true, saint: true, movement: true })}
-              className="text-xs text-blue-600 hover:text-blue-800"
-            >
-              Show All
-            </button>
-            <span className="mx-2 text-gray-300">|</span>
-            <button 
-              onClick={() => setShow({ church: true, council: true, heresy: false, division: false, event: false, saint: false, movement: false })}
-              className="text-xs text-blue-600 hover:text-blue-800"
-            >
-              Core Only
-            </button>
-          </div>
-        </div>
 
-        {/* Main Tree Content */}
-        <div className="lg:col-span-2 bg-white rounded-lg border p-6">
-          <h1 className="text-2xl font-bold text-gray-800 mb-2">Church History Tree</h1>
-          <p className="text-gray-600 text-sm mb-4">Trunk = Catholic Church; Councils = strengths; Heresies = dangers; Divisions = separated branches.</p>
-          <div className="space-y-3">
-            {filteredTree.map((root) => (
-              <Branch key={root.id} node={root} onSelect={(n)=>setSelectedId(n.id)} />
-            ))}
-          </div>
-        </div>
+        <div className="grid lg:grid-cols-4 gap-6">
 
-        {/* Right Details Panel */}
-        <div className="bg-white rounded-lg border p-6">
-          {selected ? (
-            <div className="space-y-2 text-gray-700">
-              <div className="text-lg font-semibold">{selected.label}</div>
-              {selected.year && <div className="text-sm">Year: {selected.year}</div>}
-              {selected.summary && <div className="text-sm">{selected.summary}</div>}
-              <div className="pt-2 text-sm text-gray-600">(Detailed view) Add sources, related popes, deeper context, and links.</div>
+          {/* Left Sidebar Filters */}
+          <div className="lg:col-span-1">
+            <div className="bg-white rounded-lg border border-gray-200 p-4 sticky top-4">
+              <h3 className="text-sm font-semibold text-gray-800 mb-3 uppercase tracking-wide">Filter by Type</h3>
+              <div className="space-y-1.5">
+                {(Object.keys(TYPE_BADGE) as Array<NodeType>).map((t) => (
+                  <label key={t} className="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1.5 rounded">
+                    <input
+                      type="checkbox"
+                      checked={show[t]}
+                      onChange={(e) => setShow({ ...show, [t]: e.target.checked })}
+                      className="rounded text-amber-600"
+                    />
+                    <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${TYPE_BADGE[t].cls}`}>
+                      {TYPE_BADGE[t].text}
+                    </span>
+                  </label>
+                ))}
+              </div>
+              <div className="mt-4 pt-3 border-t border-gray-200 flex gap-3">
+                <button
+                  onClick={() => setShow({ church: true, council: true, heresy: true, division: true, event: true, saint: true, movement: true })}
+                  className="text-xs text-amber-700 hover:text-amber-900 font-medium"
+                >
+                  Show All
+                </button>
+                <span className="text-gray-300">|</span>
+                <button
+                  onClick={() => setShow({ church: true, council: true, heresy: false, division: false, event: false, saint: false, movement: false })}
+                  className="text-xs text-gray-600 hover:text-gray-800 font-medium"
+                >
+                  Core Only
+                </button>
+              </div>
+
+              {/* Cross-links */}
+              <div className="mt-5 pt-4 border-t border-gray-200 space-y-2">
+                <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-2">Related Pages</p>
+                <Link href="/history/church" className="flex items-center gap-1.5 text-xs text-amber-700 hover:text-amber-900">
+                  <ChevronRight className="w-3 h-3" /> The Church (Full History)
+                </Link>
+                <Link href="/history/church-divisions" className="flex items-center gap-1.5 text-xs text-amber-700 hover:text-amber-900">
+                  <ChevronRight className="w-3 h-3" /> Church Divisions (Detail)
+                </Link>
+                <Link href="/history/apostles" className="flex items-center gap-1.5 text-xs text-amber-700 hover:text-amber-900">
+                  <ChevronRight className="w-3 h-3" /> The Apostles
+                </Link>
+              </div>
             </div>
-          ) : (
-            <p className="text-gray-500 text-sm">Click "More" on any item to view details here.</p>
-          )}
+          </div>
+
+          {/* Main Tree */}
+          <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 p-6 overflow-x-auto">
+            <div className="space-y-3">
+              {filteredTree.map((root) => (
+                <Branch key={root.id} node={root} onSelect={(n) => setSelectedId(n.id)} selectedId={selectedId} />
+              ))}
+            </div>
+          </div>
+
+          {/* Right Details Panel */}
+          <div className="lg:col-span-1">
+            {selected ? (
+              <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-4 sticky top-4">
+                <div>
+                  <h2 className="text-lg font-bold text-gray-900 leading-tight">{selected.label}</h2>
+                  {selected.year && (
+                    <p className="text-sm text-amber-700 font-medium mt-1">{selected.year}</p>
+                  )}
+                  {selected.type && (
+                    <div className="mt-2">
+                      <TypeBadge type={selected.type} />
+                    </div>
+                  )}
+                </div>
+                {(selected.detail || selected.summary) && (
+                  <p className="text-sm text-gray-700 leading-relaxed">
+                    {selected.detail ?? selected.summary}
+                  </p>
+                )}
+                {selected.divisionLink && (
+                  <div className="pt-3 border-t border-gray-100">
+                    <Link
+                      href="/history/church-divisions"
+                      className="text-xs text-amber-700 hover:text-amber-900 font-medium flex items-center gap-1"
+                    >
+                      <ChevronRight className="w-3 h-3" />
+                      See Church Divisions for full detail
+                    </Link>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="bg-white rounded-lg border border-gray-200 p-6">
+                <p className="text-gray-500 text-sm">Click any node to view details here.</p>
+              </div>
+            )}
+          </div>
+
         </div>
       </div>
     </div>

--- a/src/app/science/archaeology/page.tsx
+++ b/src/app/science/archaeology/page.tsx
@@ -1,32 +1,1837 @@
 'use client'
 
-import { Search, MapPin, Calendar } from 'lucide-react'
+import { useState } from 'react'
+import {
+  Search,
+  Clock,
+  Microscope,
+  Scale,
+  Landmark,
+  FileText,
+  Shield,
+  ScrollText,
+  BookOpen,
+  CheckCircle,
+  HelpCircle,
+  MapPin,
+  Users,
+  Church,
+  Layers,
+  Calendar,
+  Home,
+  Waves,
+  Droplets,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-is-archaeology'
+  | 'old-testament-finds'
+  | 'new-testament-finds'
+  | 'exodus-question'
+  | 'dead-sea-scrolls'
+  | 'shroud-of-turin'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-is-archaeology', label: 'What Is Biblical Archaeology?' },
+  { id: 'old-testament-finds', label: 'Old Testament Discoveries' },
+  { id: 'new-testament-finds', label: 'New Testament Discoveries' },
+  { id: 'exodus-question', label: 'The Exodus Question' },
+  { id: 'dead-sea-scrolls', label: 'The Dead Sea Scrolls' },
+  { id: 'shroud-of-turin', label: 'The Shroud of Turin' },
+]
 
 export default function ArchaeologyPage() {
-  const sections = [
-    { icon: Search, title: 'Dead Sea Scrolls (1947)', description: 'The discovery at Qumran that confirmed the remarkable accuracy of biblical manuscript transmission over a thousand years.' },
-    { icon: MapPin, title: 'Biblical Sites Confirmed', description: 'Pool of Siloam, the Pilate inscription at Caesarea, the House of Peter at Capernaum, and other archaeological finds that corroborate the biblical record.' },
-    { icon: Calendar, title: 'Carbon Dating & Relics', description: 'How modern scientific methods are used to study relics, manuscripts, and sacred artifacts — including the Shroud of Turin.' },
-  ]
+  const [activeTab, setActiveTab] = useState<TabId>('what-is-archaeology')
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-10">
-        <h1 className="text-3xl sm:text-4xl font-serif font-bold text-gray-900 mb-3">Archaeology & the Bible</h1>
-        <p className="text-lg text-gray-600 leading-relaxed max-w-3xl">Modern archaeology and scientific methods have repeatedly confirmed details of the biblical record. From the Dead Sea Scrolls to the excavation of ancient Jerusalem, science has served as an ally of faith in illuminating the historical context of Scripture.</p>
-      </div>
-      <div className="rounded-xl p-6 mb-10 border-l-4" style={{ backgroundColor: '#FFFBEB', borderColor: '#D4AF37' }}>
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Coming Soon</h2>
-        <p className="text-gray-600">Archaeological discoveries that illuminate and confirm the biblical record will be detailed here.</p>
-      </div>
-      <div className="grid sm:grid-cols-3 gap-6">
-        {sections.map((s) => { const Icon = s.icon; return (
-          <div key={s.title} className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <div className="flex items-center gap-3 mb-3"><div className="p-2 rounded-lg bg-emerald-50"><Icon className="w-5 h-5 text-emerald-700" /></div>
-            <h3 className="font-serif text-lg font-semibold text-gray-900">{s.title}</h3></div>
-            <p className="text-sm text-gray-600 leading-relaxed">{s.description}</p>
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Archaeology &amp; the Bible
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            From the Dead Sea Scrolls to the ossuary of Caiaphas, archaeology has repeatedly
+            illuminated and confirmed the world of the Bible. This page surveys the major
+            discoveries, the contested questions, and the Church&rsquo;s approach to reading
+            archaeological evidence.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
           </div>
-        )})}
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: WHAT IS BIBLICAL ARCHAEOLOGY ==================== */}
+        {activeTab === 'what-is-archaeology' && (
+          <div className="space-y-8">
+
+            {/* Defining the Field */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Search className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Defining the Field</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Biblical archaeology is the systematic excavation and study of sites, artifacts,
+                texts, and material culture related to the lands and peoples of the Bible. It is
+                a discipline that sits at the intersection of history, anthropology, linguistics,
+                and &mdash; for believers &mdash; theology.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  What Biblical Archaeology Is &mdash; and Is Not
+                </h3>
+                <ul className="space-y-3 text-amber-800">
+                  <li className="flex items-start gap-2">
+                    <span className="font-bold mt-0.5">&#8227;</span>
+                    <span>It is <em>not</em> the same as &ldquo;trying to prove the Bible is true.&rdquo;
+                    Genuine archaeology follows evidence wherever it leads &mdash; including to results
+                    that complicate or challenge a simplistic reading of the biblical text.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="font-bold mt-0.5">&#8227;</span>
+                    <span>It is <em>not</em> the same as dismissing the Bible as legend. The goal is
+                    contextual illumination: understanding the historical and cultural world in which
+                    the biblical texts were written and read.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="font-bold mt-0.5">&#8227;</span>
+                    <span>The term &ldquo;biblical archaeology&rdquo; is sometimes contested by secular
+                    archaeologists who prefer &ldquo;Syro-Palestinian archaeology&rdquo; or &ldquo;Levantine
+                    archaeology&rdquo; as more neutral designations &mdash; but the former remains widely used
+                    in both academic and popular contexts.</span>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Pontifical Biblical Commission (1993)
+                </h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;Archaeology can contribute very much to a better knowledge of the living
+                  conditions in which the events of the Bible unfolded and of the literary production
+                  of the biblical period.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; Pontifical Biblical Commission, <em>The Interpretation of the Bible in the
+                  Church</em>, 1993, Section A.3
+                </p>
+              </div>
+            </div>
+
+            {/* A Brief History */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">A Brief History of the Field</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Biblical archaeology as a scientific discipline is roughly two centuries old, but
+                it has passed through dramatically different phases &mdash; from pious confirmation
+                to rigorous skepticism and, finally, to a more nuanced engagement with the evidence.
+              </p>
+
+              <div className="space-y-4">
+                <div className="border-l-4 border-amber-400 pl-5 py-2">
+                  <h3 className="font-bold text-gray-800 mb-1">Edward Robinson (1838)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    The first scientific exploration of Palestine. Robinson identified dozens of biblical
+                    sites by recognizing that Arabic place-names often preserved ancient Hebrew names in
+                    corrupted form &mdash; a breakthrough method that confirmed the geographical reality
+                    of many biblical locations.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-blue-400 pl-5 py-2">
+                  <h3 className="font-bold text-gray-800 mb-1">Charles Warren (1867&ndash;70)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    First systematic excavation of Jerusalem. Warren discovered the shaft that bears his
+                    name (Warren&rsquo;s Shaft) and established the foundations of Jerusalem archaeology,
+                    mapping the massive Herodian Temple Mount retaining walls still visible today.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-purple-400 pl-5 py-2">
+                  <h3 className="font-bold text-gray-800 mb-1">William Flinders Petrie (1890)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Established the two foundational methods of modern archaeology: stratigraphy (reading
+                    layers of occupation) and pottery chronology. Petrie demonstrated that pottery styles
+                    changed predictably over time, making broken sherds reliable dating tools &mdash; a
+                    discovery that transformed the entire discipline.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-green-400 pl-5 py-2">
+                  <h3 className="font-bold text-gray-800 mb-1">William F. Albright (1891&ndash;1971)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Often called &ldquo;the father of biblical archaeology.&rdquo; Albright excavated Tell
+                    Beit Mirsim, developed pottery chronology for the region, and used archaeology to affirm
+                    the historical reliability of the Bible. His maximalist approach dominated the field for
+                    decades and shaped a generation of American biblical scholars.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-red-400 pl-5 py-2">
+                  <h3 className="font-bold text-gray-800 mb-1">Kathleen Kenyon (1952&ndash;58)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Excavated Jericho using more rigorous stratigraphic methods and challenged Albright&rsquo;s
+                    conclusions. Kenyon found no evidence of walled Jericho at the time traditionally associated
+                    with Joshua &mdash; raising important questions about the historical interpretation of the
+                    conquest narrative that scholars continue to debate.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-400 pl-5 py-2">
+                  <h3 className="font-bold text-gray-800 mb-1">Israel Finkelstein (Tel Aviv University, from 1990s)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Representative of the &ldquo;minimalist&rdquo; school &mdash; more skeptical about early
+                    biblical history, particularly the United Monarchy of David and Solomon. Archaeologically
+                    important and methodologically rigorous, Finkelstein&rsquo;s work is taken seriously even
+                    by scholars who dispute his more sweeping historical conclusions.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-5 rounded-lg mt-6">
+                <p className="text-amber-800 text-sm">
+                  <strong>The post-1970s shift:</strong> Biblical archaeology became more systematic,
+                  less apologetic, and more open to complex and ambiguous conclusions. Modern practitioners
+                  apply increasingly sophisticated scientific tools &mdash; DNA analysis, isotopic studies,
+                  LiDAR surveys &mdash; to questions that previous generations could only address with a
+                  trowel and a pottery sherd.
+                </p>
+              </div>
+            </div>
+
+            {/* Methods */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Microscope className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Methods Used in Biblical Archaeology</h2>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-5">
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-gray-800 mb-2">Stratigraphy</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Reading layers (strata) of occupation. Each occupational layer represents a historical
+                    period; disruptions (fires, destructions, rebuilding) mark transitions between periods.
+                    Objects found within a layer help date the layer with increasing precision.
+                  </p>
+                </div>
+
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-gray-800 mb-2">Pottery Typology</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Pottery styles changed predictably over time. A broken pot sherd can date an
+                    archaeological layer within 50&ndash;100 years. It is the most common and reliable
+                    dating tool in Levantine archaeology.
+                  </p>
+                </div>
+
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-gray-800 mb-2">Epigraphy</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    The study of inscriptions and ancient writing. Inscriptions confirm names, events,
+                    languages, and administrative structures &mdash; and sometimes directly corroborate
+                    biblical persons or places mentioned in the text.
+                  </p>
+                </div>
+
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-gray-800 mb-2">Radiocarbon Dating (C-14)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Measures the decay of carbon-14 in organic material (wood, bone, textile, seeds).
+                    Reliable within &plusmn;50&ndash;100 years; invaluable for scrolls, wooden objects, and
+                    human remains where pottery typology cannot be applied.
+                  </p>
+                </div>
+
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-gray-800 mb-2">Luminescence Dating</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Dates the last time sediment or fired ceramics were exposed to light or heat.
+                    Particularly useful for dating architectural layers and fired mudbrick without
+                    relying on organic material.
+                  </p>
+                </div>
+
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-gray-800 mb-2">LiDAR &amp; Ground-Penetrating Radar</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Non-invasive survey technologies that reveal buried structures, road systems, and
+                    ancient water channels without excavation. Increasingly transforming our understanding
+                    of ancient settlement patterns across the Levant.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Faith and Archaeology */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Proper Relationship: Faith and Archaeology</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                For Catholic believers, the relationship between archaeology and faith is not
+                adversarial &mdash; it is complementary. The Church has consistently welcomed
+                honest historical inquiry as a friend, not a threat, to faith.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Key Principles for Reading Archaeological Evidence
+                </h3>
+                <ul className="space-y-3 text-amber-800">
+                  <li className="flex items-start gap-2">
+                    <span className="font-bold mt-0.5">1.</span>
+                    <span><strong>Absence of evidence is not evidence of absence.</strong> Most ancient
+                    events left no physical trace. The silence of the Egyptian record about the Exodus
+                    does not prove the Exodus did not happen &mdash; it reflects the nature of ancient
+                    record-keeping, which systematically omitted defeats and humiliations.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="font-bold mt-0.5">2.</span>
+                    <span><strong>Genuine evidence must be taken seriously.</strong> When archaeology
+                    complicates a simplistic or literalist reading of the biblical text, this is an
+                    invitation to deepen one&rsquo;s exegetical understanding, not to panic. The Bible
+                    contains history, theology, poetry, liturgy, and law &mdash; genres that do not all
+                    function identically.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="font-bold mt-0.5">3.</span>
+                    <span><strong>Archaeology illuminates context; it does not adjudicate faith claims.</strong>
+                    No archaeological discovery can &ldquo;prove&rdquo; the Resurrection or &ldquo;disprove&rdquo;
+                    the existence of God. These are metaphysical questions that lie outside the competence
+                    of any empirical science.</span>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  <em>Dei Verbum</em> 12 (Vatican II)
+                </h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;Since God speaks in Sacred Scripture through men in human fashion, the
+                  interpreter of Sacred Scripture, in order to see clearly what God wanted to communicate
+                  to us, should carefully investigate what meaning the sacred writers really intended&hellip;
+                  To search out the intention of the sacred writers, attention should be given, among other
+                  things, to <em>literary forms</em>. For truth is set forth and expressed differently in
+                  texts which are variously historical, prophetic, poetic, or of other forms of discourse.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; Vatican II, <em>Dei Verbum</em>, 12 (1965)
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: OLD TESTAMENT DISCOVERIES ==================== */}
+        {activeTab === 'old-testament-finds' && (
+          <div className="space-y-8">
+
+            {/* Merneptah Stele */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Landmark className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Merneptah Stele (1208 BC)</h2>
+              </div>
+
+              <div className="bg-amber-50 p-5 rounded-lg mb-6">
+                <p className="text-amber-800 text-sm">
+                  <strong>Discovered:</strong> 1896, Luxor, Egypt &mdash; now in the Cairo Museum.
+                  A black granite victory stele of Pharaoh Merneptah, son of Ramesses II.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Merneptah Stele contains the earliest known extrabiblical reference to
+                &ldquo;Israel&rdquo; in any ancient document &mdash; predating any other non-biblical
+                mention by centuries. Among Merneptah&rsquo;s boasts of military victories in Canaan
+                appears the line:
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <p className="text-purple-800 italic text-lg mb-3">
+                  &ldquo;Israel is laid waste; his seed is not.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm">
+                  &mdash; Merneptah Stele, c. 1208 BC (translation: Miriam Lichtheim)
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The significance of this inscription can scarcely be overstated. The hieroglyphic
+                determinative used for &ldquo;Israel&rdquo; indicates a <em>people</em>, not a
+                city-state or kingdom &mdash; consistent with the tribal confederation period described
+                in the book of Judges. This means that a people called &ldquo;Israel&rdquo; was
+                sufficiently established in Canaan by 1208 BC to attract the attention of the greatest
+                empire in the ancient Near East.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                Regardless of where one stands on the precise dating of the Exodus and the
+                Settlement, the Merneptah Stele establishes an archaeological anchor for Israel&rsquo;s
+                presence in Canaan in the late Bronze Age.
+              </p>
+            </div>
+
+            {/* Tel Dan Inscription */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <FileText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Tel Dan Inscription (&sim;9th century BC)</h2>
+              </div>
+
+              <div className="bg-blue-50 p-5 rounded-lg mb-6">
+                <p className="text-blue-800 text-sm">
+                  <strong>Discovered:</strong> 1993&ndash;94, Tel Dan (northern Israel). A fragmentary
+                  basalt stele in Aramaic, likely erected by the Aramean king Hazael of Damascus.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Among the fragments of this victory inscription appears the phrase &ldquo;House of
+                David&rdquo; (<em>bytdwd</em> in Aramaic) &mdash; the first and only extrabiblical
+                mention of the Davidic dynasty ever found. Before this discovery, critics of biblical
+                historicity frequently argued that David was a legendary or mythological figure, since
+                no non-biblical source had confirmed his existence.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-5">
+                <div className="flex items-center gap-2 mb-3">
+                  <CheckCircle className="w-5 h-5 text-green-700" />
+                  <h3 className="font-semibold text-green-900">What the Inscription Confirms</h3>
+                </div>
+                <ul className="text-green-800 text-sm space-y-2">
+                  <li>The Davidic dynasty was a known historical entity &mdash; not a later theological invention</li>
+                  <li>Israel&rsquo;s neighbors (in this case, Aram-Damascus) identified the Judean state by the name of its founding king within approximately 150 years of David&rsquo;s reign</li>
+                  <li>The stele describes a military victory over the &ldquo;king of Israel&rdquo; and the &ldquo;king of the House of David&rdquo; &mdash; consistent with 2 Kings 8&ndash;9 and Hazael&rsquo;s campaigns against both kingdoms</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Tel Dan inscription fundamentally altered the terms of the scholarly debate about
+                the United Monarchy. Even skeptical archaeologists now acknowledge that the Davidic
+                dynasty was real and historically remembered. The question has shifted from whether
+                David existed to what the precise nature and scale of his kingdom was.
+              </p>
+            </div>
+
+            {/* Hezekiah Bulla */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Shield className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hezekiah&rsquo;s Seal Bulla &amp; the Siloam Tunnel (c. 700 BC)</h2>
+              </div>
+
+              <div className="bg-green-50 p-5 rounded-lg mb-6">
+                <p className="text-green-800 text-sm">
+                  <strong>Discovered:</strong> 2015, Ophel excavations in Jerusalem (Eilat Mazar&rsquo;s
+                  team). A clay seal impression (<em>bulla</em>) bearing the king&rsquo;s personal seal.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The bulla is inscribed: &ldquo;Belonging to Hezekiah [son of] Ahaz, king of Judah.&rdquo;
+                Hezekiah is one of the most extensively documented figures in the entire Hebrew Bible
+                (2 Kings 18&ndash;20; Isaiah 36&ndash;39; 2 Chronicles 29&ndash;32) and is also mentioned
+                in Assyrian annals. This bulla is the first seal impression of an Israelite or Judean
+                king ever recovered in a scientific, controlled excavation &mdash; as opposed to the
+                antiquities market, where provenance cannot be guaranteed.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Siloam Tunnel Inscription</h3>
+                <p className="text-amber-800 mb-3">
+                  The famous tunnel carved through 533 metres of bedrock beneath the City of David
+                  &mdash; bringing water from the Gihon Spring to the Pool of Siloam inside the city
+                  walls before the Assyrian siege under Sennacherib &mdash; contains an inscription
+                  celebrating the moment the two teams of workmen met in the middle:
+                </p>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;And this is the account of the breach: while the excavators were swinging
+                  their axes, each toward his fellow, and while there were yet three cubits to be
+                  broken through, there was heard the voice of a man calling to his fellow&hellip;&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Siloam Tunnel Inscription, c. 701 BC; cf. 2 Kings 20:20; 2 Chronicles 32:30.
+                  Now in the Istanbul Archaeological Museum.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Together, the bulla and the tunnel inscription provide two independent physical
+                confirmations of the biblical account of Hezekiah&rsquo;s reign and his preparation
+                of Jerusalem for the Assyrian siege &mdash; one of the best-documented events in all
+                of biblical history from both biblical and extrabiblical sources.
+              </p>
+            </div>
+
+            {/* Black Obelisk */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Landmark className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Black Obelisk of Shalmaneser III (c. 841 BC)</h2>
+              </div>
+
+              <div className="bg-blue-50 p-5 rounded-lg mb-6">
+                <p className="text-blue-800 text-sm">
+                  <strong>Discovered:</strong> 1846, Nimrud (ancient Kalhu, Assyria). Now in the
+                  British Museum, London. A black basalt obelisk 2 metres tall, carved on all four
+                  sides with scenes of tribute-bearing delegations from five conquered regions.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                One of the five tribute panels depicts a figure kneeling prostrate before the
+                Assyrian king, with an Akkadian inscription identifying him as: &ldquo;Iaua son of
+                Omri.&rdquo; This is almost certainly Jehu, king of Israel (r. 842&ndash;815 BC),
+                who appears in 2 Kings 9&ndash;10 as the general who overthrew the house of Omri,
+                assassinated King Joram, and established his own dynasty.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Assyrians referred to Israel as &ldquo;the House of Omri&rdquo; long after
+                Omri&rsquo;s dynasty had ended &mdash; just as the Tel Dan inscription did. Jehu,
+                despite having destroyed the Omride dynasty, was apparently still identified by the
+                Assyrians under that geographical/political label.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The obelisk provides one of the earliest visual representations of a biblical figure
+                and confirms the tributary relationship between northern Israel and Assyria documented
+                in 2 Kings 17.
+              </p>
+            </div>
+
+            {/* Mesha Stele */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Mesha Stele / Moabite Stone (c. 840 BC)</h2>
+              </div>
+
+              <div className="bg-purple-50 p-5 rounded-lg mb-6">
+                <p className="text-purple-800 text-sm">
+                  <strong>Discovered:</strong> 1868, Dhiban (ancient Dibon, Jordan). Now in the
+                  Louvre, Paris. A black basalt stele of Mesha, king of Moab, celebrating his
+                  deliverance from Israelite domination.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Mesha Stele is remarkable for multiple reasons. It mentions &ldquo;Omri, king
+                of Israel&rdquo; and &ldquo;the house of Omri&rdquo; explicitly, confirming the
+                Israelite kingdom&rsquo;s dominance over Moab during the Omride period (cf. 2 Kings 3).
+                It references specific Israelite towns and the tribe of Gad &mdash; details consistent
+                with the biblical geography of the Transjordan.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Most intriguingly, line 31 of the stele has been read by some epigraphers (including
+                Andr&eacute; Lemaire of the Sorbonne) as containing the phrase &ldquo;House of
+                David&rdquo; &mdash; which would make the Mesha Stele a second extrabiblical
+                attestation of the Davidic dynasty, independent of the Tel Dan inscription. This
+                reading is disputed, but it remains a live scholarly question.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The stele also illustrates an important methodological principle: biblical events
+                are sometimes confirmed not by Israelite records but by the records of Israel&rsquo;s
+                enemies, who had no motive to embellish the Israelite narrative.
+              </p>
+            </div>
+
+            {/* Dead Sea Scrolls OT preview */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Dead Sea Scrolls (1947&ndash;1956)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The single most important manuscript discovery in the history of biblical scholarship.
+                Approximately 900 manuscripts &mdash; including fragments of every book of the Hebrew
+                Bible except Esther &mdash; were found in eleven caves near Khirbet Qumran between
+                1947 and 1956. Dates range from approximately 250 BC to 68 AD.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Great Isaiah Scroll (1QIsa<sup>a</sup>)
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  The complete 66-chapter Book of Isaiah, copied c. 125 BC &mdash; one thousand years
+                  older than any previously known Hebrew manuscript of the same text. When compared with
+                  the Masoretic Text used by modern Bibles, scholars found word-for-word agreement in the
+                  vast majority of passages, with differences limited to minor spelling variations and
+                  occasional word choices. No doctrinal content was altered.
+                </p>
+                <p className="text-blue-800">
+                  This remains the most powerful single demonstration of the fidelity with which Jewish
+                  scribes transmitted the sacred text across a millennium.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Dead Sea Scrolls are treated in full detail in the dedicated &ldquo;Dead Sea Scrolls&rdquo;
+                tab. Their significance for both Old and New Testament studies is sufficiently large to merit
+                extended treatment.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: NEW TESTAMENT DISCOVERIES ==================== */}
+        {activeTab === 'new-testament-finds' && (
+          <div className="space-y-8">
+
+            {/* Pontius Pilate Inscription */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Landmark className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Pontius Pilate Inscription (Caesarea Maritima, 1961)</h2>
+              </div>
+
+              <div className="bg-amber-50 p-5 rounded-lg mb-6">
+                <p className="text-amber-800 text-sm">
+                  <strong>Discovered:</strong> 1961, during excavations of the Roman theater at
+                  Caesarea Maritima by an Italian team led by Antonio Frova. Now in the Israel Museum,
+                  Jerusalem; a cast is displayed at the site.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                A limestone building block, originally part of a dedication inscription for a
+                public building (the <em>Tiberieum</em>, apparently dedicated to the Emperor Tiberius),
+                bears a Latin text that includes the unmistakable words:
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <p className="text-purple-800 italic font-mono text-sm mb-3">
+                  [DIS AUGUSTI]S TIBERIEUM<br />
+                  [PONTI]VS PILATVS<br />
+                  [PRAEF]ECTVS IVDAEA[E]<br />
+                  [FECIT D]E[DICAVIT]
+                </p>
+                <p className="text-purple-700 text-sm">
+                  &ldquo;Pontius Pilate, Prefect of Judaea&rdquo; &mdash; Caesarea Maritima
+                  Inscription, c. 26&ndash;36 AD
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Before this discovery, a minority of scholars had questioned whether Pontius Pilate
+                was a historical figure or a later legendary addition to the Passion narrative. The
+                inscription settled that question permanently.
+              </p>
+
+              <div className="bg-green-50 p-5 rounded-lg">
+                <div className="flex items-center gap-2 mb-3">
+                  <CheckCircle className="w-5 h-5 text-green-700" />
+                  <h3 className="font-semibold text-green-900">What the Inscription Confirms</h3>
+                </div>
+                <ul className="text-green-800 text-sm space-y-2">
+                  <li>Pilate&rsquo;s existence as a historical figure (no longer in serious doubt)</li>
+                  <li>His title: <em>Praefectus</em> (&ldquo;Prefect&rdquo;) of Judaea &mdash; not
+                  &ldquo;Procurator&rdquo; as some later sources wrote; consistent with Josephus&rsquo;
+                  and Tacitus&rsquo; accounts</li>
+                  <li>His tenure under Emperor Tiberius &mdash; consistent with Luke 3:1 (&ldquo;in the
+                  fifteenth year of the reign of Tiberius Caesar&hellip;&rdquo;)</li>
+                  <li>His administrative headquarters at Caesarea Maritima, not Jerusalem &mdash;
+                  consistent with why Pilate came to Jerusalem for Passover (John 18:28&ndash;29)</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Caiaphas Ossuary */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <FileText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Caiaphas Ossuary (Jerusalem, 1990)</h2>
+              </div>
+
+              <div className="bg-blue-50 p-5 rounded-lg mb-6">
+                <p className="text-blue-800 text-sm">
+                  <strong>Discovered:</strong> November 1990, the Peace Forest south of Jerusalem
+                  &mdash; unearthed during construction work. Now in the Israel Museum, Jerusalem.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Construction workers accidentally broke through the ceiling of a rock-cut tomb
+                and found twelve limestone ossuaries (bone boxes). The most ornately decorated of
+                them bears two inscriptions: &ldquo;Yehosef bar Qayafa&rdquo; and &ldquo;Yehosef
+                bar Qafa&rdquo; &mdash; that is, &ldquo;Joseph son of Caiaphas&rdquo; in Aramaic.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                This is the full name of the High Priest who, according to all four Gospels, presided
+                at the trial of Christ (Matthew 26:57; John 11:49&ndash;51; 18:13&ndash;14). The
+                historian Josephus confirms that the High Priest&rsquo;s full name was &ldquo;Joseph
+                called Caiaphas&rdquo; and that he held office approximately 18&ndash;36 AD
+                (<em>Antiquities</em> 18.2.2; 18.4.3).
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The ossuary contained the bones of six individuals, including a 60-year-old male.
+                It is possible &mdash; though not certain &mdash; that this is the ossuary of the
+                High Priest himself. Whether or not that identification is correct, the ossuary
+                provides the first physical connection to a named figure in the Passion narrative.
+              </p>
+
+              <div className="bg-amber-50 p-5 rounded-lg">
+                <p className="text-amber-800 text-sm">
+                  <strong>Note on the James Ossuary:</strong> A separate ossuary bearing the inscription
+                  &ldquo;James son of Joseph, brother of Jesus&rdquo; surfaced in 2002, but its
+                  provenance is unverified (it emerged from the antiquities market, not a controlled
+                  excavation) and part of the inscription has been disputed as a modern addition.
+                  The scholarly consensus remains cautious about this piece.
+                </p>
+              </div>
+            </div>
+
+            {/* Pool of Bethesda */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Droplets className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Pool of Bethesda (excavated 1956&ndash;64)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                John 5:2 describes &ldquo;a pool, called in Hebrew Bethesda, which has five
+                porticoes&rdquo; &mdash; an unusual architectural detail. For generations, critics
+                argued that this &ldquo;five-porticoed&rdquo; pool was theologically symbolic (a
+                reference to the five books of Moses) rather than a real place, since no such pool
+                was known from ancient sources.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Excavations near St. Anne&rsquo;s Church in Jerusalem (1956&ndash;64) confirmed that
+                the pool of Bethesda was real, precisely as John described it. The site consists of
+                <em> two</em> adjacent basins separated by a central dividing wall &mdash; creating
+                four exterior colonnades (one on each side) plus one colonnade running along the
+                central partition, for a total of five. John&rsquo;s &ldquo;five porticoes&rdquo;
+                is straightforward architectural description, not allegory.
+              </p>
+
+              <div className="bg-green-50 p-5 rounded-lg">
+                <p className="text-green-800 text-sm">
+                  <strong>Significance for Johannine studies:</strong> This is one of several
+                  confirmations that the Fourth Gospel&rsquo;s author possessed detailed, accurate
+                  knowledge of pre-70 AD Jerusalem &mdash; consistent with the tradition of apostolic
+                  or eyewitness composition. John&rsquo;s local topographical knowledge (Bethesda,
+                  Siloam, the Praetorium, the &ldquo;Pavement&rdquo; of John 19:13) has been confirmed
+                  repeatedly by archaeology.
+                </p>
+              </div>
+            </div>
+
+            {/* Pool of Siloam */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Waves className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Pool of Siloam (Rediscovered 2004)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                John 9:7 describes the Lord sending the man born blind to wash in &ldquo;the pool
+                of Siloam.&rdquo; A Byzantine-era pool had long been known and venerated at the site,
+                but in June 2004, city workers repairing a broken sewer pipe in the City of David
+                uncovered a large stepped structure &mdash; identified immediately as the actual
+                first-century Pool of Siloam.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The newly found pool is significantly larger than the Byzantine structure: broad
+                stone steps lead down to the water on three sides, a design consistent with its
+                use as a <em>miqveh</em> (ritual immersion pool) for pilgrims ascending to the
+                Temple. Coins found in the plaster date its construction to the late Hasmonean period
+                and its use through the first century AD.
+              </p>
+
+              <div className="bg-blue-50 p-5 rounded-lg">
+                <p className="text-blue-800 text-sm">
+                  <strong>Connection to Hezekiah&rsquo;s Tunnel:</strong> The Pool of Siloam is fed
+                  by Hezekiah&rsquo;s Tunnel (see the Old Testament Discoveries tab). The same tunnel
+                  that Hezekiah built in 701 BC to protect Jerusalem&rsquo;s water supply was still in
+                  use in the first century AD. The pool where the blind man washed is directly connected
+                  to one of the Old Testament&rsquo;s most dramatically confirmed engineering works.
+                </p>
+              </div>
+            </div>
+
+            {/* House of Peter */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Home className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The House of Peter, Capernaum</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Mark 1:29&ndash;31 describes the Lord entering &ldquo;the house of Simon and Andrew&rdquo;
+                in Capernaum and healing Peter&rsquo;s mother-in-law. Franciscan archaeologists
+                excavating beneath the 5th-century octagonal church at Capernaum (1968&ndash;2003)
+                made a remarkable find.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Beneath the octagonal church lay an earlier 4th-century house-church, and beneath
+                that lay a 1st-century fishing house with plastered walls &mdash; unusual for
+                Capernaum, where houses were typically built of rough basalt without plaster. The
+                plastered walls were covered with inscriptions in multiple languages (Aramaic, Greek,
+                Syriac, Latin), including fish symbols, crosses, and multiple instances of the names
+                &ldquo;Peter&rdquo; and &ldquo;Lord Jesus Christ.&rdquo;
+              </p>
+
+              <div className="bg-green-50 p-5 rounded-lg mb-5">
+                <p className="text-green-800 text-sm">
+                  <strong>The archaeological logic:</strong> A 4th-century church was deliberately
+                  built over a specific 1st-century house. That house attracted veneration (graffiti)
+                  at least from the 2nd century onward. The church was built precisely over that
+                  specific structure, not over nearby structures. This pattern of building &mdash;
+                  a <em>loca sancta</em> tradition &mdash; is well-attested across early Christianity
+                  as a way of preserving the memory of sacred sites.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Pope Francis celebrated Mass at the site during his 2014 pilgrimage to the Holy
+                Land. The Franciscan Custody of the Holy Land continues to maintain the site, which
+                remains open to pilgrims.
+              </p>
+            </div>
+
+            {/* Nazareth Inscription */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Nazareth Inscription (&sim;1st century AD)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                A marble slab bearing a Greek imperial decree was acquired in Nazareth around 1878
+                and eventually deposited in the Biblioth&egrave;que nationale, Paris. The inscription
+                is dated to approximately the reign of Tiberius or Claudius (14&ndash;54 AD) based on
+                letter forms and style.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The decree forbids the removal of bodies from tombs and imposes an unusually severe
+                penalty &mdash; death &mdash; for violators. This is remarkable because Roman law
+                typically treated tomb violation as a civil rather than capital matter.
+              </p>
+
+              <div className="bg-purple-50 p-5 rounded-lg mb-5">
+                <p className="text-purple-800 text-sm italic mb-2">
+                  &ldquo;&hellip;It is my decision [concerning] graves and tombs &mdash; whoever
+                  has made them for the religious observances of parents, or children, or household
+                  members &mdash; that these remain undisturbed forever&hellip; Let it be absolutely
+                  forbidden for anyone to disturb them. In the case of contravention I desire that
+                  the offender be sentenced to capital punishment on charge of violation of
+                  sepulture.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm">
+                  &mdash; The Nazareth Inscription, c. 1st century AD
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Some scholars connect this decree to a Roman administrative response to the
+                Christian proclamation of the empty tomb and Resurrection &mdash; consistent
+                with Matthew 28:13, where the chief priests spread the report that the disciples
+                had stolen the body. Others regard the connection as coincidental. The inscription
+                does not &ldquo;prove&rdquo; the Resurrection; but it demonstrates that in the
+                1st-century Roman world, the question of bodies being removed from tombs was
+                sufficiently explosive to merit an imperial decree in the very region where
+                Christianity was born.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: THE EXODUS QUESTION ==================== */}
+        {activeTab === 'exodus-question' && (
+          <div className="space-y-8">
+
+            {/* The Challenge */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <HelpCircle className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Archaeological Challenge</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Exodus from Egypt is the defining event of the Old Testament &mdash; the
+                foundational act of divine rescue on which Israel&rsquo;s entire covenant identity
+                rests. It is presupposed in every major prophetic book, in the Psalms, in the
+                prophetic proclamations of Amos and Hosea, and ultimately in the Last Supper as
+                the Passover meal that our Lord reinterprets in his own body and blood.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The archaeological challenge is this: there is no Egyptian document that explicitly
+                records the Exodus as described in the Bible. No mention of Moses appears in
+                Egyptian records. No account of ten plagues survives. No record exists of an
+                Egyptian army being drowned in the sea. The silence of the Egyptian record on
+                these events has led some archaeologists &mdash; most prominently Israel Finkelstein
+                and Neil Asher Silberman in <em>The Bible Unearthed</em> (2001) &mdash; to argue
+                that the Exodus as described in the Bible did not occur, or occurred in a form so
+                radically different from the biblical account as to be unrecognizable.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Catholic Response: Absence of Evidence
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Absence of archaeological or documentary evidence is not evidence of absence,
+                  especially in the case of ancient Egypt. Egyptian royal records were not neutral
+                  chronicles: they were instruments of ideological self-presentation, systematically
+                  omitting defeats, disasters, and humiliations. Pharaoh Ramesses II, for instance,
+                  portrayed the Battle of Kadesh (1274 BC) &mdash; which by all other evidence was
+                  at best a costly draw &mdash; as a triumphant personal victory in multiple temples.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  The silence of Egyptian records about the Exodus is therefore exactly what one
+                  would expect from ancient Egyptian royal historiography, regardless of whether
+                  the Exodus happened or not.
+                </p>
+              </div>
+            </div>
+
+            {/* Evidence for Historical Basis */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Search className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Evidence Supporting a Historical Basis</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                While direct Egyptian confirmation of the Exodus is absent, a substantial body of
+                indirect archaeological and textual evidence supports the plausibility of a genuine
+                historical event behind the biblical narrative.
+              </p>
+
+              <div className="space-y-5">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-green-900 mb-2">Semites in Egypt: Tell el-Dab&rsquo;a (Avaris)</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    Manfred Bietak&rsquo;s multi-decade excavations at Tell el-Dab&rsquo;a in the
+                    Nile Delta (ancient Avaris) have revealed a large Semitic population settled in
+                    the eastern Delta during the 12th&ndash;18th Dynasty periods. Mud-brick architecture
+                    of the type common in Canaan, Canaanite pottery, goat and sheep bones (rather
+                    than Egyptian cattle), and multi-roomed courtyard houses all indicate a substantial
+                    Semitic community living in a distinctly non-Egyptian style. This is consistent
+                    with the biblical tradition of Joseph settling his family in the region of Goshen
+                    (Genesis 47:6), which was located precisely in the eastern Nile Delta.
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-green-900 mb-2">The Ipuwer Papyrus (&sim;1800&ndash;1600 BC)</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    An Egyptian literary text that describes a series of calamities overtaking
+                    Egypt &mdash; including rivers turning to blood, crop failures, darkness, and
+                    widespread death. The parallels with the Ten Plagues are suggestive: &ldquo;Lo,
+                    the river is blood. Does a man drink from it? He rejects it as human and thirsts
+                    for water.&rdquo; Whether the Ipuwer Papyrus reflects a folk memory of events
+                    connected to the Exodus or is merely coincidental is debated, but the document
+                    demonstrates that calamitous events of the type described in Exodus were
+                    imaginable and expressible within Egyptian literary culture.
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-green-900 mb-2">The Shasu of Yahweh</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    Egyptian texts from the 13th century BC refer to nomadic groups from the
+                    Sinai/Negev region as &ldquo;Shasu-Yahweh&rdquo; &mdash; an astonishing reference
+                    to the divine name &ldquo;Yahweh&rdquo; in an Egyptian administrative document.
+                    These nomadic Shasu groups may represent an early component of what would
+                    become the Israelite confederation, suggesting that the worship of Yahweh has
+                    roots in the Sinai/Negev region consistent with the Exodus narrative.
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-green-900 mb-2">James K. Hoffmeier&rsquo;s Analysis</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    In <em>Israel in Egypt</em> (1997) and <em>Ancient Israel in Sinai</em> (2005),
+                    Egyptologist James Hoffmeier demonstrates that the Exodus narrative is saturated
+                    with authentic Egyptian detail &mdash; personal names (Moses, Phinehas, Hophni),
+                    administrative titles, geographical terminology, military organization, and
+                    cultural practices &mdash; that a fictional writer of the 6th century BC could
+                    not have invented. The narrative &ldquo;rings true&rdquo; as a document with
+                    genuine Egyptian background.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Chronology Debate */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Chronology Debate</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Among scholars who accept a genuine historical basis for the Exodus, a major debate
+                concerns its date. Two main positions dominate:
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-5 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-3">The Early Date (&sim;1446 BC)</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed mb-3">
+                    Based on 1 Kings 6:1, which places the Exodus 480 years before the founding of
+                    Solomon&rsquo;s Temple (&sim;966 BC), yielding an Exodus date around 1446 BC.
+                    This places the Exodus in the reign of Amenhotep II (18th Dynasty). Proponents
+                    include archaeologist Bryant Wood and historian Eugene Merrill.
+                  </p>
+                  <p className="text-blue-700 text-xs">
+                    <strong>Problem:</strong> The city of Ramesses (Exodus 1:11) is difficult to
+                    explain under an 18th Dynasty date, since the city bearing that name was built
+                    under Ramesses II (&sim;1279&ndash;1213 BC).
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-3">The Late Date (&sim;1280 BC)</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed mb-3">
+                    Based on Exodus 1:11 and the association of the city of Ramesses with Ramesses II
+                    (r. 1279&ndash;1213 BC), the most favored Pharaoh of the Exodus in popular
+                    treatments. Proponents include Egyptologist Kenneth Kitchen, who in <em>On the
+                    Reliability of the Old Testament</em> (2003) marshals extensive evidence for the
+                    authenticity of the Exodus narrative under a late date.
+                  </p>
+                  <p className="text-blue-700 text-xs">
+                    <strong>Problem:</strong> The Merneptah Stele (1208 BC) already places Israel
+                    as an established people group in Canaan, leaving a very compressed time for the
+                    conquest and early settlement period.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-5 rounded-lg">
+                <p className="text-amber-800 text-sm">
+                  <strong>The Church&rsquo;s position:</strong> The Catholic Church has not defined
+                  a specific date for the Exodus. The theological truth of the event &mdash; God&rsquo;s
+                  saving intervention on behalf of his people, establishing the covenant that
+                  prefigures the New Covenant in Christ &mdash; does not depend on the resolution
+                  of the chronological debate.
+                </p>
+              </div>
+            </div>
+
+            {/* The Scale Question */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Scale Question: 600,000 Men?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Exodus 12:37 states that &ldquo;about six hundred thousand men on foot, besides
+                women and children&rdquo; departed Egypt &mdash; implying a total population of
+                over two million. Archaeological surveys of the Sinai peninsula have found no
+                trace of such a large movement of people or any extended settlement of that
+                magnitude. This has led many scholars to question the literal reading of the
+                numbers.
+              </p>
+
+              <div className="space-y-4">
+                <div className="border-l-4 border-amber-400 pl-4 py-2">
+                  <h3 className="font-semibold text-gray-800 mb-1">The &ldquo;Eleph&rdquo; Solution</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    The Hebrew word <em>&lsquo;eleph</em>, translated &ldquo;thousand,&rdquo; also
+                    means a clan unit or military contingent of variable size (cf. Numbers 31:5;
+                    Judges 6:15). If &ldquo;600 &lsquo;eleph&rdquo; means &ldquo;600 military
+                    units,&rdquo; the actual number of men might be in the range of 5,000&ndash;6,000
+                    &mdash; a figure entirely consistent with Sinai archaeology. This reading was
+                    proposed by George Mendenhall and has been developed by Colin Humphreys in
+                    <em> The Miracles of Exodus</em> (2003).
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-blue-400 pl-4 py-2">
+                  <h3 className="font-semibold text-gray-800 mb-1">Rhetorical / Liturgical Numbers</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Ancient Near Eastern texts routinely used large numbers rhetorically to convey
+                    significance rather than to report census data. The Assyrian Annals and Egyptian
+                    victory inscriptions regularly inflated casualty and tribute figures for
+                    propagandistic effect. The Exodus numbers may function as a liturgical celebration
+                    of the greatness of God&rsquo;s deliverance, not as a demographic census.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-purple-400 pl-4 py-2">
+                  <h3 className="font-semibold text-gray-800 mb-1">A Smaller but Representative Group</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Some scholars propose that the Exodus involved a much smaller group &mdash;
+                    perhaps a single extended tribal confederation &mdash; whose experience of divine
+                    deliverance became the foundational narrative for a larger coalition of peoples
+                    who came to identify as &ldquo;Israel.&rdquo; The memory was preserved and
+                    universalized as the defining story of the entire nation.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* What Faith Requires */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Shield className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Faith Requires &mdash; and What Archaeology Can Provide</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catholic faith teaches that the Exodus is a real historical event &mdash; the
+                foundational act of God&rsquo;s covenant with Israel, prefiguring and pointing toward
+                the definitive Exodus accomplished by Christ through his death and Resurrection. This
+                teaching is non-negotiable.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                What the Church does <em>not</em> require is: a specific date, a specific route
+                through the Sinai, a specific number of participants, Egyptian documentary confirmation,
+                or a literal reading of the population figures. These are questions that belong to the
+                domain of historical-critical and archaeological research, not to the deposit of faith.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Pope Benedict XVI on Historical Method
+                </h3>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;The historical-critical method is an indispensable dimension of exegetical
+                  work&hellip; [but] it cannot be the last word on the matter. Where the historical
+                  method is made into the exclusive criterion&hellip; the Bible becomes a book
+                  only about the past and loses the living presence of the Word of God.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Benedict XVI, <em>Jesus of Nazareth</em>, vol. 1, Prologue (2007)
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Archaeology provides context, plausibility, and sometimes confirmation of
+                specific details in the Exodus narrative. It cannot confirm or disconfirm the
+                theological heart of the event: that the God of Abraham, Isaac, and Jacob
+                intervened in history to redeem his people and bind them to himself in covenant.
+                That claim is addressed to faith, not to a trowel.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: DEAD SEA SCROLLS ==================== */}
+        {activeTab === 'dead-sea-scrolls' && (
+          <div className="space-y-8">
+
+            {/* The Discovery */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Discovery (1947)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                In February or March of 1947, a Bedouin shepherd named Muhammad edh-Dhib
+                (&ldquo;Muhammad the Wolf&rdquo;) was searching for a lost goat in the arid cliffs
+                above the northwestern shore of the Dead Sea, near the ruins of Khirbet Qumran. He
+                threw a rock into a dark cave opening and heard, unexpectedly, the sound of pottery
+                breaking. Inside, he found tall clay jars, several of them containing ancient scrolls
+                wrapped in linen.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                This accidental discovery has been called &ldquo;the greatest manuscript find of the
+                20th century&rdquo; &mdash; and arguably of all time. Over the following decade
+                (1947&ndash;1956), archaeologists, Bedouin, and scholars searched the cliffs
+                intensively, discovering eleven caves that collectively contained approximately
+                900 manuscripts.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Site of Qumran</h3>
+                <p className="text-amber-800 mb-3">
+                  The ruins of Khirbet Qumran were excavated between 1951 and 1956 by Roland de Vaux,
+                  a Dominican priest and archaeologist. He revealed a community complex of considerable
+                  sophistication: a scriptorium (with inkwells and long plastered benches), an extensive
+                  network of <em>miqva&rsquo;ot</em> (ritual immersion baths &mdash; at least ten), a
+                  large communal dining hall/refectory, cisterns, kilns, and storage rooms. The community
+                  that used this complex lived there from approximately 130 BC until 68 AD, when the Romans
+                  destroyed the site during the First Jewish&ndash;Roman War.
+                </p>
+              </div>
+            </div>
+
+            {/* The Contents */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Contents of the Scrolls</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The approximately 900 manuscripts are divided into three broad categories, each
+                profoundly significant in its own right.
+              </p>
+
+              <div className="space-y-5">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-3">Biblical Texts</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed mb-3">
+                    Fragments of every book of the Hebrew Bible except Esther. Some books are
+                    represented by dozens of copies. The most spectacular is the Great Isaiah Scroll
+                    (1QIsa<sup>a</sup>) from Cave 1 &mdash; a complete, intact 66-chapter scroll
+                    7.34 metres (24 feet) long, dated to approximately 125 BC.
+                  </p>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    Particularly well-represented books include Deuteronomy (&sim;30 copies),
+                    Isaiah (&sim;21 copies), and the Psalms (&sim;36 copies). The Psalms Scroll
+                    from Cave 11 contains 41 canonical psalms plus 7 additional compositions
+                    not found in the canonical psalter.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-3">Sectarian Documents</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    The constitutional and disciplinary documents of the Qumran community itself:
+                    the <em>Community Rule</em> (Serek haYahad &mdash; the community&rsquo;s
+                    governing constitution); the <em>Damascus Document</em> (rules for affiliated
+                    communities living in towns outside Qumran); the <em>War Scroll</em> (an
+                    elaborate apocalyptic battle plan for the final war between the Sons of Light
+                    and Sons of Darkness); the <em>Temple Scroll</em> (the longest scroll found,
+                    8.15 metres, presenting an idealized version of the Torah from a divine first-person
+                    perspective); and the <em>Hodayot</em> (Thanksgiving Psalms, probably composed
+                    by the community&rsquo;s founding Teacher of Righteousness).
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-3">Pesharim (Biblical Commentaries)</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    Running verse-by-verse commentaries on the prophets (Habakkuk, Isaiah, Nahum,
+                    Micah, Psalms). The community read the prophets as encrypted prophecies about
+                    its own present situation: the &ldquo;Teacher of Righteousness&rdquo; (their
+                    founding leader), the &ldquo;Wicked Priest&rdquo; (a Hasmonean high priest who
+                    had persecuted them), and the imminent eschatological events they expected.
+                    This exegetical method &mdash; <em>pesher</em> interpretation &mdash; has close
+                    parallels in the New Testament&rsquo;s use of the Old Testament.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-purple-900 mb-2">The Copper Scroll (3Q15)</h3>
+                  <p className="text-purple-800 text-sm leading-relaxed">
+                    Unlike any other scroll found at Qumran, the Copper Scroll is engraved on thin
+                    copper sheets and lists 64 locations where large quantities of gold and silver
+                    are supposedly buried. Whether this represents a real hidden treasure or a
+                    symbolic/apocalyptic text remains debated. No treasure has ever been found at
+                    the indicated locations.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Significance for Transmission */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Significance for Biblical Transmission</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Before 1947, the oldest known Hebrew manuscripts of the Old Testament were the great
+                Masoretic codices: the Aleppo Codex (c. 920 AD) and the Leningrad Codex (c. 1008 AD).
+                These were the authoritative basis for virtually all modern Bible translations. The Dead
+                Sea Scrolls pushed the manuscript tradition back by approximately one thousand years.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Result: Extraordinary Fidelity
+                </h3>
+                <p className="text-green-800 mb-3">
+                  When scholars compared the Great Isaiah Scroll (1QIsa<sup>a</sup>, c. 125 BC) with
+                  the Isaiah text in the Aleppo and Leningrad Codices (c. 920&ndash;1008 AD), the
+                  agreement was overwhelming. Approximately 95% of the text is word-for-word identical.
+                  The remaining 5% consists of minor spelling variants, occasional slips of the pen,
+                  and a handful of word-order differences &mdash; none of them affecting doctrine or
+                  meaning in any significant way.
+                </p>
+                <p className="text-green-800">
+                  This means that Jewish scribes copied the Book of Isaiah with extraordinary care and
+                  fidelity across a period of more than 1,100 years &mdash; and that the Isaiah we read
+                  today is substantially the same text that the Jews of Qumran read and copied in
+                  125 BC.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Dead Sea Scrolls also revealed that in the Second Temple period, multiple text
+                types of the Hebrew scriptures were in circulation &mdash; some closer to the
+                Masoretic Text, some closer to the Septuagint (the Greek translation used by early
+                Christians), and some representing independent traditions. This diversity was greater
+                than previously realized, though the final Masoretic Text became dominant after 70 AD.
+              </p>
+            </div>
+
+            {/* Who Were They? */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Qumran Community: Who Were They?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The scholarly consensus identifies the Qumran community as Essenes &mdash; a Jewish
+                sect known from three ancient sources: the historian Josephus (<em>Jewish War</em>
+                II.8.2&ndash;13; <em>Antiquities</em> XVIII.1.5), the philosopher Philo of Alexandria
+                (<em>Every Good Person is Free</em>; <em>Hypothetica</em>), and the Roman writer
+                Pliny the Elder (<em>Natural History</em> V.73, who specifically locates the Essenes
+                on the western shore of the Dead Sea, above En Gedi &mdash; precisely where Qumran is).
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  Essene Characteristics Matching the Scrolls
+                </h3>
+                <ul className="text-purple-800 text-sm space-y-2">
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Communal ownership of property (cf. Community Rule, cols. V&ndash;VI)</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Ritual immersion baths (<em>miqva&rsquo;ot</em>) &mdash; at least ten at Qumran</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Strict Sabbath observance and purity regulations stricter than Pharisaic law</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Apocalyptic expectation: imminent divine intervention and final battle</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Two messianic figures: a priestly Messiah (Aaron) and a royal Messiah (Israel)</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Rejection of the Jerusalem Temple establishment as corrupt and illegitimate</span>
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The community&rsquo;s founding crisis was likely the Hasmonean takeover of the high
+                priesthood (c. 152 BC), when Jonathan Maccabaeus assumed the role without being of
+                the Zadokite lineage traditionally required. Their &ldquo;Teacher of Righteousness&rdquo;
+                &mdash; likely a displaced Zadokite priest &mdash; led a remnant into the desert to
+                live as the true Israel, awaiting God&rsquo;s intervention. They hid their scrolls
+                in the caves in 68 AD as the Roman army advanced; Qumran was destroyed shortly after.
+              </p>
+            </div>
+
+            {/* Scrolls and Christian Origins */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Dead Sea Scrolls and Christian Origins</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Qumran scrolls have transformed our understanding of the Jewish matrix from which
+                Christianity emerged. A number of themes and practices found in the New Testament have
+                striking parallels in the Qumran literature &mdash; though this should be understood
+                carefully.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Parallels Between Qumran and Early Christianity</h3>
+                <ul className="text-amber-800 text-sm space-y-2">
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span><strong>Baptism by immersion:</strong> Central to both communities</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span><strong>Sacred communal meals:</strong> A central ritual act at Qumran (cf. the Last Supper, Eucharist)</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span><strong>Messianic expectation:</strong> Both communities expected an imminent messianic figure</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span><strong>Dualism of light and darkness:</strong> Prominent in John&rsquo;s Gospel and the Qumran War Scroll</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span><strong>&ldquo;New Covenant&rdquo;:</strong> The Qumran community understood itself as the community of the New Covenant (Jeremiah 31:31); so did early Christianity</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span><strong>Community as &ldquo;Temple of God&rdquo;:</strong> Both Qumran and Paul describe the community itself as a spiritual temple (1 Corinthians 3:16; 1QS VIII)</span>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="bg-blue-50 p-5 rounded-lg">
+                <p className="text-blue-800 text-sm">
+                  <strong>The crucial distinction:</strong> These parallels demonstrate that the
+                  language of the New Testament was deeply embedded in the Jewish religious world of
+                  the Second Temple period &mdash; they are not imports from Greek or Persian religion.
+                  They do <em>not</em> prove that our Lord was influenced by Qumran (there is no
+                  evidence of any personal connection), that John the Baptist was an Essene (speculative,
+                  though his desert location and baptismal practice have led to comparison), or that
+                  Christianity is merely a development of Essenism. The differences are profound:
+                  Christianity is centered on a specific historical person who rose from the dead, not
+                  on a community&rsquo;s self-isolation from the world.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: SHROUD OF TURIN ==================== */}
+        {activeTab === 'shroud-of-turin' && (
+          <div className="space-y-8">
+
+            {/* What Is the Shroud? */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Is the Shroud of Turin?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Shroud of Turin is a length of linen cloth, approximately 4.4 metres by 1.1
+                metres (14 feet by 3.6 feet), that bears the faint double image &mdash; front and
+                back &mdash; of a man who shows every sign of having been crucified by Roman methods.
+                It is currently kept in the Cathedral of Saint John the Baptist, Turin, Italy, and
+                is exhibited publicly at rare intervals called &ldquo;ostensions.&rdquo; The most
+                recent was in 2015, drawing over two million visitors.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Physical Evidence on the Cloth</h3>
+                <ul className="text-amber-800 text-sm space-y-2">
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>More than 120 flagellation marks consistent with the Roman <em>flagrum</em>
+                    (a whip with metal or bone tips attached to leather thongs)</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Wounds on the wrists (not palms) and feet consistent with crucifixion nails</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>A large elliptical wound on the right side consistent with a lance thrust (cf. John 19:34)</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Marks around the scalp consistent with a cap of thorns</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Abrasions on the shoulder consistent with carrying a heavy crossbeam</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>The face bearing what appears to be swelling from blows, consistent with
+                    the Gospel accounts of the mockery and beating (Matthew 26:67)</span>
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Perhaps the most striking feature was revealed only in 1898, when Secondo Pia
+                became the first person to photograph the Shroud. When he examined his glass-plate
+                negatives, he realized that the negative of the photograph showed a positive,
+                recognizable face &mdash; meaning that the image on the cloth itself is a
+                &ldquo;negative,&rdquo; like the negative of a photograph, centuries before
+                photography was invented. This immediately raised the question that has never been
+                satisfactorily answered: how did a medieval forger anticipate photographic negativity?
+              </p>
+            </div>
+
+            {/* 1988 Carbon Dating */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The 1988 Carbon Dating Controversy</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                In 1988, three independent laboratories &mdash; the University of Oxford, the
+                University of Arizona, and the Swiss Federal Institute of Technology in Zurich
+                &mdash; each performed radiocarbon (C-14) dating on samples taken from a corner
+                of the Shroud. Their results were remarkably consistent: the linen dated to between
+                1260 and 1390 AD. The announcement was widely reported as having &ldquo;proved&rdquo;
+                that the Shroud was a medieval forgery.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                However, the 1988 result has been significantly challenged on scientific grounds in
+                subsequent peer-reviewed research &mdash; not by religious apologists, but by chemists.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Raymond Rogers&rsquo; Challenge (<em>Thermochimica Acta</em>, 2005)
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Raymond N. Rogers, a retired chemist from Los Alamos National Laboratory and a
+                  member of the original STURP team, published peer-reviewed research in the
+                  journal <em>Thermochimica Acta</em> (January 2005) demonstrating that the sample
+                  taken for the 1988 dating was not representative of the main body of the Shroud.
+                </p>
+                <p className="text-blue-800 mb-3">
+                  His analysis showed that the sampled corner had a different chemical composition
+                  from threads taken from other parts of the Shroud: the sample contained
+                  vanillin (a degradation product of lignin in linen), while the main body of the
+                  Shroud contained no detectable vanillin &mdash; suggesting a much older origin.
+                  The sample also contained cotton fibers not present elsewhere and showed evidence
+                  of reweaving consistent with the &ldquo;invisible reweave&rdquo; repair technique
+                  documented from the medieval period.
+                </p>
+                <p className="text-blue-700 text-sm">
+                  Rogers&rsquo; conclusion: the 1988 sample was a medieval repair patch, not
+                  original linen; the rest of the Shroud, by his analysis, is consistent with an
+                  age of approximately 1,300&ndash;3,000 years. The paper was accepted by a
+                  peer-reviewed chemistry journal and has not been satisfactorily refuted.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Rogers paper does not &ldquo;prove&rdquo; the Shroud is 2,000 years old.
+                But it does demonstrate that the 1988 radiocarbon result cannot be treated as
+                the final scientific word on the subject. The matter remains scientifically open.
+              </p>
+            </div>
+
+            {/* STURP */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Microscope className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The STURP Investigation (1978)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Shroud of Turin Research Project (STURP) was a team of approximately 40
+                American scientists &mdash; including physicists, chemists, biologists,
+                radiologists, and forensic experts from institutions including NASA, Los Alamos
+                National Laboratory, Brooks Air Force Base, and several universities. In October
+                1978, they were given unprecedented access to the Shroud for 120 continuous hours
+                of intensive examination.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-5">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">Key STURP Findings</h3>
+                <ul className="text-green-800 text-sm space-y-3">
+                  <li className="flex items-start gap-2">
+                    <CheckCircle className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />
+                    <span><strong>The image is not a painting.</strong> Extensive chemical and
+                    spectroscopic analysis found no pigment, paint, dye, or stain in the image
+                    areas. The image is not made of any applied substance.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <CheckCircle className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />
+                    <span><strong>The bloodstains are real blood</strong> (later confirmed as type AB
+                    through serology and immunology tests). Critically, the blood was deposited on
+                    the cloth <em>before</em> the body image formed &mdash; the image is absent
+                    beneath the blood, meaning the blood protected the underlying fibers from
+                    whatever process created the image.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <CheckCircle className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />
+                    <span><strong>The image is a surface phenomenon.</strong> The image exists only
+                    on the topmost fibrils of the linen (the outermost 200 nanometres of the thread) &mdash;
+                    it does not penetrate into the interior of the threads. No known artistic technique
+                    produces such a superficial image.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <CheckCircle className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />
+                    <span><strong>3D information encoded.</strong> The VP-8 Image Analyzer (developed
+                    by NASA for converting satellite image data) produces perfect three-dimensional
+                    relief from the Shroud image. Normal photographs and paintings produce distorted
+                    or meaningless 3D relief; the Shroud is unique in encoding 3D spatial information
+                    in its image intensity.</span>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="bg-amber-50 p-5 rounded-lg">
+                <p className="text-amber-800 text-sm italic">
+                  &ldquo;The Shroud image is that of a real human form of a scourged, crucified man.
+                  It is not the product of an artist. The bloodstains are composed of hemoglobin
+                  and also give a positive test for serum albumin. The image is an ongoing mystery
+                  and until further chemical studies are made, perhaps by this group of scientists,
+                  or perhaps by some scientists in the future, the problem remains unsolved.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm mt-2">
+                  &mdash; STURP Summary Statement, 1981
+                </p>
+              </div>
+            </div>
+
+            {/* Open Questions */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <HelpCircle className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Open Scientific Questions</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                Forty years after STURP, the image formation mechanism remains unresolved. This is
+                not for lack of scientific attention: dozens of peer-reviewed papers have proposed
+                and tested hypotheses, none of which has been broadly accepted as sufficient.
+              </p>
+
+              <div className="space-y-4">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-2">How Was the Image Formed?</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    The current leading hypothesis in the scientific literature is a brief,
+                    high-intensity emission of ultraviolet radiation from the body, which scorched
+                    the topmost fibrils of the linen in a pattern corresponding to the body&rsquo;s
+                    surface. A 2011 paper by a team from ENEA (the Italian National Agency for New
+                    Technologies) demonstrated that to produce an image matching the Shroud&rsquo;s
+                    characteristics, one would need an ultraviolet laser of extraordinary intensity
+                    for a pulse lasting fractions of a nanosecond &mdash; far beyond any current or
+                    medieval technology. No mechanism is known to natural science that could produce
+                    such an emission from a human body.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-2">The 2002 Restoration</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    In 2002, the Shroud underwent conservation work: backing cloths added after the
+                    1532 fire were removed, and the reverse side was photographed and examined for
+                    the first time since the cloth was sewn onto its backing. The examination revealed
+                    a faint mirror image of the face on the <em>reverse</em> side of the cloth &mdash;
+                    but only of the face, not the body. This indicates that the image formation process
+                    was not uniform and that the face received a different, more intense exposure. The
+                    mechanism remains unexplained.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-blue-900 mb-2">Pollen Analysis</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    Swiss criminologist Max Frei (1973) identified pollen grains on the Shroud from
+                    plants native to Palestine, Anatolia (Turkey), and Constantinople &mdash; consistent
+                    with a cloth that originated in the Near East and traveled through Byzantine
+                    territory to Europe. The identification has been partly confirmed by subsequent
+                    botanists (Avinoam Danin of the Hebrew University identified plant images on the
+                    cloth consistent with flowers native to the Jerusalem area in spring). This evidence
+                    is suggestive but contested.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Church Position */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Official Position</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-5">
+                The Catholic Church has never officially declared the Shroud to be the authentic
+                burial cloth of Christ &mdash; nor has it declared it a forgery. This
+                deliberate agnosticism is theologically principled: the Church does not base
+                its faith claims on the outcome of scientific controversies, and it does not
+                require Catholics to believe in any particular relic&rsquo;s authenticity.
+              </p>
+
+              <div className="space-y-4">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-amber-900 mb-2">
+                    Pope John Paul II &mdash; Ostension of 1998
+                  </h3>
+                  <p className="text-amber-800 text-sm italic mb-2">
+                    &ldquo;The Shroud is an image of God&rsquo;s love as well as of human sin&hellip;
+                    The imprint left by the tortured body of the Crucified One&hellip; speaks to our
+                    heart and moves us to climb the hill of Calvary, to contemplate the weight of our
+                    guilt and to say with trust: <em>Miserere mei, Deus</em> &mdash; have mercy on me,
+                    O Lord.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-xs">
+                    &mdash; Pope John Paul II, Homily at the Ostension of the Holy Shroud, May 24, 1998
+                  </p>
+                </div>
+
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-amber-900 mb-2">
+                    Pope Benedict XVI &mdash; Ostension of 2010
+                  </h3>
+                  <p className="text-amber-800 text-sm italic mb-2">
+                    &ldquo;This is a burial cloth that wrapped the remains of a crucified man in full
+                    conformity with what the Gospels tell us of Jesus&hellip; The Shroud is an icon
+                    written in blood; the blood of a man who was flogged, crowned with thorns, crucified
+                    and whose right side was pierced.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-xs">
+                    &mdash; Pope Benedict XVI, Address at the Ostension, May 2, 2010
+                  </p>
+                </div>
+
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-bold text-amber-900 mb-2">
+                    Pope Francis &mdash; Video Message, 2013
+                  </h3>
+                  <p className="text-amber-800 text-sm italic mb-2">
+                    &ldquo;This Man of the Shroud invites us to contemplate Jesus of Nazareth. This
+                    image, impressed upon the cloth, speaks to our heart and moves us to climb up
+                    Calvary, to look upon the wood of the Cross, and to immerse ourselves in the
+                    eloquent silence of love.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-xs">
+                    &mdash; Pope Francis, Video message for the Ostension, March 30, 2013
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mt-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Practical Catholic Approach
+                </h3>
+                <ul className="text-blue-800 text-sm space-y-2">
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Venerate the Shroud as an <em>icon</em> of the Passion &mdash; whatever its ultimate origin, the image invites contemplation of Christ&rsquo;s suffering and death</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Do not make belief in the Shroud&rsquo;s authenticity a condition of faith &mdash; the Church does not require it</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Remain open to ongoing scientific investigation &mdash; the Church welcomes honest inquiry</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Recognize that the 1988 radiocarbon result is not the final word &mdash; it has been legitimately challenged in peer-reviewed science</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5">&#8227;</span>
+                    <span>Approach the Shroud as one of the most scientifically inexplicable objects in human history &mdash; an invitation to wonder, not to credulity</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+          </div>
+        )}
+
       </div>
     </div>
   )

--- a/src/app/science/reading-genesis/page.tsx
+++ b/src/app/science/reading-genesis/page.tsx
@@ -1,32 +1,1831 @@
 'use client'
 
-import { BookOpen, Layers, MessageSquare } from 'lucide-react'
+import { useState } from 'react'
+import {
+  BookOpen,
+  Layers,
+  ScrollText,
+  Quote,
+  FileText,
+  Church,
+  Heart,
+  Star,
+  Scale,
+  Clock,
+  Calendar,
+  Sparkles,
+  CheckCircle,
+  HelpCircle,
+  Users,
+  Shield,
+  Globe,
+  Lightbulb,
+  Waves,
+  GraduationCap,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-kind-of-text'
+  | 'four-senses'
+  | 'six-days'
+  | 'adam-eve'
+  | 'ancient-near-east'
+  | 'key-documents'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-kind-of-text', label: 'What Kind of Text?' },
+  { id: 'four-senses', label: 'The Four Senses' },
+  { id: 'six-days', label: 'The Six Days Debate' },
+  { id: 'adam-eve', label: 'Adam & Eve' },
+  { id: 'ancient-near-east', label: 'Ancient Near Eastern Context' },
+  { id: 'key-documents', label: 'Key Documents & Voices' },
+]
 
 export default function ReadingGenesisPage() {
-  const sections = [
-    { icon: BookOpen, title: 'Literary Genres in Scripture', description: 'Genesis 1-11 uses a distinct literary genre — not modern science textbook, not pure myth, but theological narrative conveying revealed truths about God, humanity, and creation.' },
-    { icon: Layers, title: 'The Four Senses of Scripture', description: 'Literal, allegorical, moral, and anagogical — the Catholic tradition of multi-layered biblical interpretation, far richer than literalism.' },
-    { icon: MessageSquare, title: 'St. Augustine\'s Warning', description: '"It is a disgraceful thing for a Christian to speak about natural matters as if they were Scripture and be laughed at by unbelievers." — De Genesi ad Litteram (5th century).' },
-  ]
+  const [activeTab, setActiveTab] = useState<TabId>('what-kind-of-text')
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-10">
-        <h1 className="text-3xl sm:text-4xl font-serif font-bold text-gray-900 mb-3">Reading Genesis</h1>
-        <p className="text-lg text-gray-600 leading-relaxed max-w-3xl">How should Catholics read the creation accounts and prehistoric narratives of Genesis? The Church has always taught that these texts convey profound theological truths — but not necessarily in the way a modern science textbook would. Young Earth vs Old Earth is not a Catholic debate.</p>
-      </div>
-      <div className="rounded-xl p-6 mb-10 border-l-4" style={{ backgroundColor: '#FFFBEB', borderColor: '#D4AF37' }}>
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Coming Soon</h2>
-        <p className="text-gray-600">How the Church reads Genesis, the Four Senses of Scripture, and the Church Fathers on creation will be added here.</p>
-      </div>
-      <div className="grid sm:grid-cols-3 gap-6">
-        {sections.map((s) => { const Icon = s.icon; return (
-          <div key={s.title} className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <div className="flex items-center gap-3 mb-3"><div className="p-2 rounded-lg bg-amber-50"><Icon className="w-5 h-5 text-amber-700" /></div>
-            <h3 className="font-serif text-lg font-semibold text-gray-900">{s.title}</h3></div>
-            <p className="text-sm text-gray-600 leading-relaxed">{s.description}</p>
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Reading Genesis
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            How should Catholics read the creation accounts and primeval history of Genesis? The
+            Church&rsquo;s rich tradition provides multiple frameworks &mdash; none of them requiring
+            a conflict with modern science.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
           </div>
-        )})}
+        </div>
+
+        {/* ==================== TAB 1: WHAT KIND OF TEXT? ==================== */}
+        {activeTab === 'what-kind-of-text' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Genesis 1–11 as Primeval History */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Genesis 1&ndash;11 as Primeval History</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Scholars of the ancient world use the phrase &ldquo;primeval history&rdquo; to describe
+                a recognized literary category in ancient Near Eastern writing &mdash; texts that address
+                ultimate questions about the origin of the world, the nature of humanity, and the
+                relationship between God (or the gods) and creation. Genesis 1&ndash;11 belongs to this
+                category. It covers Genesis 1 (the creation of the world), Genesis 2&ndash;3 (the Garden
+                of Eden and the Fall), Genesis 4 (Cain and Abel), Genesis 5 (the antediluvian
+                genealogies), Genesis 6&ndash;9 (the great flood), and Genesis 10&ndash;11 (the Table of
+                Nations and the Tower of Babel).
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Identifying this literary category is not a concession to scepticism &mdash; it is the
+                first step in reading the text as the Church has always insisted it must be read: on its
+                own terms, in its own historical and literary context, with attention to what the sacred
+                author actually intended to communicate.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Three Things Genesis 1&ndash;11 Is NOT</h3>
+                <ul className="text-amber-800 space-y-3">
+                  <li>
+                    <span className="font-semibold">Not a modern science textbook.</span> The author
+                    was not writing to answer &ldquo;how long did creation take?&rdquo; in the modern
+                    sense. Questions of biological mechanism, geological timescale, and cosmological
+                    chronology were simply outside the scope of what the text was composed to address.
+                  </li>
+                  <li>
+                    <span className="font-semibold">Not mythology in the dismissive sense.</span> These
+                    texts make serious, binding truth-claims about God, humanity, and the world&rsquo;s
+                    origin. They are not fables or entertainment &mdash; they are divinely inspired
+                    theological declarations.
+                  </li>
+                  <li>
+                    <span className="font-semibold">Not pure history in the modern journalistic sense.</span> The
+                    texts use highly symbolic, artistically structured, and theologically charged
+                    language. The Church does not require that every element be read as a blow-by-blow
+                    chronicle of events in chronological sequence.
+                  </li>
+                </ul>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">What the Church Consistently Teaches</h3>
+                <p className="text-green-800">
+                  These texts convey <em>theological truths</em> through literary forms appropriate to
+                  their ancient context. The truths they convey &mdash; that God alone created all
+                  things, that creation is genuinely good, that humanity is uniquely made in God&rsquo;s
+                  image, that sin entered through a real historical act of human freedom &mdash; are
+                  binding on all Catholics. The literary vehicle through which those truths are
+                  expressed is not itself a doctrinal matter requiring one fixed interpretation.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: What Makes Genesis 1 Different */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Makes Genesis 1 Distinctive</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Genesis 1 is one of the most carefully structured pieces of writing in the entire Bible.
+                Its seven-day framework &mdash; six days of creative work followed by one day of divine
+                rest &mdash; is not a haphazard narrative but a deliberately crafted literary and
+                theological composition. Recognizing its structure is essential to reading it correctly.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-4">The Parallel Framework Structure</h3>
+                <p className="text-blue-800 mb-4">
+                  Days 1&ndash;3 create <em>domains</em>; Days 4&ndash;6 <em>fill</em> those domains with
+                  their respective inhabitants. This is an artistically intentional literary framework,
+                  not a scientific timetable:
+                </p>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div className="bg-blue-100 p-4 rounded-lg">
+                    <h4 className="font-semibold text-blue-900 mb-2">Days 1&ndash;3: Creating Spaces</h4>
+                    <ul className="text-blue-800 text-sm space-y-1">
+                      <li><span className="font-medium">Day 1:</span> Light (separated from darkness)</li>
+                      <li><span className="font-medium">Day 2:</span> Sky and seas (separated from each other)</li>
+                      <li><span className="font-medium">Day 3:</span> Dry land and vegetation</li>
+                    </ul>
+                  </div>
+                  <div className="bg-blue-100 p-4 rounded-lg">
+                    <h4 className="font-semibold text-blue-900 mb-2">Days 4&ndash;6: Filling Spaces</h4>
+                    <ul className="text-blue-800 text-sm space-y-1">
+                      <li><span className="font-medium">Day 4:</span> Sun, moon, stars (fill the light)</li>
+                      <li><span className="font-medium">Day 5:</span> Birds and fish (fill sky and seas)</li>
+                      <li><span className="font-medium">Day 6:</span> Land animals and humanity (fill the land)</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This parallel structure &mdash; sometimes called the &ldquo;framework hypothesis&rdquo; by
+                modern biblical scholars &mdash; is an ancient observation, not a modern invention. The
+                text&rsquo;s artistry conveys theology: God is orderly, purposeful, and sovereign;
+                creation progresses toward humanity as its crown; the Sabbath is built into the very
+                structure of existence.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Two Creation Accounts &mdash; Not a Contradiction</h3>
+                <p className="text-amber-800 mb-3">
+                  Genesis 1:1&ndash;2:4a and Genesis 2:4b&ndash;25 present the creation of humanity in
+                  noticeably different ways. In the first account, humanity is created last, on the sixth
+                  day, male and female simultaneously. In the second, the man is formed first from the
+                  ground, then the woman from his side. Ancient readers understood these as complementary
+                  perspectives, not competing accounts. Genesis 1 emphasizes humanity&rsquo;s dignity as
+                  the crown of creation; Genesis 2 emphasizes humanity&rsquo;s intimate relationship with
+                  God, the earth, and each other. The Church has never required harmonizing them as though
+                  they were sequential news reports.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The refrain &ldquo;And there was evening and there was morning, the Nth day&rdquo; is a
+                liturgical formula &mdash; an artistic punctuation of the narrative that signals the
+                completion of each creative movement. Whether &ldquo;evening and morning&rdquo; denotes a
+                literal 24-hour cycle or serves as a structural marker has been debated by Catholic
+                interpreters since at least the fourth century.
+              </p>
+            </div>
+
+            {/* Card 3: Official Guidance on Genre */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Official Guidance on Genre</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Far from leaving Catholics to guess how to read Genesis, the Church&rsquo;s magisterium
+                has issued a series of authoritative documents that provide clear hermeneutical
+                principles. Taken together, they constitute a consistent and coherent approach to the
+                literary interpretation of the creation narratives.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Dei Verbum 12 (Vatican II, 1965)</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;For a correct understanding of what the sacred author wanted to affirm, due
+                  attention must be paid to the customary and characteristic styles of feeling, speaking,
+                  and narrating which prevailed at the time of the sacred writer.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Dei Verbum</em>, 12</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Providentissimus Deus (Leo XIII, 1893)</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;The sacred writers did not intend to teach men these things &mdash; things in no
+                  way profitable unto salvation &mdash; [i.e., the essential nature of the things of the
+                  visible universe].&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Pope Leo XIII, <em>Providentissimus Deus</em> (1893)</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">CCC 116 &amp; 390</h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The literal sense is the meaning conveyed by the words of Scripture and
+                  discovered by exegesis, following the rules of sound interpretation. All other senses
+                  of Sacred Scripture are based on the literal.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; CCC 116</p>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The account of the fall in Genesis 3 uses figurative language, but affirms a
+                  primeval event, a deed that took place at the beginning of the history of man.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 390</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Pontifical Biblical Commission&rsquo;s landmark 1993 document, <em>The Interpretation
+                of the Bible in the Church</em>, provides the most comprehensive modern survey of
+                approved exegetical methods. It affirms that identifying the literary genre of a biblical
+                text is not optional &mdash; it is essential for understanding what the inspired author
+                actually intended to communicate.
+              </p>
+            </div>
+
+            {/* Card 4: Augustine's Warning */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Quote className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">St. Augustine&rsquo;s Prescient Warning (c. 415 AD)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Sixteen hundred years ago, one of the greatest theologians in the history of the Church
+                issued a warning that reads as though it were written for our own time. St. Augustine of
+                Hippo, who devoted more intellectual energy to the interpretation of Genesis than to
+                almost any other book of Scripture, warned his fellow Christians against the dangers of
+                over-literal, over-confident readings of the creation narrative.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">The Famous Warning</h3>
+                <p className="text-purple-800 italic mb-3">
+                  &ldquo;It is a disgraceful and dangerous thing for an unbeliever to hear a Christian,
+                  presumably giving the meaning of Holy Scripture, talking nonsense on these topics; and
+                  we should take all means to prevent such an embarrassing situation, in which people
+                  show up vast ignorance in a Christian and laugh it to scorn.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm">&mdash; St. Augustine, <em>De Genesi ad Litteram</em>, I.19.39 (c. 415 AD)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Augustine himself wrote <em>four</em> separate attempts at a commentary on Genesis,
+                finding the text extraordinarily difficult and repeatedly revising his views. His
+                magnum opus on the subject, <em>De Genesi ad Litteram</em> (&ldquo;On the Literal
+                Meaning of Genesis&rdquo;), took him fifteen years to complete &mdash; and even then he
+                expressed significant uncertainty about many of its interpretations.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-purple-900 mb-2">Augustine&rsquo;s Key Insights on Genesis</h4>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>&ldquo;Day&rdquo; may not mean a literal 24-hour period</li>
+                    <li>Time itself was created with the universe</li>
+                    <li>God does not exist <em>before</em> the universe in a temporal sense</li>
+                    <li>When Scripture seems to conflict with certain natural knowledge, we must re-examine our interpretation of Scripture</li>
+                    <li>Multiple valid readings of Genesis may coexist; intellectual humility is required</li>
+                  </ul>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-amber-900 mb-2">Augustine&rsquo;s Four Genesis Commentaries</h4>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li><em>De Genesi contra Manichaeos</em> (388 AD) &mdash; Against Manichaean dualism</li>
+                    <li><em>De Genesi ad Litteram Imperfectus Liber</em> (393 AD) &mdash; Abandoned as unsatisfactory</li>
+                    <li><em>Confessions</em>, Books XI&ndash;XIII (400 AD) &mdash; Mystical and philosophical</li>
+                    <li><em>De Genesi ad Litteram</em> (401&ndash;415 AD) &mdash; The definitive attempt, 12 books</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Augustine&rsquo;s approach establishes a principle the Church has never abandoned: the
+                interpretation of Genesis must be guided by intellectual honesty, theological
+                seriousness, and willingness to hold open questions with appropriate humility. He is
+                not a &ldquo;liberal&rdquo; interpreter undermining Scripture &mdash; he is one of the
+                most orthodox theologians in Catholic history, insisting that the truth of Scripture
+                be defended by reading it correctly.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 2: THE FOUR SENSES ==================== */}
+        {activeTab === 'four-senses' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Introduction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Catholic Tradition of Multi-Layered Reading</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                One of the distinctive glories of the Catholic intellectual tradition is its insistence
+                that Scripture operates on multiple levels simultaneously. This is not a concession to
+                ambiguity or a retreat from the text&rsquo;s plain meaning &mdash; it is a recognition
+                that the Word of God is inexhaustibly rich, capable of speaking to human beings at
+                every level of their existence: historical, doctrinal, moral, and eschatological.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This multi-layered approach goes back to Origen of Alexandria (3rd century), was
+                systematized by John Cassian (5th century), and was definitively formulated by the
+                medieval theologians, especially St. Thomas Aquinas. It was preserved in Vatican II&rsquo;s
+                <em> Dei Verbum</em> and codified in the Catechism of the Catholic Church at paragraphs
+                115&ndash;118.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Classic Medieval Couplet</h3>
+                <p className="text-amber-800 italic mb-3 text-lg">
+                  &ldquo;Littera gesta docet, quid credas allegoria,<br />
+                  moralis quid agas, quo tendas anagogia.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm mb-2">
+                  &ldquo;The literal teaches what happened; the allegorical what to believe;<br />
+                  the moral what to do; the anagogical where you&rsquo;re going.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; Traditional scholastic mnemonic, attributed to Augustine of Dacia (c. 1260)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Applying these four senses to Genesis transforms the question &ldquo;are the six days
+                literal?&rdquo; from the only question worth asking into one question among many &mdash;
+                and arguably not the most important one. The Church has much richer questions to put to
+                the text than how many hours each creative act took.
+              </p>
+            </div>
+
+            {/* Card 2: Literal Sense */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <FileText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Literal Sense</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The literal sense is what the text actually says, understood in the light of the
+                literary form the author employed. The crucial point &mdash; one that is regularly
+                misunderstood &mdash; is that &ldquo;literal&rdquo; does <em>not</em> mean
+                &ldquo;literalistic.&rdquo; It means understanding what the author <em>intended</em>
+                to communicate. If an author writes a poem, the literal sense of the poem is what the
+                poem means as a poem &mdash; not what its images would mean if they were treated as
+                prose descriptions of physical events.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">CCC 116</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;The literal sense is the meaning conveyed by the words of Scripture and
+                  discovered by exegesis, following the rules of sound interpretation. All other senses
+                  of Sacred Scripture are based on the literal.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Catechism of the Catholic Church, 116</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                For Genesis 1, the literal sense &mdash; what the author intended to communicate &mdash;
+                includes the following binding theological affirmations:
+              </p>
+
+              <ul className="list-disc list-inside text-gray-700 space-y-2 mb-6 ml-4">
+                <li>God alone created everything that exists, freely and out of love</li>
+                <li>Creation is genuinely good &mdash; not evil matter to be escaped (against Gnosticism and Manichaeism)</li>
+                <li>Humanity is the crown of creation, uniquely made in God&rsquo;s image and likeness</li>
+                <li>The Sabbath is holy &mdash; rest is built into the structure of creation itself</li>
+                <li>The created order is intelligible and orderly, reflecting the mind of its Creator</li>
+              </ul>
+
+              <p className="text-gray-700 leading-relaxed">
+                What the literal sense does <em>not</em> necessarily include is a definitive answer
+                about the age of the universe, the biological mechanisms of creation, or the number
+                of hours in each &ldquo;day.&rdquo; These questions were not within the author&rsquo;s
+                communicative intention.
+              </p>
+            </div>
+
+            {/* Card 3: Allegorical Sense */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Allegorical Sense</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The allegorical sense &mdash; also called the typological sense &mdash; asks how the
+                text of the Old Testament points forward to Christ, the Church, and the sacraments.
+                This is not arbitrary &ldquo;reading things into&rdquo; the text; it is the logic
+                of salvation history, in which earlier events and figures anticipate and are fulfilled
+                in Christ. St. Paul himself established this principle: &ldquo;Adam&hellip; is a type
+                of the one who was to come&rdquo; (Romans 5:14).
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">Allegorical Readings of Genesis</h3>
+                <ul className="text-purple-800 space-y-3">
+                  <li>
+                    <span className="font-semibold">The waters of creation</span> &rarr; Baptism: water
+                    and the Spirit bringing new life (cf. John 3:5; the Spirit hovering over the waters
+                    in Gen 1:2 and hovering at Christ&rsquo;s baptism)
+                  </li>
+                  <li>
+                    <span className="font-semibold">Adam</span> &rarr; Christ as the &ldquo;New
+                    Adam&rdquo; (Romans 5:14; 1 Corinthians 15:45): where the first Adam brought death
+                    through disobedience, the New Adam brings life through obedience
+                  </li>
+                  <li>
+                    <span className="font-semibold">Eve formed from Adam&rsquo;s side</span> &rarr; the
+                    Church born from the pierced side of Christ on the Cross (blood and water, John
+                    19:34)
+                  </li>
+                  <li>
+                    <span className="font-semibold">Light on Day 1</span> &rarr; Christ who is &ldquo;the
+                    Light of the world&rdquo; (John 8:12), whose coming is the new act of divine creation
+                  </li>
+                  <li>
+                    <span className="font-semibold">The six days</span> &rarr; the six ages of salvation
+                    history, culminating in the seventh age of rest in God (a common patristic reading
+                    in Augustine, Isidore, and the medieval schoolmen)
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The allegorical sense does not displace the literal sense but enriches it. Genesis 1
+                is not merely a creation account &mdash; it is a prophetic anticipation of the new
+                creation in Christ. The first words of John&rsquo;s Gospel (&ldquo;In the beginning
+                was the Word&rdquo;) deliberately echo Genesis 1:1 to make precisely this point.
+              </p>
+            </div>
+
+            {/* Card 4: Moral Sense */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Moral Sense</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The moral sense &mdash; also called the tropological sense &mdash; draws from the
+                sacred text guidance for how to live. It asks: what does this passage call me to do or
+                to become? For Genesis, the moral implications are extraordinarily rich and form the
+                foundation of Catholic social teaching on the environment, human dignity, work, and
+                the family.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">Moral Readings of Genesis</h3>
+                <ul className="text-green-800 space-y-3">
+                  <li>
+                    <span className="font-semibold">The Sabbath rest</span> &rarr; We must rest in God,
+                    not in our own works. The injunction against overwork and the obligation of religious
+                    observance are embedded in the structure of creation itself.
+                  </li>
+                  <li>
+                    <span className="font-semibold">The naming of the animals (Gen 2:19&ndash;20)</span> &rarr;
+                    Human beings have been given dominion over creation &mdash; not to exploit it but
+                    to care for it as stewards. This is the biblical foundation of Catholic ecological
+                    ethics, developed in Pope Francis&rsquo;s <em>Laudato Si&rsquo;</em> (2015).
+                  </li>
+                  <li>
+                    <span className="font-semibold">Creation is &ldquo;very good&rdquo; (Gen 1:31)</span> &rarr;
+                    Respect for the created order as a moral obligation; the theology of the body is
+                    grounded here (the body is good, not a prison for the soul).
+                  </li>
+                  <li>
+                    <span className="font-semibold">The Fall (Gen 3)</span> &rarr; The constant human
+                    temptation to &ldquo;be like God&rdquo; on our own terms, without reference to the
+                    divine will. Pride &mdash; putting self before God &mdash; is identified as the root
+                    of all sin.
+                  </li>
+                  <li>
+                    <span className="font-semibold">The Imago Dei (Gen 1:26&ndash;27)</span> &rarr;
+                    Every human being, regardless of age, condition, or achievement, possesses
+                    inalienable dignity because each is made in the image and likeness of God. This is
+                    the foundation of Catholic teaching on human rights.
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Card 5: Anagogical Sense */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Anagogical Sense</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The anagogical sense &mdash; from the Greek <em>anag&#333;g&#275;</em>, &ldquo;leading
+                upward&rdquo; &mdash; asks how the text points toward our ultimate destiny: the
+                beatific vision, the resurrection of the body, the life of the world to come. It reads
+                the events and images of Scripture as anticipations of heaven. Genesis, which begins
+                with creation, provides the opening notes of a symphony that will not resolve until
+                the new heavens and new earth of the Apocalypse.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Anagogical Readings of Genesis</h3>
+                <ul className="text-amber-800 space-y-3">
+                  <li>
+                    <span className="font-semibold">The Garden of Eden</span> &rarr; The heavenly
+                    Jerusalem. Revelation 22 deliberately echoes Genesis 2: the river of life, the tree
+                    of life, the absence of night, and the direct presence of God are all restored in the
+                    new creation. What was lost in the Fall is more than recovered in Christ.
+                  </li>
+                  <li>
+                    <span className="font-semibold">The Sabbath rest on the seventh day</span> &rarr;
+                    The eternal Sabbath rest in God. Hebrews 4:1&ndash;11 develops this typology
+                    explicitly: &ldquo;A sabbath rest still remains for the people of God.&rdquo; Our
+                    earthly Sunday rest anticipates the endless rest of the blessed.
+                  </li>
+                  <li>
+                    <span className="font-semibold">Light at creation</span> &rarr; The light of the Lamb
+                    in the New Jerusalem: &ldquo;The city has no need of sun or moon to shine on it, for
+                    the glory of God is its light, and its lamp is the Lamb&rdquo; (Rev 21:23).
+                  </li>
+                  <li>
+                    <span className="font-semibold">God walking in the garden (Gen 3:8)</span> &rarr; The
+                    beatific vision: the direct, face-to-face communion with God that is the goal of
+                    human existence, lost through sin and restored through Christ.
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Origen, Ambrose, and Augustine all developed rich anagogical readings of Genesis. For
+                them, the creation narrative was not merely backward-looking (what happened at the
+                beginning) but forward-looking: where is the entire created order going? The answer
+                is the new creation in Christ &mdash; and Genesis 1 already anticipates it.
+              </p>
+            </div>
+
+            {/* Card 6: Practical Application */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Reading Genesis Today: A Practical Guide</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A Catholic reader of Genesis 1 does not have to choose between &ldquo;taking it
+                seriously&rdquo; and &ldquo;accepting modern science.&rdquo; The Church&rsquo;s
+                tradition provides a far richer set of questions to bring to the text than the
+                narrow either/or that dominates popular debate.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Four Questions a Catholic Reader Asks</h3>
+                <ul className="text-amber-800 space-y-3">
+                  <li>
+                    <span className="font-semibold">Literal:</span> What did this text communicate to
+                    ancient Israel? What was the author&rsquo;s theological intention? What truths does
+                    the text bind us to hold?
+                  </li>
+                  <li>
+                    <span className="font-semibold">Allegorical:</span> How does this passage point to
+                    Christ and the Church? Where are the types and foreshadowings of the new creation?
+                  </li>
+                  <li>
+                    <span className="font-semibold">Moral:</span> What does this text call me to do?
+                    How does it shape my relationships with God, other people, and the natural world?
+                  </li>
+                  <li>
+                    <span className="font-semibold">Anagogical:</span> What does this text tell me
+                    about my ultimate destiny &mdash; and the destiny of all creation?
+                  </li>
+                </ul>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <CheckCircle className="w-5 h-5 text-green-700" />
+                    <h4 className="font-semibold text-green-900">Settled by the Church</h4>
+                  </div>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>God is Creator of all things</li>
+                    <li>Creation is genuinely good</li>
+                    <li>The human soul is specially created</li>
+                    <li>Sin entered through a real historical Fall</li>
+                    <li>All humans share one nature in Adam and one redemption in Christ</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <HelpCircle className="w-5 h-5 text-blue-700" />
+                    <h4 className="font-semibold text-blue-900">Left Open by the Church</h4>
+                  </div>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Whether the &ldquo;days&rdquo; are 24 hours or longer epochs</li>
+                    <li>The age of the universe in years</li>
+                    <li>Whether Adam and Eve are a single pair or a founding population</li>
+                    <li>The precise biological mechanism of creation</li>
+                    <li>The literary source history of Genesis</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE SIX DAYS DEBATE ==================== */}
+        {activeTab === 'six-days' && (
+          <div className="space-y-8">
+
+            {/* Card 1: A Catholic Spectrum */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">A Catholic Spectrum of Views</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The meaning of the &ldquo;six days&rdquo; of Genesis 1 is one of the oldest debates in
+                biblical interpretation. Catholics have disagreed about it since at least the second
+                century &mdash; and the Church has never settled the question by a definitive dogmatic
+                definition. This is not a failure of nerve but a recognition that the text itself
+                permits multiple interpretations, all of which can be held in good faith.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Church&rsquo;s Position in Brief</h3>
+                <p className="text-amber-800 mb-2">
+                  The Church has <span className="font-semibold">never defined</span> the precise
+                  meaning of <em>yom</em> (Hebrew: &ldquo;day&rdquo;) in Genesis 1. The Pontifical
+                  Biblical Commission&rsquo;s 1909 response to questions about Genesis explicitly
+                  declined to require a particular interpretation of the six days.
+                </p>
+                <p className="text-amber-800">
+                  What the Church has defined is the <span className="font-semibold">theological
+                  content</span> of Genesis 1 &mdash; not the precise literary or chronological form.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The following survey covers the main positions held by Catholics in good standing,
+                from the most literal to the most symbolic, with the historical and scholarly context
+                of each. A Catholic may hold any of these positions without contradiction of defined
+                Catholic doctrine &mdash; provided they also affirm the Church&rsquo;s binding
+                theological teaching on creation (summarized in the final card).
+              </p>
+            </div>
+
+            {/* Card 2: 24-Hour Day Literalism */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">24-Hour Day Literalism (Young Earth)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The most literal reading of Genesis 1 takes the six days as six sequential 24-hour
+                periods, placing the creation of the universe approximately 6,000&ndash;10,000 years
+                ago. This view is most commonly associated with certain strands of Protestant
+                fundamentalism, though it has some traditional Catholic advocates.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <CheckCircle className="w-5 h-5 text-green-700" />
+                    <h4 className="font-semibold text-green-900">What Can Be Said for It</h4>
+                  </div>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>Takes the text at its most surface reading</li>
+                    <li>Held by some early Church Fathers (Theophilus of Antioch)</li>
+                    <li>Reflects a sincere desire to honor the authority of Scripture</li>
+                    <li>The Church has never formally condemned it</li>
+                  </ul>
+                </div>
+                <div className="bg-red-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <HelpCircle className="w-5 h-5 text-red-700" />
+                    <h4 className="font-semibold text-red-900">Challenges to Consider</h4>
+                  </div>
+                  <ul className="text-red-800 text-sm space-y-2">
+                    <li>The age of the universe (~13.8 billion years) is among the most well-confirmed findings in modern science</li>
+                    <li>Never the mainstream Catholic scholarly position</li>
+                    <li>Augustine, Origen, Clement of Alexandria all resisted strictly literal readings</li>
+                    <li>The PBC (1909) declined to define the meaning of &ldquo;day&rdquo;</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                It is important to note that <em>the Church has never required this view</em>. Young
+                Earth creationism is a permissible personal opinion for a Catholic, but it has never
+                been the dominant Catholic theological position and has never been defined as
+                obligatory. Catholics who hold it should be aware that they are in a distinct minority
+                within the Catholic scholarly tradition.
+              </p>
+            </div>
+
+            {/* Card 3: Day-Age Theory */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Day-Age Theory</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Day-Age theory holds that the Hebrew word <em>yom</em> (&ldquo;day&rdquo;) in
+                Genesis 1 refers not to a 24-hour period but to a long epoch or era of indeterminate
+                length. This interpretation is well-supported by the Hebrew text itself, where
+                <em> yom</em> is used with a range of meanings.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Linguistic Evidence</h3>
+                <p className="text-blue-800 mb-3">
+                  The Hebrew <em>yom</em> can mean: (1) a 24-hour day; (2) the daylight portion of a
+                  day; (3) a period or season; (4) an era or epoch. Context determines meaning. The
+                  most striking example is Genesis 2:4: &ldquo;In the day (<em>yom</em>) that the LORD
+                  God made the earth and the heavens&rdquo; &mdash; here <em>yom</em> clearly refers to
+                  the entire creative period of Genesis 1, not a single 24-hour day.
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Cf. also Psalm 90:4; 2 Peter 3:8: &ldquo;With the Lord one day is like a thousand years, and a thousand years are like one day.&rdquo;</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Early Catholic advocates of a non-literal reading of the &ldquo;days&rdquo; include
+                St. Justin Martyr (2nd century), St. Irenaeus of Lyon (2nd century), and St. Clement
+                of Alexandria (2nd&ndash;3rd century). In modern times, Gerald Schroeder&rsquo;s
+                <em> The Science of God</em> (1997) attempted to reconcile the six days with modern
+                cosmology using the framework of relativistic time dilation &mdash; a speculative but
+                interesting approach.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                This interpretation was widely accepted in the early Church and remains a fully
+                legitimate Catholic option. It allows the plain sequence of Genesis 1 &mdash; water,
+                sky, land, vegetation, animals, humans &mdash; to be read as broadly corresponding
+                to the sequence of development in the natural sciences, without requiring exact
+                correspondence in detail.
+              </p>
+            </div>
+
+            {/* Card 4: Framework/Literary Hypothesis */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Layers className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Framework / Literary Hypothesis</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The framework hypothesis, developed in the 20th century but rooted in ancient
+                observations, holds that the six days of Genesis 1 are a literary and theological
+                structure &mdash; not a chronological account at all. The parallel arrangement of days
+                (Days 1&ndash;3 creating domains; Days 4&ndash;6 filling them) is artistically
+                intentional theology, not a timeline.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Parallel Structure Revisited</h3>
+                <div className="grid sm:grid-cols-3 gap-3">
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">Day 1 / Day 4</p>
+                    <p className="text-blue-800 text-sm">Light created &rarr; Lights (sun, moon, stars) placed in it</p>
+                  </div>
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">Day 2 / Day 5</p>
+                    <p className="text-blue-800 text-sm">Sky and seas &rarr; Birds and fish fill them</p>
+                  </div>
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">Day 3 / Day 6</p>
+                    <p className="text-blue-800 text-sm">Dry land and plants &rarr; Land animals and humans fill it</p>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On this reading, the seven-day structure conveys a single theological message in
+                artistic form: God is the all-sovereign Creator who brings order out of chaos,
+                fills emptiness with life, and crowns the whole with humanity made in His image &mdash;
+                before entering into His Sabbath rest, which He invites humanity to share. The
+                &ldquo;week&rdquo; is a theological poem, not a historical schedule.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                Modern Catholic biblical scholars have been broadly sympathetic to this reading. It
+                is fully compatible with modern cosmology because it does not make any historical or
+                scientific claims at all &mdash; it makes theological ones. Interestingly, John H.
+                Walton&rsquo;s &ldquo;cosmic temple&rdquo; proposal (<em>The Lost World of Genesis
+                One</em>, 2009) &mdash; widely cited in Catholic theological circles &mdash; develops
+                a similar reading from the perspective of ancient Near Eastern functional ontology.
+              </p>
+            </div>
+
+            {/* Card 5: Augustine's Instantaneous Creation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Sparkles className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Augustine&rsquo;s &ldquo;Instantaneous Creation&rdquo;</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                St. Augustine of Hippo proposed the most radical solution of all. In his
+                <em> De Genesi ad Litteram</em>, he argued that God created everything simultaneously
+                &mdash; in a single instant &mdash; and that the &ldquo;days&rdquo; of Genesis 1 are
+                a conceptual framework provided for human understanding, not an account of a temporal
+                sequence in the mind of God.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">Augustine&rsquo;s Key Insight</h3>
+                <p className="text-purple-800 italic mb-3">
+                  &ldquo;Perhaps Scripture said &lsquo;day&rsquo; and &lsquo;night&rsquo; in
+                  reference to some spiritual knowledge in the angels, not to this visible world.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm mb-4">&mdash; <em>De Genesi ad Litteram</em>, IV.28.45</p>
+                <p className="text-purple-800">
+                  Augustine also developed the concept of <em>rationes seminales</em> &mdash;
+                  &ldquo;seminal reasons&rdquo; or seed-principles &mdash; implanted by God in matter
+                  at the moment of creation, which subsequently develop and unfold according to God&rsquo;s
+                  design. This is sometimes cited as a patristic anticipation of evolutionary development.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Augustine&rsquo;s deepest insight was philosophical: <em>time itself was created with
+                the universe.</em> God does not exist in time; God is the Creator of time. Therefore
+                it is literally meaningless to ask &ldquo;what was God doing before creation?&rdquo; &mdash;
+                there was no &ldquo;before.&rdquo; This insight was later developed by Thomas Aquinas
+                and continues to be relevant to modern cosmological discussions about the origin of time.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                Thomas Aquinas, who surveyed all the patristic opinions on the six days, concluded that
+                Augustine&rsquo;s approach was &ldquo;more subtle and profound,&rdquo; while also
+                affirming that more literal readings were not contrary to faith
+                (<em>Summa Theologiae</em>, I, Q.74, art.2). This double affirmation &mdash; that
+                both are legitimate &mdash; is itself instructive about the Church&rsquo;s approach.
+              </p>
+            </div>
+
+            {/* Card 6: What the Church Requires */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What the Church Actually Requires</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Whatever interpretation of the six days one holds, the following theological
+                affirmations are required by Catholic faith. These are not negotiable positions:
+                they are the settled doctrinal content that Genesis 1&ndash;3 communicates, and which
+                the Church has defined in her creeds, catechisms, and conciliar documents.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-3">
+                    <CheckCircle className="w-5 h-5 text-green-700" />
+                    <h4 className="font-semibold text-green-900">Required by Catholic Faith</h4>
+                  </div>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>God freely created the world from nothing (<em>ex nihilo</em>) &mdash; CCC 296&ndash;298</li>
+                    <li>Creation is genuinely good &mdash; CCC 299</li>
+                    <li>Human beings are created in the image of God (<em>imago Dei</em>) &mdash; CCC 355&ndash;361</li>
+                    <li>The human soul is immediately created by God &mdash; <em>Humani Generis</em>, 36</li>
+                    <li>A real, historical Fall introduced sin into human history &mdash; CCC 390, 396&ndash;409</li>
+                    <li>Original sin is transmitted to all humans &mdash; CCC 404&ndash;406</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-3">
+                    <HelpCircle className="w-5 h-5 text-blue-700" />
+                    <h4 className="font-semibold text-blue-900">Not Required by Catholic Faith</h4>
+                  </div>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>A specific age of the universe in years</li>
+                    <li>Literal 24-hour creative days</li>
+                    <li>Young-earth chronology (~6,000&ndash;10,000 years)</li>
+                    <li>A specific biological mechanism of creation</li>
+                    <li>Rejection of the scientific evidence for an ancient universe</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Principle That Holds It Together</h3>
+                <p className="text-amber-800">
+                  Truth cannot contradict truth. The God who speaks in Scripture is the same God who
+                  created the universe that science studies. If the sciences reveal genuine truths about
+                  the age and structure of the cosmos, those truths are truths about God&rsquo;s
+                  creation &mdash; and the Catholic faithful have nothing to fear from them. What the
+                  sciences cannot tell us is <em>why</em> the universe exists, <em>who</em> created
+                  it, or what our place in it ultimately means. That is the domain of Scripture and
+                  Tradition &mdash; and Genesis speaks with full authority on all three.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 4: ADAM & EVE ==================== */}
+        {activeTab === 'adam-eve' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Hardest Question */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <HelpCircle className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Hardest Question</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The historicity of Adam and Eve is the most theologically sensitive question in the
+                dialogue between Catholic faith and modern science. It touches the heart of Catholic
+                doctrine on original sin, which &mdash; per CCC 404 &mdash; requires a <em>real
+                historical event</em> at the origin of the human race. It is not a peripheral
+                question but a central one: the entire theology of redemption in Christ as the
+                &ldquo;New Adam&rdquo; depends on there being a &ldquo;First Adam&rdquo; whose sin
+                required redemption.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The challenge from modern science comes primarily from population genetics. Genetic
+                analysis of the human genome indicates that the human population never passed through
+                a bottleneck of fewer than approximately 10,000 individuals. This creates an apparent
+                tension with the traditional doctrine of monogenism &mdash; the belief that all humans
+                descend from a single first couple.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Why This Matters Theologically</h3>
+                <p className="text-amber-800 mb-2">
+                  The doctrine of original sin, as defined at the Council of Trent and explained in
+                  the Catechism, holds that:
+                </p>
+                <ul className="text-amber-800 space-y-2">
+                  <li>Original sin was committed by a real historical individual (or couple)</li>
+                  <li>It is transmitted to all humans by propagation, not merely by imitation</li>
+                  <li>All humans are therefore in solidarity in both sin and redemption</li>
+                  <li>Christ&rsquo;s redemption is truly universal because the original fall was truly universal</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Card 2: Church's Core Teaching */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Core Teaching: Monogenism</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <strong>Monogenism</strong> is the teaching that all human beings descend from a
+                single first couple. It has been the consistent teaching of the Church and is
+                closely bound up with the doctrine of original sin. The operative magisterial text
+                remains Pius XII&rsquo;s encyclical <em>Humani Generis</em> (1950).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">CCC 360</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;Because of its common origin the human race forms a unity.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Catechism of the Catholic Church, 360</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">CCC 404</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;By yielding to the tempter, Adam and Eve committed a personal sin, but this
+                  sin affected the human nature that they would then transmit in a fallen state.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Catechism of the Catholic Church, 404</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Humani Generis, &sect;37 (Pius XII, 1950)</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;It is in no way apparent how such an opinion [polygenism] can be reconciled
+                  with that which the sources of revealed truth and the documents of the Teaching
+                  Authority of the Church propose with regard to original sin, which proceeds from a
+                  sin actually committed by an individual Adam and which through generation is passed
+                  on to all and is in everyone as his own.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Pius XII, <em>Humani Generis</em>, 37 (1950)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This passage remains the operative magisterial text on this question. No subsequent
+                document from the Magisterium has overtly contradicted or formally superseded it. Any
+                Catholic proposal for reconciling genetic science with original sin must take this
+                text seriously and show how it is compatible with the doctrinal substance Pius XII
+                was protecting.
+              </p>
+            </div>
+
+            {/* Card 3: The Genetic Challenge */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Genetic Challenge: What Population Genetics Shows</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Population genetics studies patterns of genetic variation within and between
+                populations to reconstruct demographic history. Applied to the human species, it has
+                produced results that are directly relevant to the question of human origins.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Core Finding</h3>
+                <p className="text-blue-800 mb-3">
+                  The human genome carries patterns of genetic variation &mdash; particularly in the
+                  diversity of alleles at multiple loci &mdash; that could not have passed through a
+                  single ancestral couple without miraculous creation of extraordinary genetic
+                  diversity. Geneticist Francis Collins, founder of BioLogos and former director of
+                  the Human Genome Project, has stated:
+                </p>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;We know with great certainty that humans share a common ancestor with other
+                  primates and that the size of the ancestral population was never less than several
+                  thousand.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Francis Collins, <em>The Language of God</em> (2006)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Denis Venema and Scot McKnight&rsquo;s <em>Adam and the Genome</em> (2017) presents
+                the genetic evidence in comprehensive detail and concludes that the traditional view
+                of a single founding couple is incompatible with the population genetics data.
+                However, both authors are Protestant, and neither engages deeply with the specific
+                Catholic theological framework (the transmission of a wounded nature, not merely
+                sinful behavior) that makes the question more complex for Catholics.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The key theological question for Catholics is not primarily a genetic one but a
+                doctrinal one: does the Church&rsquo;s teaching on original sin require literal
+                biological descent from exactly two individuals &mdash; or does it require a real,
+                historical originating event involving what we might call a &ldquo;founding
+                population&rdquo;? This is a genuinely open question in current Catholic theology.
+              </p>
+            </div>
+
+            {/* Card 4: Catholic Responses */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Shield className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Catholic Responses to the Challenge</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Several serious Catholic thinkers have proposed solutions that attempt to honor both
+                the genetic evidence and the Church&rsquo;s doctrinal commitments. None of these
+                proposals has been officially endorsed or condemned by the Magisterium &mdash; the
+                question remains genuinely open.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Kenneth Kemp&rsquo;s Proposal (2011)</h3>
+                <p className="text-amber-800 mb-2">
+                  Kenneth Kemp, a Catholic philosopher, proposed in &ldquo;Science, Theology, and
+                  Monogenism&rdquo; (<em>American Catholic Philosophical Quarterly</em>, 2011) a
+                  solution that has been widely discussed. He distinguishes between biological
+                  humanity (<em>Homo sapiens</em> as a species) and philosophical/theological humanity
+                  (beings with rational souls made in the image of God).
+                </p>
+                <p className="text-amber-800">
+                  On his view, a population of biological <em>Homo sapiens</em> may have existed, but
+                  God specially elevated two individuals within that population to full rational and
+                  spiritual status &mdash; creating the <em>imago Dei</em> in them specifically. These
+                  two were the first true human beings in the theological sense, and original sin was
+                  transmitted from them spiritually as well as biologically. The surrounding population
+                  eventually merged into the spiritually-elevated lineage.
+                </p>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">Pope Benedict XVI / Joseph Ratzinger</h3>
+                <p className="text-purple-800 mb-2">
+                  Benedict XVI never directly addressed the genetic polygenism question but
+                  consistently insisted on a <em>historical</em> Fall. In his 1986 catechetical
+                  addresses published as <em>In the Beginning</em>:
+                </p>
+                <p className="text-purple-800 italic mb-2">
+                  &ldquo;At its beginning is always a personal act of sin. There is a historical
+                  beginning to it.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm">&mdash; Joseph Ratzinger, <em>In the Beginning</em> (Eerdmans, 1995)</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">International Theological Commission, <em>Communion and Stewardship</em> (2004)</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;Catholic theology affirms that the emergence of the first members of the
+                  human species (whether as individuals or in populations) represents an event that is
+                  not susceptible of a purely natural explanation and can appropriately be attributed
+                  to divine intervention.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; ITC, <em>Communion and Stewardship</em>, &sect;70 (2004); endorsed by then-Cardinal Ratzinger</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Note the ITC&rsquo;s careful formulation: &ldquo;whether as individuals or in
+                populations.&rdquo; This phrase suggests that the Commission deliberately left open
+                the question of whether the first humans were a single couple or a founding
+                population, while insisting that their emergence involves divine action that exceeds
+                purely natural explanation.
+              </p>
+            </div>
+
+            {/* Card 5: What Must Be Held */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Must Be Held</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Given the genuine openness of this question in current Catholic theology, it is worth
+                being precise about what is and is not required. The following summary distinguishes
+                defined doctrine from open theological questions.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-3">
+                    <CheckCircle className="w-5 h-5 text-green-700" />
+                    <h4 className="font-semibold text-green-900">Required</h4>
+                  </div>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>There was a real, historical originating event &mdash; a &ldquo;Fall&rdquo; &mdash; in which humanity turned from God</li>
+                    <li>Original sin is transmitted to all humans; it is not merely imitated</li>
+                    <li>The <em>imago Dei</em> is conferred by God, not produced by evolution alone</li>
+                    <li>All humans share one human nature and one solidarity in original sin and redemption</li>
+                    <li>The human soul is immediately created by God (<em>Humani Generis</em>, 36)</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <div className="flex items-center gap-2 mb-3">
+                    <HelpCircle className="w-5 h-5 text-blue-700" />
+                    <h4 className="font-semibold text-blue-900">Currently Open</h4>
+                  </div>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Whether &ldquo;Adam and Eve&rdquo; are a single genetic couple or a representative founding population</li>
+                    <li>The precise biological mechanism by which original sin is transmitted</li>
+                    <li>Whether pre-human <em>Homo sapiens</em> existed alongside the spiritually-created first humans</li>
+                    <li>The exact relationship between population genetics and doctrinal monogenism</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="bg-red-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-red-900 mb-3">What Is Not Permitted</h3>
+                <p className="text-red-800">
+                  Catholics may not hold polygenism <em>in the sense condemned by Pius XII</em> &mdash;
+                  that is, a view according to which original sin is merely a cultural inheritance or
+                  a pattern of behavior that spreads through imitation, rather than a real wounding of
+                  human nature transmitted by propagation. The theological substance of
+                  <em> Humani Generis</em> &sect;37 remains binding: original sin has a real historical
+                  origin and is truly transmitted to every human being.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 5: ANCIENT NEAR EASTERN CONTEXT ==================== */}
+        {activeTab === 'ancient-near-east' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Why Context Matters */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Why Ancient Context Matters</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Genesis was written for ancient Israel &mdash; most likely during the period roughly
+                spanning the 10th to the 6th centuries BC, whether in a single authorial act or through
+                a process of composition and editing that modern scholars continue to debate. It was not
+                written for 21st-century Western readers shaped by Enlightenment science. Understanding
+                what Genesis was <em>responding to</em> in its historical context is not a threat to
+                faith; it is the first step toward understanding the text as God intended it to be
+                understood.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Dei Verbum&rsquo;s Directive</h3>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;For a correct understanding of what the sacred author wanted to affirm, due
+                  attention must be paid to the customary and characteristic styles of feeling,
+                  speaking, and narrating which prevailed at the time of the sacred writer.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Dei Verbum</em>, 12 (Vatican II, 1965)</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The ancient world in which Israel lived was saturated with creation stories. Egypt,
+                Mesopotamia, Canaan, and Ugarit all had their own accounts of how the world came to
+                be, who the gods were, and what human beings were created for. Genesis did not emerge
+                in a vacuum &mdash; it emerged in conversation (and deliberate contrast) with this
+                broader world.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                Recognizing this context reveals the theological genius of Genesis: it takes the
+                forms, images, and questions of its world, and answers them with a radically
+                different &mdash; and divinely revealed &mdash; theological vision.
+              </p>
+            </div>
+
+            {/* Card 2: Enuma Elish */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The <em>Enuma Elish</em>: Babylonian Creation Epic</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The <em>Enuma Elish</em> (Akkadian: &ldquo;When on high&hellip;&rdquo;) is the
+                great Babylonian creation epic, dating in its written form to approximately
+                1750&ndash;1200 BC, though it preserves much older traditions. It was the official
+                creation narrative of the Babylonian empire and was publicly recited at the
+                New Year festival.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Babylonian Story</h3>
+                <p className="text-blue-800 mb-3">
+                  In the beginning, the primordial waters &mdash; the freshwater god Apsu and the
+                  saltwater goddess Tiamat &mdash; mingle together. From them the first gods are born.
+                  When the younger gods&rsquo; noise disturbs Apsu, he plans to destroy them. The god
+                  Ea kills Apsu first. Tiamat then goes to war against the younger gods. The hero-god
+                  Marduk defeats Tiamat, splits her body in two like a shellfish, and from her corpse
+                  forms the sky and earth. Humans are created from the blood of the rebel god Kingu to
+                  serve as slaves of the gods.
+                </p>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-amber-900 mb-2">Parallels with Genesis</h4>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>Primordial waters at the beginning</li>
+                    <li>A wind/spirit moving over the waters</li>
+                    <li>Separation of waters above and below</li>
+                    <li>A progression from chaos to ordered creation</li>
+                    <li>The importance of light in the first act of creation</li>
+                  </ul>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-green-900 mb-2">Genesis&rsquo; Theological Contrasts</h4>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li><span className="font-medium">One God</span> vs. a warring pantheon</li>
+                    <li><span className="font-medium">Creation is good</span> &mdash; not made from a slain monster&rsquo;s body</li>
+                    <li><span className="font-medium">Humans are God&rsquo;s image</span> &mdash; not slaves made from rebel blood</li>
+                    <li><span className="font-medium">God rests in sovereign peace</span> &mdash; not exhausted from battle</li>
+                    <li><span className="font-medium">No chaos-god</span> &mdash; evil is not co-equal with God</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Genesis 1 is, among other things, a deliberate theological polemic against Babylonian
+                cosmology. The Hebrew word for the primordial deep &mdash; <em>t&ecirc;h&ocirc;m</em> &mdash;
+                is linguistically related to Tiamat. But in Genesis, the deep is not a hostile
+                goddess &mdash; it is simply formless matter over which God&rsquo;s Spirit moves. God
+                does not struggle; God speaks, and it is so. This is a revolutionary theological claim
+                in its ancient context.
+              </p>
+            </div>
+
+            {/* Card 3: Atrahasis Epic and the Flood */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Waves className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Atrahasis Epic and the Flood Narrative</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The <em>Atrahasis Epic</em> (c. 1700 BC, Babylonian) is the most important
+                parallel text for Genesis 6&ndash;9. Its story of a great flood survived by a single
+                righteous man has obvious similarities to the Noah narrative &mdash; and equally
+                important differences that reveal Genesis&rsquo; theological purpose.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Babylonian Flood Story</h3>
+                <p className="text-blue-800">
+                  In the Atrahasis Epic, the gods send a flood to reduce human overpopulation, because
+                  the noise of humanity disturbs the god Enlil&rsquo;s sleep. Enki (the water-god,
+                  equivalent to Ea) warns Atrahasis (&ldquo;exceedingly wise&rdquo;) to build a boat.
+                  Atrahasis survives with his family and animals. After the flood, the gods smell the
+                  sacrifice and gather &ldquo;like flies&rdquo; because they are hungry. A similar
+                  story appears in the Epic of Gilgamesh (Tablet XI), with the flood survivor named
+                  Utnapishtim.
+                </p>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-amber-900 mb-2">Shared Elements</h4>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>A boat built to survive a catastrophic flood</li>
+                    <li>Animals taken on board</li>
+                    <li>A single family surviving</li>
+                    <li>Birds sent out to test for dry land</li>
+                    <li>A sacrifice offered after the flood</li>
+                    <li>A divine response to the sacrifice</li>
+                  </ul>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-green-900 mb-2">Genesis&rsquo; Radical Differences</h4>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>The flood is <em>moral judgment</em>, not divine irritation at noise</li>
+                    <li>Noah is saved because he is righteous, not because a god favors him arbitrarily</li>
+                    <li>God makes a <em>covenant</em> with Noah after the flood &mdash; a binding promise</li>
+                    <li>The flood is not repeated &mdash; God commits Himself to the preservation of creation</li>
+                    <li>One God acts consistently &mdash; no divine conflict or caprice</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Genesis flood narrative is not &ldquo;copied&rdquo; from Atrahasis but addresses
+                the same primordial human questions &mdash; Why does catastrophe come? Is there a God
+                who saves? &mdash; with a radically different theological answer. The God of Genesis
+                acts with moral purpose, extends covenantal mercy, and commits Himself to the
+                preservation of creation. That is the theological content the narrative was inspired
+                to communicate.
+              </p>
+            </div>
+
+            {/* Card 4: Documentary Hypothesis */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <FileText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Documentary Hypothesis (J, E, D, P)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Since the 19th century, many Old Testament scholars have proposed that the Pentateuch
+                is not the work of a single author (traditionally Moses) but a composite of several
+                distinct literary sources, brought together by editors over centuries. This theory,
+                known as the Documentary Hypothesis, was developed principally by Julius Wellhausen
+                (1878) and Karl Graf. It has been enormously influential in academic biblical
+                scholarship, though it has also been significantly revised and debated.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Four Proposed Sources</h3>
+                <div className="grid sm:grid-cols-2 gap-3">
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">J (Yahwist, c. 950 BC)</p>
+                    <p className="text-blue-800 text-sm">Uses &ldquo;YHWH&rdquo; for God; anthropomorphic style; Gen 2:4b onward (the Eden story)</p>
+                  </div>
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">E (Elohist, c. 850 BC)</p>
+                    <p className="text-blue-800 text-sm">Uses &ldquo;Elohim&rdquo;; more distant, transcendent God; fragments throughout Genesis</p>
+                  </div>
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">D (Deuteronomist, c. 620 BC)</p>
+                    <p className="text-blue-800 text-sm">Primarily Deuteronomy; characteristic hortatory style</p>
+                  </div>
+                  <div className="bg-blue-100 p-3 rounded">
+                    <p className="font-semibold text-blue-900 text-sm">P (Priestly, c. 550 BC)</p>
+                    <p className="text-blue-800 text-sm">Uses &ldquo;Elohim&rdquo;; systematic, formulaic style; Gen 1:1&ndash;2:4a (the seven-day account)</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Catholic Response</h3>
+                <p className="text-amber-800 mb-2">
+                  The Pontifical Biblical Commission&rsquo;s 1906 response permitted careful scholarly
+                  use of source criticism. The PBC&rsquo;s landmark 1993 document, <em>The
+                  Interpretation of the Bible in the Church</em>, acknowledged that source theories
+                  are working hypotheses, not settled facts, and that subsequent scholarship has
+                  significantly modified and contested Wellhausen&rsquo;s original model.
+                </p>
+                <p className="text-amber-800">
+                  The Church does not define the literary history of Genesis. What is essential is
+                  that the canonical text, as received by the Church, is the inspired Word of God
+                  &mdash; whatever compositional history lies behind it. The Church reads the
+                  canonical text.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 5: Genesis as Theological Statement */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Lightbulb className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Genesis as Theological Statement, Not Competitor to Science</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Seen against its ancient Near Eastern background, Genesis 1 emerges as a document
+                of extraordinary theological precision. It answers every major question its ancient
+                audience would have been asking about the creation myths of the surrounding cultures
+                &mdash; and it answers them with a radically different and divinely revealed vision.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-4 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-green-900 mb-2">Questions Genesis Answers</h4>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li><span className="font-medium">Who</span> created? God alone &mdash; not Marduk, not the Enneads of Egypt</li>
+                    <li><span className="font-medium">Why</span> did God create? Out of love and sovereign freedom &mdash; not from war or necessity</li>
+                    <li><span className="font-medium">What is</span> creation? Genuinely good &mdash; not evil matter or a monster&rsquo;s corpse</li>
+                    <li><span className="font-medium">Who are</span> humans? Image of God &mdash; not slaves made from rebel blood</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-blue-900 mb-2">Questions Genesis Does Not Answer</h4>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>How long did creation take in years?</li>
+                    <li>What biological mechanisms were used?</li>
+                    <li>When in absolute chronological terms?</li>
+                    <li>What were the intermediate stages of biological development?</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Dei Verbum 11: The Key Principle</h3>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;The books of Scripture must be acknowledged as teaching firmly, faithfully,
+                  and without error that truth which God wanted put into them for the sake of our
+                  salvation.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm mb-3">&mdash; <em>Dei Verbum</em>, 11 (Vatican II, 1965)</p>
+                <p className="text-amber-800">
+                  Natural science questions were not the purpose of Genesis. That is not a limitation
+                  &mdash; it is the genius of divine revelation: giving Israel, and through Israel all
+                  of humanity, the truths essential for salvation while leaving the legitimate work of
+                  natural science to human reason. The perceived conflict between Genesis and science
+                  dissolves when the text is allowed to answer the questions it was actually asked to
+                  answer.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ==================== TAB 6: KEY DOCUMENTS & VOICES ==================== */}
+        {activeTab === 'key-documents' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Magisterial Documents */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Magisterial Documents</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Church has addressed the interpretation of Genesis and the relationship between
+                Scripture and natural science in a series of authoritative documents spanning more
+                than a century. Taken together, they constitute a coherent and consistently
+                developing body of magisterial guidance.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-amber-900 mb-2">Providentissimus Deus (Leo XIII, 1893)</h3>
+                <p className="text-amber-800 mb-2">
+                  The first major papal encyclical on biblical interpretation. Leo XIII established
+                  the foundational principle: &ldquo;The sacred writers did not intend to teach men
+                  these things, things in no way profitable unto salvation.&rdquo; He taught that
+                  Scripture is not a manual of natural science and that apparent conflicts between
+                  Scripture and science should prompt a re-examination of the scriptural
+                  interpretation, not a rejection of either.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-amber-900 mb-2">Pascendi Dominici Gregis (Pius X, 1907)</h3>
+                <p className="text-amber-800 mb-2">
+                  Condemned Modernism&rsquo;s reduction of Scripture to purely human documents shaped
+                  by historical forces. Insisted on divine inspiration as essential to Catholic
+                  understanding of Scripture. A needed corrective to the tendency to dissolve
+                  Scripture into mere human literature &mdash; but not a mandate for literalism.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-amber-900 mb-2">Divino Afflante Spiritu (Pius XII, 1943)</h3>
+                <p className="text-amber-800 mb-2">
+                  A watershed document &mdash; the &ldquo;Magna Carta&rdquo; of Catholic biblical
+                  scholarship. Pius XII actively encouraged Catholic scholars to use historical-critical
+                  methods; stressed the identification of the <em>genus litterarium</em> (literary
+                  genre) as essential to correct interpretation; called for studying the ancient Near
+                  Eastern context. This document opened the door to the rich tradition of Catholic
+                  biblical scholarship that flourished in the second half of the 20th century.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Dei Verbum (Vatican II, 1965)</h3>
+                <p className="text-blue-800 italic mb-3">
+                  &ldquo;The books of Scripture must be acknowledged as teaching firmly, faithfully,
+                  and without error that truth which God wanted put into them for the sake of our
+                  salvation. Thus &lsquo;all Scripture is divinely inspired and has its use for
+                  teaching the truth and refuting error, for reformation of manners and discipline
+                  in right living&rsquo; (2 Tim 3:16&ndash;17).&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Dei Verbum</em>, 11</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                <em>Dei Verbum</em> is the Church&rsquo;s most complete teaching on Scripture. Its
+                definition of inerrancy &mdash; that Scripture is without error in &ldquo;that truth
+                which God wanted put into them for the sake of our salvation&rdquo; &mdash; is
+                deliberately formulated to exclude the claim that Scripture must be scientifically
+                accurate in all its natural descriptions.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">PBC, <em>The Interpretation of the Bible in the Church</em> (1993)</h3>
+                <p className="text-blue-800">
+                  The most comprehensive modern survey of approved methods for interpreting Scripture.
+                  The document warmly endorses the historical-critical method (with appropriate
+                  cautions), surveys narrative, rhetorical, canonical, and reader-response approaches,
+                  and issues an explicit warning against both fundamentalism (&ldquo;a kind of
+                  intellectual suicide&rdquo;) and excessive rationalism that evacuates the text of
+                  divine meaning. Available in full at the Vatican website.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Church Fathers */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Quote className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church Fathers on Genesis</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The interpretation of Genesis is not a modern problem. The Church Fathers wrestled
+                with it intensively, and their range of approaches &mdash; from the more literal to
+                the highly allegorical &mdash; establishes the breadth of legitimate Catholic
+                interpretation across the centuries.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-purple-900 mb-2">St. Augustine of Hippo (354&ndash;430)</h3>
+                <p className="text-purple-800 mb-2">
+                  <em>De Genesi ad Litteram</em> (12 books, 401&ndash;415 AD): Augustine&rsquo;s
+                  magisterial, fifteen-year engagement with Genesis. He accepted that &ldquo;day&rdquo;
+                  may not mean a 24-hour period; proposed that time was created with the universe;
+                  suggested God may have created everything simultaneously with the &ldquo;days&rdquo;
+                  being an ordered conceptual framework; introduced the concept of <em>rationes
+                  seminales</em> &mdash; seed-principles in matter that unfold according to God&rsquo;s
+                  design. His insistence that Christian interpreters must not make themselves a
+                  laughingstock before unbelievers through overconfident literal readings remains
+                  the gold standard of Catholic hermeneutical wisdom.
+                </p>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-purple-900 mb-2">St. Basil the Great (329&ndash;379)</h3>
+                <p className="text-purple-800 mb-2">
+                  <em>Hexaemeron</em> (&ldquo;On the Six Days&rdquo;) &mdash; nine homilies preached
+                  during Holy Week, probably in 378 AD. Basil accepted a broadly more literal reading
+                  of the six days but was deeply interested in the natural science of his day, drawing
+                  on Aristotle and the Greek natural philosophers throughout. His principle:
+                  &ldquo;It is not difficult for a physician to understand the Book of Nature.&rdquo;
+                  He treated the creation narrative as entirely compatible with careful observation
+                  of the natural world.
+                </p>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-purple-900 mb-2">St. John Chrysostom (349&ndash;407)</h3>
+                <p className="text-purple-800 mb-2">
+                  <em>Homilies on Genesis</em> &mdash; 67 homilies covering the entire book. Chrysostom
+                  emphasized the moral and tropological sense of the text; resisted overly speculative
+                  allegorical readings (he was more cautious than Origen or Augustine in this regard);
+                  and consistently brought the text to bear on the practical spiritual life of his
+                  congregation in Antioch and later Constantinople.
+                </p>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-2">St. Thomas Aquinas (1225&ndash;1274)</h3>
+                <p className="text-purple-800 mb-2">
+                  <em>Summa Theologiae</em>, I, Questions 65&ndash;74 (On the Work of the Six Days).
+                  Aquinas surveyed the full range of patristic opinions on the six days and reached
+                  a characteristically Thomistic conclusion: multiple interpretations are legitimate
+                  as long as none of them contradicts defined doctrine or certain natural knowledge.
+                  He held Augustine&rsquo;s instantaneous creation view to be &ldquo;more subtle and
+                  profound&rdquo; but did not require it. His principle: where Scripture does not
+                  define the matter, we should hold our interpretation humbly and be willing to revise
+                  it in light of further evidence.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Modern Catholic Voices */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <GraduationCap className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Modern Catholic Voices</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">Pope Benedict XVI / Joseph Ratzinger</h3>
+                <p className="text-blue-800 mb-2">
+                  <em>In the Beginning</em> (1986, published in English by Eerdmans, 1995): A series
+                  of catechetical addresses on creation, the Fall, and redemption. Ratzinger insisted
+                  on reading Genesis in terms of its theological intention &mdash; the affirmation of
+                  the <em>Logos</em>, the rational structure of creation &mdash; rather than as a
+                  competitor to science. His 2007 Castel Gandolfo conference on creation and evolution
+                  brought together some of Europe&rsquo;s leading Catholic scientists and theologians
+                  for a serious engagement with the question. Key theme: &ldquo;The universe is not
+                  the result of chance, as some would like to make us believe. Contemplating it, we
+                  are invited to read something profound in it: the wisdom of the Creator, the
+                  inexhaustible creativity of God.&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">Pope John Paul II</h3>
+                <p className="text-blue-800 mb-2">
+                  Address to the Pontifical Academy of Sciences (1996): &ldquo;Today, more than a
+                  half-century after the appearance of that encyclical [<em>Humani Generis</em>],
+                  some new findings lead us toward the recognition of evolution as more than a
+                  hypothesis.&rdquo; John Paul II affirmed evolutionary science for the origin of the
+                  body while insisting: &ldquo;If the human body has its origin in living material
+                  which pre-exists it, the spiritual soul is immediately created by God.&rdquo; His
+                  <em> Theology of the Body</em> (1979&ndash;1984) developed a rich reading of
+                  Genesis 1&ndash;3 as the foundation of Catholic anthropology and sexual ethics.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-4">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">International Theological Commission, <em>Communion and Stewardship</em> (2004)</h3>
+                <p className="text-blue-800 mb-2">
+                  The most comprehensive recent document on creation, evolution, and human origins,
+                  produced by the ITC under then-President Cardinal Ratzinger. It affirms evolution,
+                  insists on divine action in the emergence of the first human beings, addresses
+                  intelligent design critically (while sympathetic to &ldquo;purposeful design&rdquo;),
+                  and leaves open whether &ldquo;the first members of the human species&rdquo; emerged
+                  &ldquo;as individuals or in populations.&rdquo; Essential reading for any Catholic
+                  engaging these questions seriously.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">Stephen M. Barr</h3>
+                <p className="text-blue-800">
+                  Particle physicist and Catholic apologist. <em>Modern Physics and Ancient Faith</em>
+                  (University of Notre Dame Press, 2003) is one of the most rigorous Catholic
+                  engagements with the alleged conflict between modern physics and Christian faith.
+                  Barr argues that modern physics &mdash; far from undermining belief in God &mdash;
+                  has actually undermined the materialist worldview that claimed to be based on
+                  science. His chapter on creation and the Big Bang is particularly relevant to the
+                  interpretation of Genesis.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 4: Sources for Further Study */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sources for Further Study</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The following sources represent the essential reading for a Catholic who wishes to
+                engage these questions seriously. They range from primary magisterial documents
+                (freely available on the Vatican website) to specialist scholarly works.
+              </p>
+
+              <div className="grid sm:grid-cols-2 gap-6">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-800 mb-3">Magisterial &amp; Official Documents</h3>
+                  <ul className="text-gray-700 space-y-2 text-sm">
+                    <li><span className="font-medium">CCC 279&ndash;421</span> &mdash; Creation, the Fall, Original Sin</li>
+                    <li><span className="font-medium">Dei Verbum</span> (Vatican II, 1965) &mdash; Full text</li>
+                    <li><span className="font-medium">Humani Generis</span> (Pius XII, 1950) &mdash; esp. &sect;&sect;36&ndash;37</li>
+                    <li><span className="font-medium">Divino Afflante Spiritu</span> (Pius XII, 1943)</li>
+                    <li><span className="font-medium">Providentissimus Deus</span> (Leo XIII, 1893)</li>
+                    <li><span className="font-medium">PBC, <em>The Interpretation of the Bible in the Church</em></span> (1993)</li>
+                    <li><span className="font-medium">ITC, <em>Communion and Stewardship</em></span> (2004)</li>
+                  </ul>
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-800 mb-3">Books</h3>
+                  <ul className="text-gray-700 space-y-2 text-sm">
+                    <li>Joseph Ratzinger, <em>In the Beginning</em> (Eerdmans, 1995)</li>
+                    <li>John H. Walton, <em>The Lost World of Genesis One</em> (IVP, 2009)</li>
+                    <li>Kenneth Kemp, &ldquo;Science, Theology, and Monogenesis,&rdquo; <em>ACPQ</em> 85 (2011)</li>
+                    <li>Francis Collins, <em>The Language of God</em> (Free Press, 2006)</li>
+                    <li>Stephen M. Barr, <em>Modern Physics and Ancient Faith</em> (Notre Dame, 2003)</li>
+                    <li>St. Augustine, <em>De Genesi ad Litteram</em>, tr. J. H. Taylor (Newman Press)</li>
+                    <li>Denis Venema &amp; Scot McKnight, <em>Adam and the Genome</em> (Brazos, 2017)</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
       </div>
     </div>
   )

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -66,6 +66,42 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly' as const,
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/eschatology/overview`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/eschatology/apocalyptic-literature`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/eschatology/revelation`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/eschatology/protestant-views`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/eschatology/catholic-vs-protestant`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/eschatology/signs-of-times`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
   ]
 
   // Dynamic pages - posts

--- a/src/components/HistoryNavigation.tsx
+++ b/src/components/HistoryNavigation.tsx
@@ -62,6 +62,18 @@ const categories = [
       { href: '/commentary/liturgical-calendar', label: 'Liturgical Calendar' },
     ],
   },
+  {
+    id: 'eschatology',
+    label: 'End Times',
+    tabs: [
+      { href: '/eschatology/overview', label: 'Catholic Teaching' },
+      { href: '/eschatology/apocalyptic-literature', label: 'Apocalyptic Literature' },
+      { href: '/eschatology/revelation', label: 'Book of Revelation' },
+      { href: '/eschatology/protestant-views', label: 'Protestant Views' },
+      { href: '/eschatology/catholic-vs-protestant', label: 'Catholic vs. Protestant' },
+      { href: '/eschatology/signs-of-times', label: 'Signs of the Times' },
+    ],
+  },
 ]
 
 export default function HistoryNavigation() {


### PR DESCRIPTION
## Summary

- **Removed** the "Development in Progress" banner
- **Expanded** tree from ~20 sparse nodes to 50+ well-researched nodes across five eras
- **Added** a `detail` field (3–5 sentences) to every node for the right details panel
- **Improved** the `Branch` component: selected-node amber highlighting, type-specific border colours
- **Added** `divisionLink` flag — division/heresy nodes surface a link to `/history/church-divisions` for full detail
- **Proper page header** (h1 + subtitle) matching the other history pages
- **Cross-links sidebar** to `/history/church`, `/history/church-divisions`, `/history/apostles`

### New nodes added
Gnosticism, Montanism, Donatism, Jansenism, Edict of Milan (313), Council of Constantinople I (381), Council of Ephesus (431), St. Jerome & the Vulgate, St. Augustine, Gregory the Great, Charlemagne, Iconoclasm, The Crusades, Catharism, Hussites, Avignon Papacy, Western Schism, Teresa of Ávila, Reformed/Calvinist separation, Anglican separation, Rerum Novarum, Immaculate Conception & Assumption, Lourdes & Fátima, WWII & Pius XII, Pope John Paul II, Pope Francis

## Test plan
- [ ] Visit `/history/church-tree` — no "Development in Progress" banner
- [ ] Verify page header renders correctly
- [ ] Click any leaf node — details panel shows the `detail` text (not the old placeholder)
- [ ] Division/heresy nodes show "See Church Divisions" link in detail panel
- [ ] Filter checkboxes work (toggle councils, heresies, etc.)
- [ ] Cross-links to `/history/church`, `/history/church-divisions`, `/history/apostles` all route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)