### PR TITLE
feat: Add Prayer & Devotion section (8 pages)

### DIFF
--- a/src/app/prayer/charismatic-renewal/page.tsx
+++ b/src/app/prayer/charismatic-renewal/page.tsx
@@ -1,0 +1,1154 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Flame,
+  BookOpen,
+  Star,
+  Globe,
+  Users,
+  Heart,
+  Wind,
+  Compass,
+  ArrowRight,
+  Scale,
+} from 'lucide-react'
+
+type TabId =
+  | 'origins'
+  | 'gifts-of-the-spirit'
+  | 'papal-endorsements'
+  | 'charis'
+  | 'ccr-vs-pentecostalism'
+  | 'how-to-participate'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'origins', label: 'Origins' },
+  { id: 'gifts-of-the-spirit', label: 'Gifts of the Spirit' },
+  { id: 'papal-endorsements', label: 'Papal Endorsements' },
+  { id: 'charis', label: 'CHARIS' },
+  { id: 'ccr-vs-pentecostalism', label: 'CCR vs. Pentecostalism' },
+  { id: 'how-to-participate', label: 'How to Participate' },
+]
+
+export default function CharismaticRenewalPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('origins')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Catholic Charismatic Renewal
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            Born at Duquesne in 1967, now 160 million strong &mdash; the CCR is a movement of the
+            Holy Spirit within the Catholic Church, not a denomination, bringing renewal to
+            sacramental, Marian, and papal faith.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: ORIGINS ==================== */}
+        {activeTab === 'origins' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Context */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Context (1960s)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Second Vatican Council (1962&ndash;1965) had called for renewal in the Church.
+                Among laypeople and theologians, there was a growing hunger for a deeper, more
+                conscious experience of the Holy Spirit promised in the New Testament. Vatican II&rsquo;s
+                constitutions and decrees opened the windows of the Church to fresh air &mdash; and
+                for many, that meant a rediscovery of the charismatic dimension that had always been
+                present in the Church but had often gone unnoticed.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Council&rsquo;s <em>Lumen Gentium</em> &sect;12 explicitly affirmed charisms as
+                integral to the life of the Church: <em>&ldquo;These charismatic gifts, whether they
+                are the more outstanding or the more simple and widely diffused, are to be received
+                with thanksgiving and consolation, for they are perfectly suited to and useful for
+                the needs of the Church.&rdquo;</em> This conciliar statement gave theological
+                legitimacy to what was about to happen in Pittsburgh, Pennsylvania in February 1967.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                  Lumen Gentium &sect;12 (Vatican II, 1964)
+                </h3>
+                <p className="text-blue-800 italic">
+                  &ldquo;It is not only through the sacraments and the ministries of the Church that the
+                  Holy Spirit sanctifies and leads the people of God and enriches it with virtues, but,
+                  allotting his gifts to everyone according as he wills, he distributes special graces
+                  among the faithful of every rank.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The generation of Catholics who came of age in the 1960s had lived through the
+                extraordinary experience of an ecumenical council. They had seen bishops and
+                theologians speak with renewed freshness about Scripture, the liturgy, the Holy
+                Spirit, and the mission of the Church. Into this prepared soil, the charismatic
+                renewal took root.
+              </p>
+            </div>
+
+            {/* Card 2: The Duquesne Weekend */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Duquesne Weekend (February 17&ndash;19, 1967)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The founding event of the CCR in the United States &mdash; and effectively in the
+                modern Catholic Church worldwide &mdash; was a weekend retreat held at the
+                &ldquo;Ark and the Dove&rdquo; retreat house on the campus of Duquesne University
+                in Pittsburgh, Pennsylvania. A group of about 25 students and faculty gathered
+                for what was billed as a simple spiritual retreat.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                In preparation, several participants had been reading David Wilkerson&rsquo;s
+                <em> The Cross and the Switchblade</em> &mdash; a Protestant charismatic text about
+                ministry among street gangs &mdash; and <em>Catholic Pentecostals</em> by Kevin
+                Ranaghan. They had also been meeting weekly for prayer and asking God to renew
+                the gifts of the Spirit in their lives. The preparation was not spectacular: it
+                was marked by Scripture reading, prayer, and sincere desire.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                During the Saturday night prayer meeting in the chapel, a student spontaneously
+                picked up the Bible and opened it to Acts 2 &mdash; the account of Pentecost.
+                Within hours, many in the group experienced what they described as a profound
+                and unmistakable encounter with the Holy Spirit: some spoke in tongues for the
+                first time, others experienced deep peace, prophecy, and a burning sense of
+                God&rsquo;s presence. The atmosphere was not hysteria but awe.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Key Figures at Duquesne</h3>
+                <ul className="space-y-2 text-amber-800">
+                  <li><strong>Patrick Bourgeois</strong> &mdash; the first to receive the gift of tongues that weekend</li>
+                  <li><strong>Ralph Keifer</strong> &mdash; a theology instructor who helped lead the retreat</li>
+                  <li><strong>David Mangan</strong> &mdash; a student whose experience on the chapel stairs became iconic in CCR history</li>
+                  <li><strong>Kevin and Dorothy Ranaghan</strong> &mdash; who documented the early events and wrote <em>Catholic Pentecostals Today</em></li>
+                </ul>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <p className="text-green-800 italic text-base leading-relaxed">
+                  The Duquesne Weekend was not an explosion from nowhere. It was prepared for by
+                  prayer, Scripture reading, and a genuine desire for God. Many who were there said
+                  that what they experienced was not foreign to Catholicism but was a rediscovery of
+                  what their sacraments already contained &mdash; the living power of the Holy Spirit
+                  poured out at Baptism and Confirmation.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Spread */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">From Pittsburgh to the World</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The experience spread with remarkable speed. Within two months of the Duquesne
+                Weekend, similar prayer meetings were happening at Notre Dame, Michigan State, and
+                other Catholic universities across the United States. The first national CCR
+                conference was held at Notre Dame in 1967 with only 87 participants. By 1973,
+                the annual Notre Dame conference had grown to 22,000 attendees.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The <strong>Word of God community</strong> in Ann Arbor, Michigan became one of
+                the most influential early centers of the CCR, developing structured formation
+                programs, teaching materials, and covenant community life that would be replicated
+                around the world. The community&rsquo;s <em>Life in the Spirit Seminars</em> became
+                the standard entry point for new participants worldwide.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                From the USA, the CCR spread rapidly to Latin America, Europe, Africa, and Asia.
+                By the 1980s it was present in over 100 countries. The pivotal moment of
+                international visibility came on <strong>Pentecost Sunday 1975</strong>, when the
+                International Congress of the Charismatic Renewal in Rome brought 10,000
+                charismatics to St. Peter&rsquo;s Square for a meeting with Pope Paul VI &mdash;
+                who called the renewal &ldquo;a chance for the Church.&rdquo;
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Name Explained</h3>
+                <p className="text-amber-800 leading-relaxed">
+                  The movement is called &ldquo;charismatic&rdquo; from the Greek <em>charisma</em>
+                  (gift of grace) and &ldquo;renewal&rdquo; because it understood itself not as
+                  creating something new but as recovering what was always present in the Church
+                  &mdash; the power of the Holy Spirit poured out at Pentecost (Acts 2) and
+                  conferred in every Baptism and Confirmation. It is a renewal of what already
+                  exists, not a replacement for it.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: GIFTS OF THE SPIRIT ==================== */}
+        {activeTab === 'gifts-of-the-spirit' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Two Categories */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Wind className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Two Categories of Gifts</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholic theology distinguishes two main categories of gifts given by the Holy
+                Spirit. Understanding this distinction is essential to understanding what the CCR
+                claims and what it does not claim.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                    Sanctifying Gifts (Isaiah 11:2&ndash;3)
+                  </h3>
+                  <p className="text-blue-800 mb-3 text-sm">
+                    Confirmed in the rite of Confirmation; given for the personal holiness of
+                    the recipient:
+                  </p>
+                  <ul className="text-blue-700 text-sm space-y-1">
+                    <li>Wisdom</li>
+                    <li>Understanding</li>
+                    <li>Counsel</li>
+                    <li>Fortitude</li>
+                    <li>Knowledge</li>
+                    <li>Piety</li>
+                    <li>Fear of the Lord</li>
+                  </ul>
+                </div>
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                    Charisms (1 Cor 12; Rom 12; Eph 4)
+                  </h3>
+                  <p className="text-amber-800 mb-3 text-sm">
+                    Special gifts of the Holy Spirit given for the building up of the Church
+                    and the proclamation of the Gospel. The CCR focuses particularly on these:
+                  </p>
+                  <ul className="text-amber-700 text-sm space-y-1">
+                    <li>Word of wisdom, word of knowledge</li>
+                    <li>Faith, healing, miraculous powers</li>
+                    <li>Prophecy, distinguishing spirits</li>
+                    <li>Tongues, interpretation of tongues</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                  CCC 799&ndash;801
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Whether extraordinary or simple and humble, charisms are graces of the Holy
+                  Spirit which directly or indirectly benefit the Church, ordered as they are to her
+                  building up, to the good of men, and to the needs of the world.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  CCC 800: &ldquo;Charisms are to be accepted with gratitude by the person who receives
+                  them and by all members of the Church as well... Extraordinary charisms are not to
+                  be rashly sought after.&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Glossolalia */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Glossolalia: Speaking in Tongues</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The most well-known and most debated charism. In Acts 2, the Apostles spoke in
+                foreign languages that were miraculously understood by people of every nation
+                present in Jerusalem for Pentecost. This was a sign to unbelievers and a dramatic
+                proclamation of the Gospel across linguistic barriers.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Paul in 1 Corinthians 14 distinguishes carefully between tongues as a sign
+                for unbelievers and tongues as a personal prayer language between the soul and
+                God, not necessarily understood by the intellect: <em>&ldquo;For if I pray in a tongue,
+                my spirit prays but my mind is unfruitful&rdquo;</em> (1 Cor 14:14). In CCR practice,
+                the latter &mdash; often called &ldquo;praying in the Spirit&rdquo; or &ldquo;singing in the
+                Spirit&rdquo; &mdash; is the common experience. It is not necessarily a foreign human
+                language; it is understood as a surrender of the tongue to the Spirit as a form
+                of praise beyond the capacity of ordinary speech.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Paul also speaks of &ldquo;tongues of men and of angels&rdquo; (1 Cor 13:1) and says
+                that he himself speaks in tongues more than all the Corinthians (1 Cor 14:18),
+                while also insisting that in the assembly, prophecy is more useful than tongues
+                unless there is interpretation (1 Cor 14:5).
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <p className="text-green-800 italic leading-relaxed">
+                  The CCR does not claim that speaking in tongues is a required sign of the
+                  Spirit&rsquo;s presence &mdash; unlike many Pentecostal denominations. The charisms
+                  are distributed as the Spirit wills (1 Cor 12:11) and serve the community,
+                  not personal prestige. Many faithful CCR members pray in tongues privately;
+                  others receive different charisms entirely.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Prophecy and Baptism in the Spirit */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Prophecy and Baptism in the Holy Spirit</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <strong>Prophecy</strong>: Paul says to &ldquo;earnestly desire to prophesy&rdquo;
+                (1 Cor 14:1). In CCR practice, prophecy is understood as speaking a word of
+                encouragement, consolation, or exhortation that one believes is prompted by the
+                Holy Spirit &mdash; not the same as the canonical prophecy of the Old Testament
+                prophets or a new addition to the deposit of faith (which is closed with the death
+                of the Apostles). CCC 801 notes that charisms &ldquo;are not to be rashly sought after,
+                nor are the fruits of apostolic works to be presumptuously expected from them.&rdquo;
+                All prophecy is to be tested against Scripture and Church teaching (1 Thess 5:19&ndash;21).
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <strong>Baptism in the Holy Spirit</strong>: This is the central experience of the
+                CCR. In Catholic theology, it is carefully understood as a &ldquo;release&rdquo; or
+                &ldquo;actualization&rdquo; of the graces already received in the sacraments of
+                Baptism and Confirmation &mdash; not a third sacrament, not a second baptism,
+                not a correction of a deficient first baptism. CCC 1302&ndash;1305 teaches that
+                Confirmation &ldquo;brings an increase and deepening of baptismal grace.&rdquo; The
+                Baptism in the Spirit is the conscious, experiential appropriation of what was
+                given sacramentally, often through prayer with laying on of hands.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Why &ldquo;Baptism in the Spirit&rdquo; Is Not a New Sacrament
+                </h3>
+                <p className="text-amber-800 leading-relaxed">
+                  The Church teaches that there are seven sacraments, instituted by Christ,
+                  and they cannot be augmented. The &ldquo;Baptism in the Spirit&rdquo; is not
+                  an eighth sacrament but a sacramental act (like a blessing or a prayer of
+                  intercession) through which God is asked to bring to conscious life what was
+                  already given. Francis Sullivan SJ, a leading Catholic theologian of the CCR,
+                  described it as &ldquo;a renewal of the grace of Christian initiation.&rdquo;
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: PAPAL ENDORSEMENTS ==================== */}
+        {activeTab === 'papal-endorsements' && (
+          <div className="space-y-8">
+
+            {/* Intro */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">A Movement Affirmed by Four Popes</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed">
+                No modern ecclesial movement has received such consistent and enthusiastic papal
+                support across four consecutive pontificates. From Paul VI to Francis, each pope
+                has affirmed the CCR in terms that go well beyond polite acknowledgment &mdash;
+                calling it &ldquo;a chance for the Church,&rdquo; &ldquo;co-essential&rdquo; to
+                the Church&rsquo;s life, a &ldquo;gift of the Lord,&rdquo; and linking it to a
+                &ldquo;new Pentecost.&rdquo;
+              </p>
+            </div>
+
+            {/* Paul VI */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Pope Paul VI (1975)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The pivotal papal encounter came on <strong>May 19, 1975</strong> &mdash; Pentecost
+                Sunday &mdash; when Paul VI addressed the International Charismatic Congress in
+                Rome, attended by 10,000 charismatics. In his address, the Pope called the CCR
+                &ldquo;a chance for the Church and for the world.&rdquo; He asked: &ldquo;How then
+                could this &lsquo;spiritual renewal&rsquo; not be a &lsquo;chance&rsquo; for the
+                Church and for the world? And how, in this case, could one not take all the means
+                necessary to ensure that it remains so?&rdquo;
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                  Paul VI, Final Mass Address, St. Peter&rsquo;s Square, May 19, 1975
+                </h3>
+                <p className="text-blue-800 italic">
+                  &ldquo;Nothing is more necessary to this more and more secularized world than the
+                  witness of this &lsquo;spiritual renewal&rsquo; that we see the Holy Spirit
+                  evoking in the most diverse regions and milieux. It is above all this renewal
+                  that we desire.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The final Mass on Pentecost Sunday brought 50,000 people to St. Peter&rsquo;s
+                Square. Paul VI&rsquo;s endorsement at this moment cemented the CCR&rsquo;s status
+                as a legitimate and welcomed movement within the universal Church.
+              </p>
+            </div>
+
+            {/* John Paul II */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Pope John Paul II (1978&ndash;2005)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                John Paul II had a deep personal affinity for charismatic spirituality throughout
+                his pontificate. At Notre Dame in October 1979 he addressed 1,500 charismatics
+                and praised the renewal. He used the phrase &ldquo;new Pentecost&rdquo; repeatedly
+                in his teaching. At the CCR International Congress in 1998, he declared: &ldquo;The
+                institutional and the charismatic aspects are co-essential to the life and mission
+                of the Church.&rdquo;
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                  <em>Novo Millennio Ineunte</em> &sect;44 (JPII, 2001)
+                </h3>
+                <p className="text-blue-800 italic">
+                  Calls for &ldquo;a spirituality of communion&rdquo; as the foundational program
+                  for the Church in the third millennium &mdash; an aspiration that echoes the
+                  CCR&rsquo;s communal and relational dimension at its best.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                JPII&rsquo;s phrase &ldquo;co-essential&rdquo; for the institutional and charismatic
+                dimensions of the Church became a touchstone for CCR theology and was later
+                repeated by Benedict XVI and Francis.
+              </p>
+            </div>
+
+            {/* Benedict XVI */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Pope Benedict XVI (2005&ndash;2013)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Benedict XVI addressed 350,000 members of ecclesial movements and new communities
+                &mdash; including the CCR &mdash; at St. Peter&rsquo;s Square on Pentecost 2006.
+                He repeated JPII&rsquo;s formulation: &ldquo;The institutional and charismatic
+                dimensions of the Church are co-essential.&rdquo;
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Benedict was personally more reserved about highly experiential forms of religion,
+                but he consistently affirmed the CCR&rsquo;s legitimate place in the Church, met
+                with CCR leaders in formal audience, and endorsed the creation of CHARIS in its
+                planning stages. His theological writings on the Holy Spirit in <em>Jesus of
+                Nazareth</em> provided a rich doctrinal foundation that CCR teachers drew upon
+                extensively.
+              </p>
+            </div>
+
+            {/* Francis */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Pope Francis (2013&ndash;present)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Francis has had the most intense personal relationship with the CCR of any pope.
+                At Castel Gandolfo on October 1, 2014, speaking at the 40th anniversary gathering
+                of CCR in Italy and Europe, he said: &ldquo;You, the Catholic Charismatic Renewal,
+                have received a great gift from the Lord. You were born of the will of the Spirit
+                as a renewal of grace in the whole Church.&rdquo;
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                  Francis, 50th Anniversary of the CCR, June 4, 2017
+                </h3>
+                <p className="text-blue-800 italic">
+                  &ldquo;I expect from you to share with everyone in the Church the grace of Baptism
+                  in the Holy Spirit.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                In 2019, Francis personally established CHARIS (see the CHARIS tab) and addressed
+                35,000 charismatics at Rome&rsquo;s Circus Maximus for the 52nd anniversary congress
+                with the words: &ldquo;Go, do not be afraid, and serve.&rdquo; Francis also personally
+                participates in informal charismatic prayer meetings, having been closely associated
+                with CCR communities in Argentina before his election.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <p className="text-green-800 italic leading-relaxed">
+                  No modern ecclesial movement has received such consistent and enthusiastic papal
+                  support across four pontificates. The CCR&rsquo;s emphasis on the Holy Spirit,
+                  personal conversion, communal prayer, Scripture, and evangelization aligns with
+                  the central concerns of each pope who has addressed it.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: CHARIS ==================== */}
+        {activeTab === 'charis' && (
+          <div className="space-y-8">
+
+            {/* Card 1: What is CHARIS */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Is CHARIS?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <strong>CHARIS</strong> &mdash; Catholic Charismatic Renewal International Service
+                &mdash; is the official umbrella body for the CCR worldwide. It was established by
+                Pope Francis on <strong>June 8, 2019</strong> (the Feast of Pentecost), through a
+                decree of the Dicastery for Laity, Family and Life. The name <em>CHARIS</em> is
+                itself from the Greek <em>charis</em> (grace, gift), reflecting the movement&rsquo;s
+                emphasis on the freely given gifts of the Holy Spirit.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CHARIS replaces two previous international CCR service bodies that had operated
+                in parallel for decades:
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">
+                    ICCRS (founded 1972)
+                  </h3>
+                  <p className="text-blue-800 text-sm">
+                    International Catholic Charismatic Renewal Services &mdash; served prayer
+                    groups and individual charismatics worldwide; based at the Vatican.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">
+                    Catholic Fraternity (founded 1990)
+                  </h3>
+                  <p className="text-amber-800 text-sm">
+                    Catholic Fraternity of Charismatic Covenant Communities and Fellowships
+                    &mdash; served covenant communities and intentional communities within the CCR.
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                CHARIS unifies these two bodies under a single structure with a single canonical
+                identity, responding to Francis&rsquo;s call for unity within the renewal.
+              </p>
+            </div>
+
+            {/* Card 2: Canonical Status and Governance */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Canonical Status and Governance</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CHARIS is recognized by the Holy See as a <strong>private international
+                association of the faithful</strong>, governed by statutes approved by the
+                Dicastery for Laity, Family and Life. It reports directly to the Dicastery.
+                This gives it a formal canonical standing &mdash; it is not a parachurch
+                organization but an entity recognized by Church law.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CHARIS is led by a president and a board representing the geographic and
+                cultural diversity of the CCR worldwide. Its secretariat is based in Rome
+                (formerly at the Pontifical University of St. Thomas Aquinas, the Angelicum).
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Mandate from Pope Francis (June 2019)
+                </h3>
+                <div className="space-y-3">
+                  <div>
+                    <p className="font-semibold text-blue-800">1. Unity</p>
+                    <p className="text-blue-700 text-sm">
+                      &ldquo;All the members of the Renewal in the Catholic Church, under the
+                      umbrella of CHARIS, express and strengthen their unity.&rdquo;
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-blue-800">2. Holiness</p>
+                    <p className="text-blue-700 text-sm">
+                      &ldquo;To help all the baptized to live the grace of Baptism in the Spirit
+                      and to exercise the charisms.&rdquo;
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-blue-800">3. Mission</p>
+                    <p className="text-blue-700 text-sm">
+                      &ldquo;To bring the proclamation of the Gospel, in the power of the Holy
+                      Spirit, to every person.&rdquo;
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 3: Launch and Global Scale */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Launch and Global Scale</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CHARIS was formally launched at a gathering of <strong>35,000 charismatics</strong>
+                at Rome&rsquo;s Circus Maximus on June 8, 2019. Pope Francis addressed the crowd:
+                &ldquo;Go, do not be afraid, and serve.&rdquo; The event was a visible sign of the
+                CCR&rsquo;s institutional maturity and its place within the universal Church.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The CCR under CHARIS is present in <strong>235 countries</strong>, with an
+                estimated 160 million Catholics involved worldwide &mdash; making it numerically
+                the largest Catholic movement in the Church. Each country with significant CCR
+                presence has a National Service (NSC) affiliated with CHARIS, coordinating
+                formation programs, national congresses, and ecumenical dialogue.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Notable National Communities
+                </h3>
+                <ul className="space-y-1 text-amber-800 text-sm">
+                  <li><strong>United States</strong>: Catholic Charismatic Renewal Services (CCRS)</li>
+                  <li><strong>India</strong>: ICCRS India (one of the oldest and largest national CCR bodies)</li>
+                  <li><strong>Philippines</strong>: Catholic Charismatic Renewal of the Philippines (among the largest globally)</li>
+                  <li><strong>Brazil</strong>: Renovacao Carismatica Catolica (enormous in size, deeply rooted in parish life)</li>
+                </ul>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <p className="text-green-800 italic leading-relaxed">
+                  The creation of CHARIS represents the Holy See&rsquo;s desire to shepherd the
+                  CCR more closely &mdash; providing unity, doctrinal guidance, and connection to
+                  the universal Church&rsquo;s structures, while preserving the movement&rsquo;s
+                  charismatic vitality and its fundamental orientation to the Holy Spirit.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: CCR VS. PENTECOSTALISM ==================== */}
+        {activeTab === 'ccr-vs-pentecostalism' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Why This Distinction Matters */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Why This Distinction Matters</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The CCR emerged partly through contact with Protestant Pentecostalism &mdash; the
+                Duquesne group was reading Wilkerson&rsquo;s <em>The Cross and the Switchblade</em>,
+                a Protestant charismatic text. Many Catholics and non-Catholics confuse the two
+                movements or assume the CCR is simply &ldquo;Pentecostalism with rosaries.&rdquo;
+                This is deeply mistaken. They share some spiritual experiences but are founded on
+                radically different theologies.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">What They Share</h3>
+                  <ul className="space-y-2 text-amber-800 text-sm">
+                    <li>Emphasis on the Holy Spirit and the charisms (tongues, prophecy, healing)</li>
+                    <li>Personal conversion and &ldquo;Baptism in the Spirit&rdquo;</li>
+                    <li>Communal prayer with spontaneous expressions of praise</li>
+                    <li>Scripture as the living word of God</li>
+                    <li>Evangelization and personal witness</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Where They Part Ways</h3>
+                  <p className="text-blue-800 text-sm">
+                    The differences are not peripheral but go to the heart of Catholic faith:
+                    sacraments, Mary, the papacy, the Eucharist, Tradition, and the nature of
+                    the Church. The CCR is irrevocably Catholic in all of these.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 2: Comparison Table */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Fundamental Differences</h2>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="bg-amber-100">
+                      <th className="border border-amber-200 p-3 text-left text-amber-900 font-semibold">Feature</th>
+                      <th className="border border-amber-200 p-3 text-left text-amber-900 font-semibold">Catholic CCR</th>
+                      <th className="border border-amber-200 p-3 text-left text-amber-900 font-semibold">Classical Pentecostalism</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Sacraments</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Baptism, Confirmation, Eucharist are primary; charisms flow from and return to sacramental life</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">No sacraments as efficacious signs; ordinances only (baptism, communion as memorials)</td>
+                    </tr>
+                    <tr className="bg-gray-50">
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Mary</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Strong Marian devotion; Our Lady as Mother of the Church; rosary, scapular widely practiced</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Marian devotion absent or explicitly rejected as unscriptural</td>
+                    </tr>
+                    <tr>
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Papal Authority</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Full obedience to Rome; CCR submitted to the Magisterium; bishops and Dicasteries can evaluate and correct</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">No church hierarchy with binding doctrinal authority; <em>sola scriptura</em></td>
+                    </tr>
+                    <tr className="bg-gray-50">
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Tongues as Sign</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Tongues are ONE charism, not the required evidence of Spirit-baptism</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Tongues as the &ldquo;initial evidence&rdquo; of Spirit-baptism (Assemblies of God position)</td>
+                    </tr>
+                    <tr>
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Eucharist</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">The Eucharist is the summit of Christian life; charismatic prayer is ordered toward Mass</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">No Eucharistic theology; the Lord&rsquo;s Supper is a symbolic memorial only</td>
+                    </tr>
+                    <tr className="bg-gray-50">
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Saints</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Veneration of saints; invoking their intercession as part of the Communion of Saints</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Saints venerated only as examples; not invoked as intercessors</td>
+                    </tr>
+                    <tr>
+                      <td className="border border-gray-200 p-3 font-medium text-gray-800">Scripture + Tradition</td>
+                      <td className="border border-gray-200 p-3 text-gray-700">Bible interpreted within the Church&rsquo;s living Tradition and Magisterium</td>
+                      <td className="border border-gray-200 p-3 text-gray-700"><em>Sola scriptura</em>; tradition viewed as human addition to be tested against private interpretation</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Card 3: Ecumenical Dialogue and Suenens */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Ecumenical Dimension</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Since 1972, the Vatican&rsquo;s Pontifical Council for Promoting Christian Unity
+                has conducted formal theological dialogue with classical Pentecostals. The CCR
+                has served as a natural bridge in this ecumenical conversation: its members share
+                common spiritual experiences with Pentecostals while maintaining full Catholic
+                identity in doctrine, sacraments, and structure.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Cardinal <strong>L&eacute;on Joseph Suenens</strong> of Belgium, the most prominent
+                episcopal champion of the CCR in the 1970s, articulated its Catholic identity with
+                elegance: &ldquo;The Renewal is nothing other than the rediscovery of the third
+                article of the Creed&rdquo; &mdash; the article that says &ldquo;I believe in the
+                Holy Spirit.&rdquo; It is not an import from Protestantism; it is a recovery of
+                what the Catholic Creed has always confessed.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <p className="text-green-800 italic leading-relaxed">
+                  Cardinal Suenens, <em>A New Pentecost?</em> (1974): &ldquo;The Renewal is
+                  nothing other than the rediscovery of the third article of the Creed &mdash; the
+                  Holy Spirit. It is profoundly Catholic: ordered to the Incarnation, the sacraments,
+                  and the Communion of Saints.&rdquo;
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: HOW TO PARTICIPATE ==================== */}
+        {activeTab === 'how-to-participate' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Life in the Spirit Seminars */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Life in the Spirit Seminars (LSS)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The standard 7-week formation program for those new to the CCR. Developed at the
+                Word of God community in Ann Arbor, Michigan, in the late 1960s, the Life in the
+                Spirit Seminars have been used worldwide for over fifty years to introduce
+                Catholics to charismatic renewal.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Seven-Week Structure
+                </h3>
+                <div className="grid sm:grid-cols-2 gap-3">
+                  <div>
+                    <p className="font-semibold text-amber-800 text-sm">Week 1</p>
+                    <p className="text-amber-700 text-sm">God&rsquo;s love: the foundation</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 text-sm">Week 2</p>
+                    <p className="text-amber-700 text-sm">Salvation: what Christ has done</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 text-sm">Week 3</p>
+                    <p className="text-amber-700 text-sm">The new life in the Spirit</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 text-sm">Week 4</p>
+                    <p className="text-amber-700 text-sm">Receiving the gifts of the Spirit</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 text-sm">Week 5 (climax)</p>
+                    <p className="text-amber-700 text-sm">Prayer for Baptism in the Holy Spirit</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 text-sm">Weeks 6&ndash;7</p>
+                    <p className="text-amber-700 text-sm">Growth, transformation, service in the community</p>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The LSS is available through most CCR communities and through many parishes
+                worldwide. It is recommended as the starting point for anyone wishing to explore
+                the CCR seriously.
+              </p>
+            </div>
+
+            {/* Card 2: Prayer Groups */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Prayer Groups</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The foundational unit of the CCR. Prayer groups typically meet weekly for 1&ndash;2
+                hours and follow a characteristic pattern: charismatic praise and worship songs,
+                spontaneous prayer in tongues (corporate), prophecies and words of knowledge shared
+                with the group, teaching from Scripture, and intercessory prayer. They are open to
+                any Catholic.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                If you are attending for the first time, it is encouraged to go with someone
+                knowledgeable in CCR spirituality who can help you interpret what you experience.
+                A good CCR prayer group will always be linked to a parish and ideally have a
+                priest chaplain or deacon guide.
+              </p>
+
+              <div className="bg-blue-50 p-5 rounded-lg">
+                <p className="text-blue-800 text-sm">
+                  <strong>Pastoral Note</strong>: Bishops&rsquo; Conferences of many countries have
+                  issued pastoral guidelines for CCR prayer groups. Key principles: prayer groups
+                  should be linked to a parish or diocese; charisms should be exercised in an
+                  ordered, not disruptive, way (1 Cor 14:40 &mdash; &ldquo;let all things be done
+                  decently and in order&rdquo;); formation in Catholic doctrine is essential alongside
+                  any charismatic experience.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Covenant Communities */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Covenant Communities</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                More committed forms of CCR life in which members live in proximity, pool some
+                resources, meet regularly for formation and prayer, and commit to one another in
+                formal covenants. These are not religious orders &mdash; members are laypeople,
+                priests, and deacons living in the world &mdash; but they involve a significant
+                communal commitment.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Major Covenant Communities
+                </h3>
+                <ul className="space-y-2 text-amber-800 text-sm">
+                  <li><strong>Emmanuel Community</strong> (France, 1972; now worldwide; ~12,000 members) &mdash; known for its integration of contemplation, evangelization, and mercy for the poor</li>
+                  <li><strong>Chemin Neuf</strong> (Lyon, France; 1973) &mdash; ecumenical in spirit, with Protestant members alongside Catholics, active in family ministry and formation</li>
+                  <li><strong>Word of God</strong> (Ann Arbor, Michigan; 1967) &mdash; the original large covenant community; pioneered LSS and CCR formation materials</li>
+                  <li><strong>Sword of the Spirit</strong> (international network; 1982) &mdash; includes both Catholic and Protestant communities in formal association</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Covenant communities are not for everyone. They require genuine commitment and
+                should be entered only after discernment, ideally under the guidance of a spiritual
+                director. Visiting a community&rsquo;s retreat or conference before making any
+                commitment is strongly recommended.
+              </p>
+            </div>
+
+            {/* Card 4: Discernment Criteria */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Discernment Criteria and Cautions</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Church does not require anyone to seek charismatic experiences. They are
+                freely given by the Spirit. You do not need to speak in tongues to be holy.
+                The following criteria help distinguish a genuinely Catholic CCR community from
+                one that has drifted:
+              </p>
+
+              <div className="space-y-4 mb-6">
+                <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+                  <span className="text-amber-700 font-bold text-lg mt-0.5">1</span>
+                  <div>
+                    <p className="font-semibold text-gray-800">Parish Connection</p>
+                    <p className="text-gray-600 text-sm">A sound CCR prayer group has a chaplain (priest or deacon) or is formally linked to a parish priest. Isolation from the local Church is a warning sign.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+                  <span className="text-amber-700 font-bold text-lg mt-0.5">2</span>
+                  <div>
+                    <p className="font-semibold text-gray-800">Order in Prayer</p>
+                    <p className="text-gray-600 text-sm">1 Cor 14:40 &mdash; &ldquo;let all things be done decently and in order.&rdquo; Genuine CCR prayer is fervent but not chaotic; it builds up the community rather than overwhelming individuals.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+                  <span className="text-amber-700 font-bold text-lg mt-0.5">3</span>
+                  <div>
+                    <p className="font-semibold text-gray-800">Catholic Doctrinal Formation</p>
+                    <p className="text-gray-600 text-sm">Formation in the Catechism, sacramental theology, Mariology, and Church history must accompany any charismatic experience. Experience without doctrine is unstable.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+                  <span className="text-amber-700 font-bold text-lg mt-0.5">4</span>
+                  <div>
+                    <p className="font-semibold text-gray-800">Full Sacramental Life</p>
+                    <p className="text-gray-600 text-sm">Regular Mass attendance, frequent Confession, and reception of the Eucharist must accompany charismatic experience. Any community that marginalizes the sacraments has drifted from Catholic identity.</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+                  <span className="text-amber-700 font-bold text-lg mt-0.5">5</span>
+                  <div>
+                    <p className="font-semibold text-gray-800">Testing Alleged Prophecy</p>
+                    <p className="text-gray-600 text-sm">1 Thess 5:19&ndash;21 &mdash; &ldquo;do not quench the Spirit... but test everything.&rdquo; Any alleged prophetic word must be measured against Scripture and Church teaching. Private revelation never has the binding force of Scripture or Magisterium.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <p className="text-green-800 italic leading-relaxed">
+                  If you are drawn to explore the CCR, seek out a solid community with good
+                  doctrinal formation. Bring your questions to your pastor or spiritual director.
+                  The test of any spiritual experience is its fruits: &ldquo;love, joy, peace,
+                  patience, kindness, goodness, faithfulness, gentleness, self-control&rdquo;
+                  (Gal 5:22&ndash;23).
+                </p>
+              </div>
+            </div>
+
+            {/* Related Links */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Related Pages</h2>
+              <div className="grid sm:grid-cols-3 gap-4">
+                <a
+                  href="/prayer/overview"
+                  className="flex items-center gap-3 p-4 bg-amber-50 rounded-lg hover:bg-amber-100 transition-colors group"
+                >
+                  <Wind className="w-5 h-5 text-amber-700 flex-shrink-0" />
+                  <div>
+                    <p className="font-semibold text-amber-900 text-sm group-hover:text-amber-800">What Is Prayer?</p>
+                    <p className="text-amber-700 text-xs">Overview of Catholic prayer</p>
+                  </div>
+                  <ArrowRight className="w-4 h-4 text-amber-700 ml-auto" />
+                </a>
+                <a
+                  href="/prayer/contemplative-prayer"
+                  className="flex items-center gap-3 p-4 bg-blue-50 rounded-lg hover:bg-blue-100 transition-colors group"
+                >
+                  <Heart className="w-5 h-5 text-blue-700 flex-shrink-0" />
+                  <div>
+                    <p className="font-semibold text-blue-900 text-sm group-hover:text-blue-800">Contemplative Prayer</p>
+                    <p className="text-blue-700 text-xs">Lectio Divina, mental prayer</p>
+                  </div>
+                  <ArrowRight className="w-4 h-4 text-blue-700 ml-auto" />
+                </a>
+                <a
+                  href="/history/church-divisions"
+                  className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
+                >
+                  <Globe className="w-5 h-5 text-gray-700 flex-shrink-0" />
+                  <div>
+                    <p className="font-semibold text-gray-900 text-sm group-hover:text-gray-800">Church Divisions</p>
+                    <p className="text-gray-600 text-xs">Including Pentecostalism as Protestant tradition</p>
+                  </div>
+                  <ArrowRight className="w-4 h-4 text-gray-700 ml-auto" />
+                </a>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== SOURCES (shown on all tabs) ==================== */}
+        <div className="bg-white rounded-lg shadow-lg p-8 mt-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+          <div className="grid md:grid-cols-2 gap-3 text-sm text-gray-700">
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Lumen Gentium &sect;12</strong> (Vatican II, 1964) &mdash; conciliar foundation for charisms in the Church
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>CCC 799&ndash;801</strong> &mdash; Catholic teaching on charisms; their ordering to the Church&rsquo;s mission
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>CCC 1830&ndash;1832</strong> &mdash; the gifts of the Holy Spirit and their relation to moral life
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>CCC 1302&ndash;1305</strong> &mdash; Confirmation as deepening of baptismal grace; basis for Baptism in the Spirit
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Novo Millennio Ineunte</strong> (John Paul II, 2001) &sect;44 &mdash; spirituality of communion
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>CHARIS Statutes and Decree</strong>, Dicastery for Laity, Family and Life (June 8, 2019)
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Kevin Ranaghan</strong>, <em>Catholic Pentecostals Today</em> (1969) &mdash; primary account of the Duquesne Weekend
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Pope Francis</strong>, Address to CCR, 50th Anniversary, June 4, 2017
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Pope Paul VI</strong>, Address to the International Charismatic Congress, Rome, May 19, 1975
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Cardinal L&eacute;on Suenens</strong>, <em>A New Pentecost?</em> (Darton, Longman & Todd, 1974)
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>Francis Sullivan SJ</strong>, <em>Charisms and Charismatic Renewal</em> (Servant Books, 1982)
+            </div>
+            <div className="p-3 bg-gray-50 rounded">
+              <strong>CDF</strong>, <em>Letter to the Bishops of the Catholic Church on Some Aspects of Christian Meditation</em> (1989) &mdash; broader spiritual discernment principles
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/contemplative-prayer/page.tsx
+++ b/src/app/prayer/contemplative-prayer/page.tsx
@@ -1,0 +1,1276 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Heart,
+  Star,
+  Flame,
+  Wind,
+  AlertTriangle,
+  Scale,
+  Search,
+  ArrowRight,
+  Compass,
+  Cross,
+  Users,
+  Eye,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-is-contemplation'
+  | 'lectio-divina'
+  | 'jesus-prayer'
+  | 'carmelite-tradition'
+  | 'ignatian-prayer'
+  | 'discernment-cautions'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-is-contemplation', label: 'What Is Contemplation?' },
+  { id: 'lectio-divina', label: 'Lectio Divina' },
+  { id: 'jesus-prayer', label: 'The Jesus Prayer' },
+  { id: 'carmelite-tradition', label: 'Carmelite Tradition' },
+  { id: 'ignatian-prayer', label: 'Ignatian Prayer' },
+  { id: 'discernment-cautions', label: 'Discernment & Cautions' },
+]
+
+export default function ContemplativePrayerPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('what-is-contemplation')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Contemplative Prayer
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            From Lectio Divina to the Jesus Prayer, the Carmelite mystics to the Ignatian Exercises &mdash;
+            the rich tradition of Catholic contemplative and mystical prayer.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: WHAT IS CONTEMPLATION? ==================== */}
+        {activeTab === 'what-is-contemplation' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Church's Definition */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Eye className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Understanding of Contemplation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catechism of the Catholic Church devotes an entire section to contemplative prayer,
+                beginning with the words of St. Teresa of &Aacute;vila &mdash; one of the great Doctors of
+                the Church and one of history&rsquo;s most celebrated teachers of prayer. Her definition
+                has become the Church&rsquo;s own:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  CCC 2709 &mdash; Teresa&rsquo;s Definition
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;What is contemplative prayer? St. Teresa answers: &lsquo;Contemplative prayer
+                  [<em>oraci&oacute;n mental</em>] in my opinion is nothing else than a close sharing
+                  between friends; it means taking time frequently to be alone with him who we know
+                  loves us.&rsquo;&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 2709</p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  CCC 2715 &mdash; A Gaze of Faith
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Contemplative prayer is the simple expression of the mystery of prayer. It is a
+                  gaze of faith fixed on Jesus, an attentiveness to the Word of God, a silent love.
+                  It achieves real union with the prayer of Christ to the extent that it makes us
+                  share in his mystery.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 2715</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                These two definitions together capture the essence of the Catholic contemplative
+                tradition: contemplative prayer is relational (between persons), Christocentric (fixed
+                on Jesus), attentive (to the Word), and silent (beyond ordinary verbal communication).
+                It is neither an exotic spiritual technique nor an achievement of spiritual virtuosos
+                &mdash; it is, at root, friendship with God.
+              </p>
+            </div>
+
+            {/* Card 2: Acquired vs. Infused Contemplation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Acquired vs. Infused Contemplation</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The tradition makes an important distinction that helps clarify what we can do and what
+                only God can give:
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">Acquired (Active) Contemplation</h3>
+                  <p className="text-amber-800 text-sm">
+                    A disposition we cultivate &mdash; quieting the mind, stilling distraction, resting
+                    in God&rsquo;s presence. We can grow in this through practice, fidelity to prayer,
+                    and cooperation with grace. It is the fruit of faithful effort over time.
+                  </p>
+                </div>
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-2">Infused (Passive) Contemplation</h3>
+                  <p className="text-purple-800 text-sm">
+                    A gift God gives, not produced by human effort &mdash; what the great mystics
+                    describe as mystical union, the dark night, or transforming love. It cannot be
+                    manufactured or forced; it can only be received with open hands.
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Both are part of the same Catholic tradition. Thomas Aquinas in the <em>Summa Theologiae</em>
+                (II-II, q.180) treats contemplation as the highest form of the Christian life &mdash;
+                not a special vocation for monks, but the natural endpoint of every Christian&rsquo;s
+                journey toward God.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Contemplation vs. Meditation
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  <strong>Meditation</strong> involves active mental work &mdash; thinking, imagining, reasoning
+                  about spiritual truths. It is discursive: it moves from one thought to another.
+                  <strong> Contemplation</strong> is simpler &mdash; a loving, wordless attention to God beyond
+                  concepts, images, and reasoning.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  John of the Cross offers a vivid analogy: meditation is like a child learning to
+                  walk &mdash; much effort, deliberate steps. Contemplation is like a grown person
+                  walking naturally &mdash; the same movement, but now easy, free, and unreflective.
+                  Meditation prepares the soul for contemplation; contemplation is not its replacement
+                  but its ripening.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Apophatic and Kataphatic Traditions */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Apophatic and Kataphatic Traditions</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholic mystical theology recognizes two great approaches to prayer, both ancient,
+                both valid, both ultimately needing each other:
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">Kataphatic Prayer (<em>Via Positiva</em>)</h3>
+                  <p className="text-green-800 text-sm">
+                    Using images, words, feelings, concepts, and created beauty to encounter God.
+                    The Rosary, the Stations of the Cross, Ignatian imaginative contemplation, and
+                    Lectio Divina all draw on kataphatic methods. God is known through what he has
+                    made and revealed.
+                  </p>
+                </div>
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-gray-900 mb-2">Apophatic Prayer (<em>Via Negativa</em>)</h3>
+                  <p className="text-gray-700 text-sm">
+                    Stripping away all images and concepts to rest in the divine darkness &mdash;
+                    approaching God through what he is <em>not</em>, since his reality surpasses every
+                    created category. The apophatic way is found in John of the Cross, the author of
+                    <em> The Cloud of Unknowing</em>, and Pseudo-Dionysius (<em>The Divine Names</em>;
+                    <em> Mystical Theology</em>).
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Both ways are valid; both need each other. The kataphatic approach without apophatic
+                purification risks confusing our images of God with God himself. The apophatic approach
+                without kataphatic grounding risks an empty abstraction. The great Catholic mystics
+                typically move through both.
+              </p>
+            </div>
+
+            {/* Card 4: Contemplation as the Goal of Christian Life */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Contemplation as the Goal of Christian Life</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 2558 reminds us that &ldquo;prayer is the whole life of a Christian&rdquo; &mdash; not an
+                activity alongside other activities, but the animating relationship from which all
+                else flows. Contemplative prayer is not a specialized department of this life; it
+                is its inner depth.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Vatican II: <em>Perfectae Caritatis</em> (1965), &sect;7
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;Those members who are devoted to the contemplative life offer to God a sacrifice
+                  of praise; they illuminate the People of God with the richest fruits of holiness.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  The contemplative orders &mdash; Carmelites, Cistercians, Camaldolese, Carthusians
+                  &mdash; are not spiritual escapists but intercessors at the heart of the Church&rsquo;s
+                  mission. Their prayer sustains the whole Body of Christ.
+                </p>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Little Way: Contemplation for All
+                </h3>
+                <p className="text-green-800 mb-3">
+                  Contemplation is not reserved for monks and nuns. St. Th&eacute;r&egrave;se of Lisieux
+                  showed that a simple, childlike love of God &mdash; her &ldquo;Little Way&rdquo; &mdash; is
+                  itself a form of contemplation available to all the faithful. Her insight was
+                  revolutionary: the ordinary, humble, loving attention to God in the midst of
+                  daily duties is as profound as any mystical experience in a cloister.
+                </p>
+                <p className="text-green-700 text-sm">
+                  Named a Doctor of the Church (1997), Th&eacute;r&egrave;se remains one of the most
+                  widely read spiritual teachers in Catholic history &mdash; precisely because she
+                  made holiness and contemplation accessible.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: LECTIO DIVINA ==================== */}
+        {activeTab === 'lectio-divina' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Name, Meaning, and Origins */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sacred Reading: Name, Meaning, and Origins</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <em>Lectio Divina</em> means &ldquo;Sacred Reading&rdquo; or &ldquo;Divine Reading&rdquo; in Latin.
+                It is a method of praying with Scripture that moves from reading to meditation to
+                prayer to contemplation &mdash; a structured yet deeply personal encounter with the
+                living Word of God.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The roots of <em>Lectio Divina</em> lie among the Desert Fathers of the 3rd and 4th
+                centuries, who practiced <em>ruminatio</em> &mdash; a Latin word meaning &ldquo;chewing&rdquo;
+                or &ldquo;ruminating,&rdquo; as a cow chews its cud. They read the Scriptures slowly,
+                memorizing and repeating passages until the words sank from the mind into the heart.
+                St. Benedict (480&ndash;547) incorporated this practice into the <em>Rule of St. Benedict</em>
+                as a central monastic activity alongside the <em>Opus Dei</em> (the Liturgy of the Hours)
+                and manual labor.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Guigo II: <em>Scala Claustralium</em> (The Ladder of Monks, 12th c.)
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The classic systematic treatment of <em>Lectio Divina</em> comes from the Carthusian
+                  prior Guigo II in his <em>Scala Claustralium</em> (c.1150). Guigo describes four
+                  rungs of a ladder leading from earth to heaven: (1) <strong>Lectio</strong> (reading),
+                  (2) <strong>Meditatio</strong> (meditation), (3) <strong>Oratio</strong> (prayer),
+                  (4) <strong>Contemplatio</strong> (contemplation). A fifth step, <strong>Actio</strong>
+                  (action), is often added in modern presentations.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  Guigo writes: &ldquo;Reading seeks for the sweetness of a blessed life, meditation
+                  perceives it, prayer asks for it, contemplation tastes it.&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: The Four (Five) Steps in Detail */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Search className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Four Steps in Detail</h2>
+              </div>
+
+              <div className="space-y-6">
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-xl font-bold text-amber-800 mb-2">1. Lectio &mdash; Read</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Read a short Scripture passage slowly, attentively, even aloud. Let the words
+                    sink in. Repeat a word or phrase that strikes you. This is different from Bible
+                    study &mdash; you are not analyzing the text but listening to it. The tradition
+                    recommends reading the same short passage several times, unhurriedly, until one
+                    word or phrase catches your attention like a finger on the shoulder.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-blue-400 pl-6">
+                  <h3 className="text-xl font-bold text-blue-800 mb-2">2. Meditatio &mdash; Meditate</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Dwell on the word or phrase. Turn it over in your mind. Ask: what is God saying
+                    to me here? What does this touch in my life? The Church Fathers compared this to
+                    a cow chewing cud &mdash; slowly drawing out all the nourishment from what was
+                    first taken in. There is no hurry; no goal but receptivity. Meditatio is not
+                    biblical analysis; it is allowing Scripture to speak into your particular
+                    situation, history, and heart.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-green-400 pl-6">
+                  <h3 className="text-xl font-bold text-green-800 mb-2">3. Oratio &mdash; Pray</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Respond to God from the heart. If the text brings consolation, offer thanks.
+                    If it brings challenge or conviction, offer that to God honestly. Ask for grace
+                    to live what you have received. <em>Oratio</em> is the turning point from
+                    receptivity to response &mdash; from listening to speaking. It should flow
+                    naturally from what arose in <em>meditatio</em>, not be imposed from outside.
+                    No special words are required; only honesty.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-purple-400 pl-6">
+                  <h3 className="text-xl font-bold text-purple-800 mb-2">4. Contemplatio &mdash; Contemplate</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Simply rest in God&rsquo;s presence. No words, no thoughts &mdash; just loving
+                    attention. This is not achieved by effort; it is received as a gift. When
+                    <em> oratio</em> becomes wordless and the soul simply rests in God&rsquo;s nearness,
+                    <em> contemplatio</em> has begun. Remain still as long as God holds you there.
+                    Do not force it; do not resist it. Let it come when God gives it.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-400 pl-6">
+                  <h3 className="text-xl font-bold text-gray-700 mb-2">5. Actio &mdash; Act <span className="text-sm font-normal text-gray-500">(Added in modern practice)</span></h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Bring what was received into daily life. What concrete action does God&rsquo;s word
+                    call me to? What must change? What must I do or stop doing? <em>Lectio Divina</em>
+                    that never reaches action risks becoming spiritual self-indulgence. The Word
+                    that enters us in prayer must transform us in living.
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+            {/* Card 3: Vatican II Encouragement and Practical Guidance */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Vatican II&rsquo;s Encouragement & Practical Guidance</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  <em>Dei Verbum</em>, &sect;25 (Dogmatic Constitution on Divine Revelation, 1965)
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;And let them remember that prayer should accompany the reading of Sacred Scripture,
+                  so that God and man may talk together; for &lsquo;we speak to Him when we pray; we
+                  hear Him when we read the divine sayings.&rsquo;&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  The quotation within is from St. Ambrose of Milan &mdash; one of the earliest patristic
+                  articulations of what would later be called <em>Lectio Divina</em>.
+                </p>
+              </div>
+
+              <h3 className="text-xl font-bold text-gray-800 mb-4">Practical Guidance for Beginners</h3>
+
+              <div className="grid md:grid-cols-2 gap-4 mb-6">
+                <div className="bg-amber-50 p-4 rounded-lg">
+                  <p className="font-semibold text-amber-900 mb-1">Start with a prayer</p>
+                  <p className="text-amber-800 text-sm">Invoke the Holy Spirit before beginning. Ask God to speak through his Word and grant understanding.</p>
+                </div>
+                <div className="bg-amber-50 p-4 rounded-lg">
+                  <p className="font-semibold text-amber-900 mb-1">Choose a short passage</p>
+                  <p className="text-amber-800 text-sm">A lectionary passage, a short Gospel scene, or a psalm &mdash; 5 to 15 verses is sufficient. Length is not the point.</p>
+                </div>
+                <div className="bg-amber-50 p-4 rounded-lg">
+                  <p className="font-semibold text-amber-900 mb-1">Use a quality translation</p>
+                  <p className="text-amber-800 text-sm">The NABRE (New American Bible, Revised Edition) or RSV-CE (Revised Standard Version, Catholic Edition) are recommended.</p>
+                </div>
+                <div className="bg-amber-50 p-4 rounded-lg">
+                  <p className="font-semibold text-amber-900 mb-1">20&ndash;30 minutes is sufficient</p>
+                  <p className="text-amber-800 text-sm">Daily consistency matters more than length. A short daily practice is worth far more than occasional long sessions.</p>
+                </div>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Key Distinction
+                </h3>
+                <p className="text-green-800 mb-3">
+                  <em>Lectio Divina</em> is not Bible study. It is not about extracting information,
+                  completing a reading plan, or acquiring theological knowledge. It is about
+                  encountering the living God through his written word. The goal is not to
+                  finish the passage &mdash; it is to let the passage work on you.
+                </p>
+                <p className="text-green-700 text-sm">
+                  A person who spends twenty minutes on a single verse and comes away changed has
+                  practiced <em>Lectio Divina</em> perfectly. A person who races through three
+                  chapters in twenty minutes has done something else entirely.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE JESUS PRAYER ==================== */}
+        {activeTab === 'jesus-prayer' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Prayer Itself */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Prayer of the Heart</h2>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-2xl text-center text-amber-900 font-serif italic mb-3">
+                  &ldquo;Lord Jesus Christ, Son of God, have mercy on me, a sinner.&rdquo;
+                </p>
+                <p className="text-center text-amber-700 text-sm">
+                  In Greek: <em>K&yacute;rie I&emacr;so&ucirc; Christe, Hu&iacute;e Theo&ucirc;, el&eacute;is&oacute;n me t&oacute;n hamartolon.</em>
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Jesus Prayer is a complete act of faith, adoration, and contrition compressed
+                into a single breath. In its few words it encompasses the whole of Christian theology:
+                the lordship of Christ, the Incarnation, the Trinity, the need for grace, and the
+                honest acknowledgment of sin. To pray it attentively &mdash; not mechanically, but
+                with focused heart &mdash; is to make a profound act of faith with every repetition.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Scriptural Roots</h3>
+                <div className="space-y-3">
+                  <p className="text-blue-800 text-sm">
+                    <strong>Bartimaeus (Mark 10:47):</strong> &ldquo;Jesus, Son of David, have mercy on me!&rdquo; &mdash;
+                    the blind man who would not be silenced, whose cry of faith opened his eyes.
+                  </p>
+                  <p className="text-blue-800 text-sm">
+                    <strong>The Tax Collector (Luke 18:13):</strong> &ldquo;God, be merciful to me, a sinner!&rdquo; &mdash;
+                    the prayer Jesus himself praised as justifying before God.
+                  </p>
+                  <p className="text-blue-800 text-sm">
+                    <strong><em>Kyrie Eleison</em> (Lord, have mercy):</strong> The oldest liturgical prayer of
+                    the Church, preserved in every Mass since the earliest centuries.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  CCC 2667 on the Holy Name
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;The invocation of the holy name of Jesus is the simplest way of praying always.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; CCC 2667</p>
+              </div>
+            </div>
+
+            {/* Card 2: Hesychasm and the Philokalia */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Wind className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Hesychasm and the <em>Philokalia</em></h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Jesus Prayer is the heart of the <strong>hesychast</strong> tradition. The Greek
+                word <em>hesychia</em> means &ldquo;stillness,&rdquo; &ldquo;quiet,&rdquo; or &ldquo;inner peace.&rdquo;
+                Hesychasm is the Eastern Christian practice of stilling the passions, focusing the
+                mind in the heart, and using the Jesus Prayer to achieve union with God. It was
+                developed by the Desert Fathers &mdash; Evagrius Ponticus, John Climacus (<em>The
+                Ladder of Divine Ascent</em>) &mdash; and reached its fullest theological expression
+                in the 14th century through Gregory Palamas.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The <em>Philokalia</em> (1782)
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  A collection of writings by Eastern Christian mystics on prayer and the spiritual
+                  life, compiled by St. Nikodemos of the Holy Mountain and St. Makarios of Corinth
+                  (1782). The <em>Philokalia</em> (&ldquo;Love of Beauty&rdquo;) is a foundational text of
+                  hesychasm and one of the great treasures of Christian spiritual literature.
+                </p>
+                <p className="text-purple-700 text-sm">
+                  The <em>Philokalia</em> originates in the Orthodox tradition but is recognized
+                  in Catholic spiritual circles as a valuable resource &mdash; its teaching on
+                  attentiveness, purification of the heart, and union with God is fully consonant
+                  with Catholic mystical theology.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Breath Prayer</h3>
+                <p className="text-amber-800 mb-3">
+                  The Jesus Prayer is traditionally synchronized with breathing: on the inhale,
+                  &ldquo;Lord Jesus Christ, Son of God&rdquo;; on the exhale, &ldquo;have mercy on me, a sinner.&rdquo;
+                  This physio-spiritual technique helps quiet mental distraction and unites body
+                  and soul in prayer. The breathing is not magical &mdash; the value is in the
+                  prayer and the intention, not the technique itself. The body is engaged because
+                  the whole person &mdash; body and soul together &mdash; is called to pray.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: The Way of a Pilgrim and Catholic Context */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800"><em>The Way of a Pilgrim</em> and Catholic Context</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <em>The Way of a Pilgrim</em> is a 19th-century Russian anonymous spiritual classic
+                in which a simple peasant seeks to fulfill St. Paul&rsquo;s command to &ldquo;pray without
+                ceasing&rdquo; (1 Thess 5:17). He learns the Jesus Prayer from a <em>starets</em>
+                (spiritual father) and discovers that, through faithful practice, the prayer moves
+                from his lips to his mind to his heart &mdash; becoming what the tradition calls the
+                <strong> Prayer of the Heart</strong>: a ceaseless interior prayer that eventually continues
+                without conscious effort, like a heartbeat.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Prayer of the Heart</h3>
+                <p className="text-blue-800 mb-3">
+                  In the hesychast tradition, the movement of the Jesus Prayer from lips to mind
+                  to heart is the central goal. &ldquo;Heart&rdquo; here does not mean emotion but the
+                  Biblical sense: the deep center of the person, the seat of the will, where God
+                  and the human person meet. When the prayer descends into the heart, it becomes
+                  a ceaseless orientation of the whole person toward God.
+                </p>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Jesus Prayer in Catholic Spirituality
+                </h3>
+                <p className="text-green-800 mb-3">
+                  The Jesus Prayer is primarily associated with Eastern Christianity (Orthodox and
+                  Eastern Catholic) but is fully compatible with Catholic theology and has been
+                  adopted widely in Western Catholic contemplative circles. It is emphatically not
+                  a mantra in the Eastern religious sense &mdash; it does not aim at emptying the
+                  mind or dissolving the self into an impersonal Absolute. It is a theologically
+                  precise act of Christian faith addressed to a personal God.
+                </p>
+                <p className="text-green-700 text-sm">
+                  To pray it attentively is to make an act of deep faith with every breath: &ldquo;Lord&rdquo;
+                  proclaims his lordship; &ldquo;Jesus Christ&rdquo; confesses the Incarnation; &ldquo;Son of God&rdquo;
+                  affirms the Trinity; &ldquo;have mercy on me&rdquo; acknowledges the need for grace;
+                  &ldquo;a sinner&rdquo; is honest self-knowledge. Every word carries weight.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: CARMELITE TRADITION ==================== */}
+        {activeTab === 'carmelite-tradition' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Carmelite Order */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Flame className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Carmelite Order and Its Origins</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Carmelite Order was founded on Mt. Carmel in present-day Israel by 12th-century
+                Latin Crusaders who gathered around a spring where the prophet Elijah had prayed
+                (1 Kings 18&ndash;19). When the Crusades ended, they returned to Europe and became a
+                mendicant order. Our Lady of Mt. Carmel is their patroness, and the order has always
+                placed Marian devotion at the heart of its spirituality. The Discalced Carmelites
+                (the reformed branch) were founded by St. Teresa of &Aacute;vila and St. John of the
+                Cross in 16th-century Spain.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Three Great Carmelite Doctors
+                </h3>
+                <div className="grid md:grid-cols-3 gap-4">
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">St. Teresa of &Aacute;vila (1515&ndash;1582)</p>
+                    <p className="text-amber-700 text-sm">Co-founder of the Discalced Carmelites; first woman Doctor of the Church (1970); author of <em>The Interior Castle</em>.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">St. John of the Cross (1542&ndash;1591)</p>
+                    <p className="text-amber-700 text-sm">Poet, mystic, Doctor of the Church; author of <em>The Dark Night of the Soul</em> and <em>The Ascent of Mount Carmel</em>.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">St. Th&eacute;r&egrave;se of Lisieux (1873&ndash;1897)</p>
+                    <p className="text-amber-700 text-sm">Doctor of the Church (1997); Co-Patroness of the Missions; author of <em>Story of a Soul</em>.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 2: St. Teresa of Avila */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">St. Teresa of &Aacute;vila: The Interior Castle</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Teresa of &Aacute;vila wrote <em>The Interior Castle</em> (<em>Las Moradas</em>) in 1577
+                &mdash; reportedly in two weeks of intense inspiration. It is widely considered the
+                masterpiece of Western mystical literature. Her central image: the soul is like a
+                crystal castle with seven <em>mansions</em> or dwellings. Prayer is the journey from
+                the outer rooms inward toward the innermost chamber, where God himself dwells.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-4 mb-6">
+                <div className="bg-purple-50 p-4 rounded-lg">
+                  <p className="font-semibold text-purple-900 mb-1">Outer Mansions (1&ndash;3)</p>
+                  <p className="text-purple-800 text-sm">Vocal prayer, penance, beginning of self-knowledge. The soul begins its journey but remains largely exterior.</p>
+                </div>
+                <div className="bg-purple-50 p-4 rounded-lg">
+                  <p className="font-semibold text-purple-900 mb-1">Middle Mansions (4&ndash;5)</p>
+                  <p className="text-purple-800 text-sm">Prayer of recollection, prayer of quiet. Infused graces begin; the soul starts to receive more than it gives.</p>
+                </div>
+                <div className="bg-purple-50 p-4 rounded-lg">
+                  <p className="font-semibold text-purple-900 mb-1">Inner Mansions (6&ndash;7)</p>
+                  <p className="text-purple-800 text-sm">The sixth: mystical betrothal, intense purification, locutions, raptures. The seventh: transforming union &mdash; &ldquo;spiritual marriage.&rdquo;</p>
+                </div>
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <p className="font-semibold text-blue-900 mb-1">Teresa&rsquo;s Four Degrees of Prayer</p>
+                  <p className="text-blue-800 text-sm">Drawing water from a well &rarr; the water wheel &rarr; irrigation channel &rarr; rain from heaven. Each stage: less human effort, more divine gift.</p>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Let nothing disturb you, let nothing frighten you; all things pass away, God
+                  never changes. Patience obtains all things. Nothing is wanting to him who
+                  possesses God. God alone suffices.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; St. Teresa of &Aacute;vila, <em>Bookmark</em></p>
+              </div>
+            </div>
+
+            {/* Card 3: St. John of the Cross */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-gray-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">St. John of the Cross: The Dark Night</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                John of the Cross is the great theologian of mystical purification. His four major
+                works &mdash; <em>The Ascent of Mount Carmel</em>, <em>The Dark Night of the Soul</em>,
+                <em> The Spiritual Canticle</em>, and <em>The Living Flame of Love</em> &mdash; constitute
+                the most rigorous and systematic body of mystical theology in the Catholic tradition.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-gray-900 mb-2">The Dark Night of the Senses</h3>
+                  <p className="text-gray-700 text-sm">
+                    God withdraws consolations from prayer and from life. The soul feels spiritually
+                    dry, confused, bored in prayer &mdash; as if God has abandoned it. In fact, God
+                    is purifying the soul&rsquo;s attachment to spiritual <em>feelings</em>, teaching it
+                    to seek God himself rather than the comfort of God&rsquo;s presence.
+                  </p>
+                </div>
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-gray-900 mb-2">The Dark Night of the Spirit</h3>
+                  <p className="text-gray-700 text-sm">
+                    A deeper purification of the intellect, memory, and will &mdash; the very
+                    faculties of the soul. More painful than the first night; experienced by fewer
+                    souls. Both nights are God&rsquo;s merciful work. Both are painful; both produce
+                    freedom. The soul comes out purified, detached, and capable of union.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Ascent: Active Purification
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  <em>The Ascent of Mount Carmel</em> is John&rsquo;s guide to the active (willed) purification
+                  of the soul &mdash; the dispositions we can choose. Its core principle: detachment
+                  from all that is not God frees the soul to receive all that God wishes to give.
+                </p>
+                <p className="text-amber-700 italic text-sm">
+                  &ldquo;To reach satisfaction in all, desire satisfaction in nothing. To come to possess
+                  all, desire the possession of nothing.&rdquo; &mdash; <em>Ascent</em>, Book I, ch.13
+                </p>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The Carmelite Promise: Not Comfort but Union
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  The Carmelite tradition does not promise that contemplative prayer will be
+                  comfortable. John of the Cross said that the souls who make the most progress
+                  often experience the greatest desolation. The dark nights are not signs of
+                  God&rsquo;s absence &mdash; they are signs of his working. The soul is being
+                  purified for an intimacy it could not otherwise bear.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 4: St. Therese of Lisieux */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">St. Th&eacute;r&egrave;se of Lisieux: The Little Way</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Th&eacute;r&egrave;se Martin entered the Carmelite convent at Lisieux at age 15 and died of
+                tuberculosis at 24. Her autobiography, <em>Story of a Soul</em> (<em>Histoire d&rsquo;une
+                &acirc;me</em>), written under obedience and published posthumously, became one of the
+                most widely read spiritual autobiographies in history. She was named a Doctor of
+                the Church in 1997 and Co-Patroness of the Missions &mdash; remarkable for a woman
+                who never left her convent.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">The &ldquo;Little Way&rdquo;</h3>
+                <p className="text-green-800 mb-3">
+                  Th&eacute;r&egrave;se discovered that holiness did not require heroic external deeds &mdash;
+                  it required childlike trust in God and doing small things with great love.
+                  Her &ldquo;Little Way&rdquo; is the way of spiritual childhood: abandoning oneself completely
+                  to God&rsquo;s mercy, like a small child in the arms of a father.
+                </p>
+                <p className="text-green-700 italic text-sm mb-3">
+                  &ldquo;I have always wanted to become a saint... instead of becoming discouraged, I
+                  said to myself: God would not inspire in me desires which could not be realized.&rdquo;
+                  &mdash; <em>Story of a Soul</em>
+                </p>
+                <p className="text-green-700 text-sm">
+                  She found, in her own words, the &ldquo;elevator&rdquo; to holiness &mdash; childlike trust
+                  &mdash; for those who cannot climb the steep staircase of traditional asceticism.
+                  The Little Way is itself a form of contemplation: a continuous, loving attentiveness
+                  to God in the midst of the ordinary.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: IGNATIAN PRAYER ==================== */}
+        {activeTab === 'ignatian-prayer' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Ignatius and the Spiritual Exercises */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Ignatius of Loyola and the <em>Spiritual Exercises</em></h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                St. Ignatius of Loyola (1491&ndash;1556) was a Basque soldier wounded at the Battle of
+                Pamplona in 1521. During his long recovery, he read the life of Christ and the lives
+                of the saints &mdash; and experienced a profound conversion. He founded the Society
+                of Jesus (the Jesuits) in 1540, and his <em>Spiritual Exercises</em>, written between
+                1522 and 1548, were approved by Pope Paul III in 1548. They remain one of the most
+                widely used instruments of spiritual formation in the Catholic Church.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Principle and Foundation</h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;Man is created to praise, reverence, and serve God our Lord, and by this means
+                  to save his soul. The other things on the face of the earth are created for man
+                  to help him in attaining the end for which he is created.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; <em>Spiritual Exercises</em>, &sect;23</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The <em>Spiritual Exercises</em> are a 4-week intensive retreat format &mdash; or, as the
+                &ldquo;19th Annotation,&rdquo; a retreat spread over 30 weeks for those in ordinary life
+                who cannot make a residential retreat. Their purpose is the deepening of one&rsquo;s
+                relationship with God, discernment of vocation, and making decisions in accord
+                with God&rsquo;s will.
+              </p>
+            </div>
+
+            {/* Card 2: The Four Weeks */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Four Weeks</h2>
+              </div>
+
+              <div className="space-y-4">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">Week 1 &mdash; Foundation, Sin, and Mercy</h3>
+                  <p className="text-amber-800 text-sm">
+                    The Principle and Foundation; examination of conscience; meditation on sin and
+                    its consequences; receiving God&rsquo;s mercy. The soul begins by understanding
+                    its dependence on God and the radical disorder of sin, so that it can receive
+                    mercy with genuine gratitude.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Week 2 &mdash; The Life and Ministry of Christ</h3>
+                  <p className="text-blue-800 text-sm">
+                    Imaginative contemplation of the life of Christ; the Two Standards (of Christ
+                    vs. the devil); the Three Classes of Persons; the Three Degrees of Humility;
+                    discernment of spirits. This week is especially focused on deepening the
+                    retreatant&rsquo;s desire to follow Christ.
+                  </p>
+                </div>
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-2">Week 3 &mdash; The Passion of Christ</h3>
+                  <p className="text-purple-800 text-sm">
+                    Contemplating the suffering and death of Christ; deepening identification
+                    with the suffering Lord. The retreatant is invited to grieve with Christ,
+                    to be present at the Passion, and to ask for the grace of compassion.
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">Week 4 &mdash; The Resurrection and Contemplation to Attain Divine Love</h3>
+                  <p className="text-green-800 text-sm">
+                    Contemplating the risen Christ; consolation and joy. The week closes with the
+                    <em> Contemplatio ad Amorem</em> (Contemplation to Attain Divine Love) &mdash;
+                    giving all to God and receiving all from God in return. The most famous prayer
+                    of the Exercises: &ldquo;Take, Lord, and receive all my liberty&hellip;&rdquo;
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 3: Key Methods */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Search className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Key Methods of Ignatian Prayer</h2>
+              </div>
+
+              <div className="space-y-6">
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-amber-800 mb-2">Composition of Place (<em>Compositio Loci</em>)</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Before meditating on a Gospel scene, the retreatant &ldquo;composes&rdquo; the scene in
+                    imagination &mdash; sees the place, hears the sounds, smells the air, feels the
+                    heat or cold. Then enters the scene as a participant. The Gospel does not remain
+                    a distant historical event; it happens <em>around and to</em> the one praying.
+                    This method leverages the imagination &mdash; which Ignatius considered a
+                    God-given capacity &mdash; as a vehicle for genuine encounter with Christ.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-blue-400 pl-6">
+                  <h3 className="text-lg font-bold text-blue-800 mb-2">Application of the Five Senses</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Related to composition of place: meditating through each sense on a Gospel scene.
+                    What do you see? What do you hear? What do you smell and taste? What do you touch?
+                    This engages the whole person &mdash; not just the intellect &mdash; in prayer.
+                    It is especially used to consolidate what was received in earlier meditations
+                    on the same passage.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-purple-400 pl-6">
+                  <h3 className="text-lg font-bold text-purple-800 mb-2">The Colloquy (<em>Coloquio</em>)</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    The intimate conversation with God &mdash; Father, Son, or Holy Spirit &mdash;
+                    at the end of a meditation. Ignatius describes it as speaking &ldquo;as a friend
+                    speaks to a friend&rdquo; &mdash; not formal address but personal, honest conversation.
+                    The retreatant speaks directly to God about what arose in prayer: desires,
+                    fears, gratitude, confusion, love.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-green-400 pl-6">
+                  <h3 className="text-lg font-bold text-green-800 mb-2">Discernment of Spirits</h3>
+                  <p className="text-gray-700 leading-relaxed">
+                    Ignatius&rsquo;s carefully developed rules for distinguishing the interior movements
+                    of <strong>consolation</strong> (from God) and <strong>desolation</strong> (from
+                    the enemy or one&rsquo;s own weakness). Two sets of rules: the First Week rules for
+                    beginners; the Second Week rules for those more advanced. One of the most
+                    practically useful bodies of spiritual teaching in the Church &mdash; widely
+                    taught in spiritual direction today. The <em>Exercises</em> do not merely teach
+                    how to pray; they teach how to read one&rsquo;s own interior life.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 4: Ignatian Prayer Today */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Ignatian Prayer Today</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The <em>Spiritual Exercises</em> were originally designed for a 30-day residential
+                retreat. The 19th Annotation retreat (also called the &ldquo;Retreat in Daily Life&rdquo;
+                or &ldquo;Retreat on the Go&rdquo;) adapts the Exercises for people who cannot leave their
+                ordinary commitments, spreading the four weeks over 30 weeks with daily prayer and
+                regular meetings with a spiritual director.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-4 mb-6">
+                <div className="bg-amber-50 p-4 rounded-lg">
+                  <p className="font-semibold text-amber-900 mb-1">Jesuit Retreat Houses</p>
+                  <p className="text-amber-800 text-sm">Worldwide network offering 8-day directed retreats, individually guided retreats, and thematic programs based on the Exercises.</p>
+                </div>
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <p className="font-semibold text-blue-900 mb-1">Ignatian Spiritual Direction</p>
+                  <p className="text-blue-800 text-sm">One of the most widespread forms of spiritual direction in the Latin Church today. Many trained Ignatian directors work with laity in parishes and retreat centers.</p>
+                </div>
+                <div className="bg-green-50 p-4 rounded-lg">
+                  <p className="font-semibold text-green-900 mb-1">The Daily Examen</p>
+                  <p className="text-green-800 text-sm">A 15-minute daily prayer practice from the Exercises: give thanks, ask for light, review the day, ask for forgiveness, look toward tomorrow. Practiced by millions of Catholics daily.</p>
+                </div>
+                <div className="bg-purple-50 p-4 rounded-lg">
+                  <p className="font-semibold text-purple-900 mb-1">Ignatian Discernment</p>
+                  <p className="text-purple-800 text-sm">The Exercises&rsquo; rules for discernment of spirits have become a standard resource in Catholic pastoral formation, seminary training, and lay spirituality programs.</p>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: DISCERNMENT & CAUTIONS ==================== */}
+        {activeTab === 'discernment-cautions' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Problem */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Authentic Contemplation and the Problem of Counterfeits</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Since the Second Vatican Council, various forms of Eastern-influenced meditation
+                and prayer have entered Catholic spiritual practice &mdash; some compatible with
+                authentic Christian prayer, some genuinely problematic. The desire for contemplative
+                depth is entirely right; the methods used to pursue it require careful discernment.
+                The Church has given clear and careful guidance on this question.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  CDF Letter on Christian Meditation (October 15, 1989)
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The Congregation for the Doctrine of the Faith, under Cardinal Joseph Ratzinger
+                  (later Pope Benedict XVI), issued a <em>Letter to the Bishops of the Catholic Church
+                  on Some Aspects of Christian Meditation</em> (1989). It is a carefully balanced
+                  document: it strongly affirms the validity and beauty of Catholic contemplative
+                  prayer while identifying specific dangers in methods imported from non-Christian
+                  traditions.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  The letter begins: &ldquo;The call to prayer and contemplation that resounds in the
+                  prophets and in the psalms &mdash; &lsquo;Be still and know that I am God&rsquo; (Ps 46:10)
+                  &mdash; has never ceased to find an echo in the hearts of Christians.&rdquo; Its purpose
+                  is guidance, not condemnation.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Centering Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Wind className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Centering Prayer: The Practice and the Concerns</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Centering Prayer is a method developed in the 1970s and 1980s by Fr. Thomas Keating
+                OCSO, Fr. Basil Pennington OCSO, and Fr. Thomas Clarke SJ, drawing on
+                <em> The Cloud of Unknowing</em> (14th century) and the writings of John of the Cross.
+                The practice: choose a &ldquo;sacred word&rdquo; as a symbol of consent to God&rsquo;s presence;
+                sit silently for 20 minutes; whenever thoughts arise, gently return to the sacred word.
+              </p>
+
+              <h3 className="text-xl font-bold text-gray-800 mb-4">Why Theologians Urge Caution (Not Condemnation)</h3>
+
+              <div className="space-y-4 mb-6">
+                <div className="bg-orange-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-orange-900 mb-2">1. CDF Warning on Technique</h4>
+                  <p className="text-orange-800 text-sm">
+                    The 1989 CDF letter warned against methods that use bodily postures or breathing
+                    techniques in ways that <em>mechanically produce</em> spiritual states; against
+                    emptying the mind in a way that is not oriented to a <em>personal</em> God;
+                    against any confusion between the Christian God and an impersonal Absolute.
+                  </p>
+                </div>
+                <div className="bg-orange-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-orange-900 mb-2">2. The Theological Question</h4>
+                  <p className="text-orange-800 text-sm">
+                    Fr. Aidan Nichols OP, Fr. Thomas Dubay SM (<em>Fire Within</em>), and other Catholic
+                    theologians have questioned whether Centering Prayer&rsquo;s passive emptying of the
+                    mind is authentically Carmelite or apophatic &mdash; or whether it risks
+                    fostering a non-personal, non-theistic kind of &ldquo;contemplation.&rdquo;
+                  </p>
+                </div>
+                <div className="bg-orange-50 p-5 rounded-lg">
+                  <h4 className="font-semibold text-orange-900 mb-2">3. The Central Distinction</h4>
+                  <p className="text-orange-800 text-sm">
+                    Authentic Catholic apophatic prayer (John of the Cross) is not about emptying the
+                    mind &mdash; it is about the soul&rsquo;s loving, active attentiveness to a personal
+                    God who transcends all images. The emptiness is not a vacuum but a posture of
+                    loving receptivity toward <em>someone</em>. Some implementations of Centering
+                    Prayer have drifted toward techniques indistinguishable from Transcendental
+                    Meditation or Buddhist mindfulness.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">What the CDF Letter Affirms</h3>
+                <p className="text-blue-800 mb-3">
+                  The same 1989 letter strongly affirms the validity and beauty of Catholic
+                  contemplative prayer. It is an encouragement to seek <em>authentic</em> Christian
+                  mysticism &mdash; not a rejection of contemplation. The letter explicitly commends
+                  the Ignatian method, the Rosary, Lectio Divina, and the Liturgy of the Hours as
+                  reliable forms of Catholic contemplative prayer.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Eastern Meditation and How to Discern */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Scale className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Eastern Practices and How to Discern</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Yoga, Zen sitting, Transcendental Meditation, and secular mindfulness practices
+                are widely used in the West, including by Catholics. The Church does not condemn
+                these practices as inherently evil. The guidance is more nuanced: when any practice
+                is used by Catholics for <em>spiritual</em> purposes, the theological framework
+                matters enormously.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Pastoral Principle</h3>
+                <p className="text-amber-800 mb-3">
+                  A Catholic may use breathing techniques, body postures, or stillness practices
+                  for relaxation or health without adopting the metaphysics of Hinduism or Buddhism.
+                  But a Catholic who practices Zen <em>as a path to enlightenment</em>, or TM
+                  <em> as a means of union with Brahman</em>, is adopting a theological framework
+                  that is not Christianity. The technique and the theology are not always separable
+                  in practice.
+                </p>
+              </div>
+
+              <h3 className="text-xl font-bold text-gray-800 mb-4">Six Questions for Discerning Authentic Catholic Contemplative Practice</h3>
+
+              <div className="space-y-3 mb-6">
+                <div className="flex items-start gap-3 bg-green-50 p-4 rounded-lg">
+                  <ArrowRight className="w-5 h-5 text-green-700 mt-0.5 flex-shrink-0" />
+                  <p className="text-green-800 text-sm"><strong>Is God personal?</strong> Does the practice orient you toward the Father, Son, and Holy Spirit &mdash; or toward an impersonal Absolute or universal consciousness?</p>
+                </div>
+                <div className="flex items-start gap-3 bg-green-50 p-4 rounded-lg">
+                  <ArrowRight className="w-5 h-5 text-green-700 mt-0.5 flex-shrink-0" />
+                  <p className="text-green-800 text-sm"><strong>Is Christ central?</strong> Is the Incarnation, Passion, and Resurrection of Jesus Christ honored as the center of the relationship with God?</p>
+                </div>
+                <div className="flex items-start gap-3 bg-green-50 p-4 rounded-lg">
+                  <ArrowRight className="w-5 h-5 text-green-700 mt-0.5 flex-shrink-0" />
+                  <p className="text-green-800 text-sm"><strong>Is the Eucharist honored?</strong> Does the practice deepen one&rsquo;s participation in the Mass and Eucharist as the summit and source of the Christian life?</p>
+                </div>
+                <div className="flex items-start gap-3 bg-green-50 p-4 rounded-lg">
+                  <ArrowRight className="w-5 h-5 text-green-700 mt-0.5 flex-shrink-0" />
+                  <p className="text-green-800 text-sm"><strong>Is there submission to the Magisterium?</strong> Is the practitioner open to the Church&rsquo;s guidance and willing to submit the practice to theological review?</p>
+                </div>
+                <div className="flex items-start gap-3 bg-green-50 p-4 rounded-lg">
+                  <ArrowRight className="w-5 h-5 text-green-700 mt-0.5 flex-shrink-0" />
+                  <p className="text-green-800 text-sm"><strong>Does it bear good fruit?</strong> Does the practice produce the fruits of the Spirit (Galatians 5:22&ndash;23): love, joy, peace, patience, kindness, goodness, faithfulness, gentleness, self-control?</p>
+                </div>
+                <div className="flex items-start gap-3 bg-green-50 p-4 rounded-lg">
+                  <ArrowRight className="w-5 h-5 text-green-700 mt-0.5 flex-shrink-0" />
+                  <p className="text-green-800 text-sm"><strong>Is there a spiritual director?</strong> Contemplative prayer benefits greatly from the guidance of a trained, orthodox Catholic spiritual director who can evaluate interior movements and correct errors.</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 4: Sources & Further Reading */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sources &amp; Further Reading</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The following primary sources and scholarly works underlie this page.
+                Readers who wish to go deeper will find these indispensable.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">Magisterial &amp; Official</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;2709&ndash;2724 (Contemplative prayer)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;2712&ndash;2719 (Characteristics of contemplation)</li>
+                    <li>CDF, <em>Letter to the Bishops on Some Aspects of Christian Meditation</em> (October 15, 1989)</li>
+                    <li>Vatican II, <em>Dei Verbum</em>, &sect;25 (Scripture and prayer)</li>
+                    <li>Vatican II, <em>Perfectae Caritatis</em>, &sect;7 (The contemplative life)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Primary Sources &mdash; Carmelite</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>St. Teresa of &Aacute;vila, <em>The Interior Castle</em> (1577)</li>
+                    <li>St. Teresa of &Aacute;vila, <em>The Way of Perfection</em></li>
+                    <li>St. John of the Cross, <em>The Ascent of Mount Carmel</em></li>
+                    <li>St. John of the Cross, <em>The Dark Night of the Soul</em></li>
+                    <li>St. John of the Cross, <em>The Spiritual Canticle</em></li>
+                    <li>St. Th&eacute;r&egrave;se of Lisieux, <em>Story of a Soul</em> (1898)</li>
+                    <li>Guigo II, <em>Scala Claustralium</em> (<em>The Ladder of Monks</em>, c.1150)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-3">Primary Sources &mdash; Ignatian &amp; Eastern</h3>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>St. Ignatius of Loyola, <em>The Spiritual Exercises</em> (1522&ndash;1548)</li>
+                    <li>Anonymous, <em>The Way of a Pilgrim</em> (19th century)</li>
+                    <li>Anonymous, <em>The Cloud of Unknowing</em> (14th century)</li>
+                    <li>Pseudo-Dionysius, <em>The Divine Names</em>; <em>Mystical Theology</em></li>
+                    <li>St. Nikodemos and St. Makarios, eds., <em>The Philokalia</em> (1782)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-3">Scholarly &amp; Pastoral</h3>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>Fr. Thomas Dubay SM, <em>Fire Within</em> (Ignatius Press, 1989) &mdash; the definitive Catholic study of Teresa and John of the Cross on prayer</li>
+                    <li>Thomas Merton OCSO, <em>New Seeds of Contemplation</em> (New Directions, 1961)</li>
+                    <li>Thomas Aquinas, <em>Summa Theologiae</em> II-II, q.180 (on contemplative life)</li>
+                    <li>Evelyn Underhill, <em>Mysticism</em> (1911) &mdash; classic scholarly study</li>
+                    <li>Fr. Timothy Gallagher OMV, <em>The Discernment of Spirits</em> (Crossroad, 2005) &mdash; the best modern guide to Ignatian discernment</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="mt-6 bg-gray-50 p-5 rounded-lg">
+                <h3 className="font-semibold text-gray-900 mb-3">Related Pages</h3>
+                <div className="flex flex-wrap gap-3">
+                  <a href="/prayer/overview" className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-900 text-sm font-medium">
+                    <ArrowRight className="w-4 h-4" />
+                    What Is Prayer?
+                  </a>
+                  <a href="/prayer/liturgy-of-hours" className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-900 text-sm font-medium">
+                    <ArrowRight className="w-4 h-4" />
+                    Liturgy of the Hours
+                  </a>
+                  <a href="/mysteries/public-revelation" className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-900 text-sm font-medium">
+                    <ArrowRight className="w-4 h-4" />
+                    Sacred Tradition
+                  </a>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/divine-mercy/page.tsx
+++ b/src/app/prayer/divine-mercy/page.tsx
@@ -1,0 +1,1202 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Heart,
+  Star,
+  Sun,
+  Clock,
+  ScrollText,
+  Lightbulb,
+  Cross,
+  Users,
+  ArrowRight,
+} from 'lucide-react'
+
+type TabId =
+  | 'st-faustina'
+  | 'the-image'
+  | 'the-chaplet'
+  | 'divine-mercy-sunday'
+  | 'diary-passages'
+  | 'theology-of-mercy'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'st-faustina', label: 'St. Faustina' },
+  { id: 'the-image', label: 'The Divine Mercy Image' },
+  { id: 'the-chaplet', label: 'The Chaplet' },
+  { id: 'divine-mercy-sunday', label: 'Divine Mercy Sunday' },
+  { id: 'diary-passages', label: 'Key Diary Passages' },
+  { id: 'theology-of-mercy', label: 'Theology of Mercy' },
+]
+
+export default function DivineMercyPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('st-faustina')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Divine Mercy
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The revelations given to St. Faustina Kowalska, the Divine Mercy image, chaplet,
+            and feast &mdash; and the Church&rsquo;s theology of God&rsquo;s infinite mercy.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: ST. FAUSTINA ==================== */}
+        {activeTab === 'st-faustina' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Life and Call */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Life and Early Call</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Helena Kowalska was born on August 25, 1905, in the village of G&#322;ogowiec, in
+                what was then Russian-occupied Poland. She was the third of ten children born to
+                Marianna and Stanis&#322;aw Kowalski, a poor peasant family of deep faith. From
+                childhood, Helena felt a persistent interior call to religious life, a longing she
+                could not silence even as the family&rsquo;s poverty made entrance into a convent
+                seem impossible.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                After several years of working as a domestic servant to save money for a required
+                dowry, Helena was accepted by the Congregation of the Sisters of Our Lady of Mercy
+                in Warsaw in 1925. She was twenty years old. Upon entering, she received the
+                religious name <strong>Sister Maria Faustina of the Blessed Sacrament</strong>.
+                The congregation&rsquo;s apostolate was the rehabilitation of troubled women and girls
+                &mdash; a fitting setting for someone who would become the messenger of God&rsquo;s
+                mercy to the world.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Key Facts
+                </h3>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Birth</p>
+                    <p className="text-amber-700 text-sm">August 25, 1905, G&#322;ogowiec, Poland (under Russian partition)</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Death</p>
+                    <p className="text-amber-700 text-sm">October 5, 1938, Krak&oacute;w, Poland &mdash; age 33, of tuberculosis</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Religious Congregation</p>
+                    <p className="text-amber-700 text-sm">Sisters of Our Lady of Mercy, Warsaw (entered 1925)</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Canonized</p>
+                    <p className="text-amber-700 text-sm">April 30, 2000, by Pope John Paul II in Rome</p>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Faustina lived an outwardly unremarkable religious life &mdash; obedient, humble,
+                assigned to kitchen and garden work in the congregation&rsquo;s houses in Warsaw,
+                Vilnius, and Krak&oacute;w. Her interior life, however, was extraordinary: a life
+                of mystical visions, locutions, and an intense consciousness of the suffering of
+                Christ and the desperate need of sinners for mercy.
+              </p>
+            </div>
+
+            {/* Card 2: The First Vision and the Mission */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Lightbulb className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The First Vision: Płock, 1931</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On the evening of February 22, 1931, in P&#322;ock, Poland, Faustina received the
+                vision that would define her entire mission. Christ appeared to her clothed in a
+                white garment, with two rays of light streaming from his heart &mdash; one red,
+                one white (pale). He spoke directly to her:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Paint an image according to the pattern you see, with the signature: <em>Jesus,
+                  I trust in You.</em> I desire that this image be venerated, first in your chapel,
+                  and then throughout the world. I promise that the soul that will venerate this
+                  image will not perish.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Diary</em> &sect;47&ndash;48</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This vision established Faustina&rsquo;s central mission: to be the instrument
+                through which God would reveal His mercy to the world in a new and urgent way.
+                The requests were specific and concrete: an image to be painted, a feast to be
+                established, a chaplet to be prayed, and a message to be spread. Faustina began
+                recording these visions and interior locutions in a spiritual diary at the direction
+                of her confessor.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                Faustina continued to receive visions and locutions throughout the remainder of her
+                short life. She recorded them in six notebooks totaling approximately 600 pages,
+                known collectively as the <em>Diary of St. Faustina</em> or <em>Divine Mercy in
+                My Soul</em>. The <em>Diary</em> records not only the visions but Faustina&rsquo;s
+                prayers, interior struggles, and her deep sense of unworthiness alongside an
+                unshakeable trust in God&rsquo;s mercy.
+              </p>
+            </div>
+
+            {/* Card 3: Fr. Sopocko and the Temporary Suppression */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Fr. Michał Sopoćko and the Path to Recognition</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                In Vilnius in 1933, Faustina was assigned Fr. Micha&#322; Sopo&#263;ko as her spiritual
+                director. He was initially skeptical &mdash; a trained theologian and professor
+                at the Stefan Batory University, not easily moved by claims of private revelation.
+                After careful examination of Faustina&rsquo;s visions and spiritual state, he came
+                to believe her experiences were genuine and began to support her mission actively.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                At Fr. Sopo&#263;ko&rsquo;s initiative, the first painting of the Divine Mercy image was
+                commissioned from artist Eugeniusz Kazimirowski in 1934 in Vilnius. This painting,
+                executed under Faustina&rsquo;s guidance and with her corrections, is considered the
+                closest to her description of the original vision. Fr. Sopo&#263;ko also published
+                the first theological articles on the Divine Mercy devotion and worked tirelessly
+                to obtain ecclesiastical approval.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The 1959 Suppression and Its Reversal
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  In 1959, the Holy Office (now the Congregation for the Doctrine of the Faith)
+                  issued a notification cautioning against the widespread dissemination of Faustina&rsquo;s
+                  writings and the associated devotional forms. The notification did not condemn the
+                  devotion outright but expressed concern about the theological formulations in
+                  translations of the <em>Diary</em> that had been circulating.
+                </p>
+                <p className="text-amber-800">
+                  This suppression was reversed in 1978 by Pope Paul VI, following a thorough
+                  theological investigation led in large part by Cardinal Karol Wojty&#322;a, Archbishop
+                  of Krak&oacute;w. The investigation concluded that the concerns had been based on
+                  faulty translations and that the devotion itself was theologically sound. Less than
+                  a year later, Wojty&#322;a became Pope John Paul II &mdash; and became the most
+                  powerful advocate Divine Mercy had ever known.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Beatification and Canonization
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Pope John Paul II beatified Sister Faustina on April 18, 1993 &mdash; the Second
+                  Sunday of Easter, the very Sunday Christ had asked to be the feast of Divine Mercy.
+                  Seven years later, on April 30, 2000, JPII canonized her in St. Peter&rsquo;s Square,
+                  simultaneously declaring Divine Mercy Sunday an observance of the universal Latin
+                  Church. At the canonization, he called her the <em>&ldquo;Apostle of Divine Mercy&rdquo;</em>
+                  and said: &ldquo;By this act of canonization I intend today to pass this message on to
+                  the third millennium.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; JPII, Homily at the Canonization of St. Faustina Kowalska (April 30, 2000)
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: THE IMAGE ==================== */}
+        {activeTab === 'the-image' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Vision */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Vision: What Faustina Saw</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;I saw the Lord Jesus clothed in a white garment. One hand raised in the gesture
+                  of blessing, the other touching the garment at the breast. From beneath the garment,
+                  slightly drawn aside at the breast, there were emanating two large rays, one red,
+                  the other pale.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Diary</em> &sect;47</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The image that Christ requested is one of the most widely recognized devotional
+                images in modern Catholic history. Its essential elements are fixed by the vision
+                itself and by Christ&rsquo;s own explanation: a white-robed Christ, one hand raised
+                in blessing, two rays &mdash; one red, one pale &mdash; emanating from his heart,
+                and the inscription <em>Jezu, ufam Tobie</em> (&ldquo;Jesus, I trust in You&rdquo;).
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The inscription is not optional. Christ specified it in the original vision
+                (<em>Diary</em> &sect;47). The image is not complete &mdash; and the associated
+                promise does not apply &mdash; without the words of trust. This is theologically
+                significant: the image is not a talisman or a lucky charm; it is an icon of a
+                relationship. The promise is tied to trust (<em>ufam Tobie</em>), not to possession
+                of a picture.
+              </p>
+            </div>
+
+            {/* Card 2: The Meaning of the Rays */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Meaning of the Two Rays</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Faustina asked Christ directly what the two rays meant. His answer, recorded in
+                the <em>Diary</em>, is one of the most theologically dense passages in the
+                entire text:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The two rays denote Blood and Water. The pale ray stands for the Water which
+                  makes souls righteous. The red ray stands for the Blood which is the life of
+                  souls... These two rays issued forth from the very depths of My tender mercy
+                  when My agonizing Heart was opened by a lance on the Cross.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Diary</em> &sect;299</p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Blood and Water: Sacramental Theology
+                </h3>
+                <div className="space-y-3">
+                  <div>
+                    <p className="font-semibold text-amber-800">The Red Ray &mdash; Blood</p>
+                    <p className="text-amber-700 text-sm">
+                      The Blood of Christ is the life of souls: it is the Eucharist. The red ray
+                      points to the Most Holy Eucharist and to the Redemption accomplished on the
+                      Cross. John 19:34 records that blood and water flowed from Christ&rsquo;s pierced
+                      side. The Fathers (especially Augustine) read this as the birth of the Church
+                      and the sacraments from Christ&rsquo;s side, as Eve was formed from Adam&rsquo;s side.
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800">The Pale Ray &mdash; Water</p>
+                    <p className="text-amber-700 text-sm">
+                      The Water that makes souls righteous is Baptism &mdash; and by extension,
+                      Confession, through which baptismal grace is restored. The pale ray signifies
+                      the cleansing, sanctifying action of grace in the soul. Together, Blood and
+                      Water encapsulate the entire sacramental economy of salvation.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                This identification connects the Divine Mercy image directly to John 19:34 and
+                to the ancient patristic tradition of reading the pierced side of Christ as the
+                source of Baptism (water) and Eucharist (blood) &mdash; the two foundational
+                sacraments of Christian life. The image is thus not a novelty but a visual
+                summary of the Church&rsquo;s oldest sacramental theology.
+              </p>
+            </div>
+
+            {/* Card 3: Approved Images */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Official Images and Their Differences</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Two paintings have the most widespread devotional use, each with distinct
+                characteristics:
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">The Vilnius Painting (1934)</h3>
+                  <p className="text-amber-700 text-sm mb-2">
+                    Painted by Eugeniusz Kazimirowski under Faustina&rsquo;s direct guidance and with
+                    her corrections. Considered the closest to Faustina&rsquo;s actual vision; the face
+                    of Christ is more sorrowful and contemplative. Now venerated in the Church of
+                    the Holy Trinity, Vilnius, Lithuania.
+                  </p>
+                  <p className="text-amber-600 text-xs">Generally regarded as the most historically authentic rendition.</p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">The Ł&oacute;d&oacute; Image (Adolf Hy&#322;a, 1943)</h3>
+                  <p className="text-blue-700 text-sm mb-2">
+                    The most widely distributed version worldwide. Painted by Adolf Hy&#322;a, it
+                    depicts Christ with a slightly different posture and a more serene expression.
+                    This is the version most commonly seen in Catholic homes, churches, and
+                    devotional materials globally.
+                  </p>
+                  <p className="text-blue-600 text-xs">The de facto &ldquo;standard&rdquo; image in popular Catholic devotion.</p>
+                </div>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  What Is and Is Not Essential
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  Variations in artistic style are acceptable. What is essential is: (1) Christ
+                  in a white garment; (2) the two rays emanating from the region of his heart
+                  &mdash; one red, one pale; (3) the inscription &ldquo;Jesus, I trust in You&rdquo; in any
+                  language. Christ himself said of the image (<em>Diary</em> &sect;570):
+                </p>
+                <p className="text-purple-800 italic mb-2">
+                  &ldquo;I am offering people a vessel with which they are to keep coming for graces
+                  to the fountain of mercy. That vessel is this image with the signature:
+                  &lsquo;Jesus, I trust in You.&rsquo;&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  A Word of Caution
+                </h3>
+                <p className="text-amber-800">
+                  This image is not magic. Christ&rsquo;s promise is tied to trust (<em>ufam Tobie</em>).
+                  The devotion is an invitation to deeper sacramental participation &mdash; especially
+                  Confession and the Eucharist &mdash; not a talisman to be acquired for passive
+                  protection. As with all Marian and saintly images, the image points beyond itself
+                  to the living Person of Christ and to the Church&rsquo;s sacramental life.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE CHAPLET ==================== */}
+        {activeTab === 'the-chaplet' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Origin */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Origin of the Chaplet</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Chaplet of Divine Mercy was given to Faustina in a vision recorded in her
+                <em> Diary</em> entries 474&ndash;476, in September 1935. She was praying for a
+                soul in agony, and then had a vision of an angel about to execute divine punishment
+                upon the earth. She began praying interiorly and found that the chaplet&rsquo;s words
+                arose in her, and the angel was unable to carry out the punishment. Christ later
+                confirmed the chaplet to her, instructing her in its recitation and its purpose:
+                to placate divine justice and draw souls into the ocean of His mercy.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Encourage souls to say the chaplet which I have given you. Whoever will recite
+                  it will receive great mercy at the hour of death. Priests will recommend it to
+                  sinners as their last hope of salvation. Even if there were a sinner most
+                  hardened, if he were to recite this chaplet only once, he would receive grace
+                  from My infinite mercy.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Diary</em> &sect;687</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The chaplet is prayed on ordinary rosary beads and can be completed in approximately
+                ten to fifteen minutes. Unlike the Rosary, it does not require meditation on
+                mysteries &mdash; it is a single sustained act of offering Christ&rsquo;s suffering to
+                the Father, pleading His mercy for the world. Its theology is profoundly
+                Christocentric and priestly: the one praying joins in Christ&rsquo;s own self-offering.
+              </p>
+            </div>
+
+            {/* Card 2: How to Pray */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">How to Pray the Chaplet</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The chaplet is prayed on a standard five-decade rosary. The following is the
+                complete form as given in the <em>Diary</em> and approved by the Church:
+              </p>
+
+              <div className="space-y-4">
+
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <p className="font-semibold text-amber-900 mb-2">Opening (Optional but Traditional)</p>
+                  <p className="text-amber-800 text-sm italic mb-3">
+                    Begin with an Our Father, a Hail Mary, and the Apostles&rsquo; Creed. Some also
+                    pray the following opening prayer (said three times):
+                  </p>
+                  <p className="text-amber-800 text-sm italic">
+                    &ldquo;You expired, Jesus, but the source of life gushed forth for souls, and the
+                    ocean of mercy opened up for the whole world. O Fount of Life, unfathomable
+                    Divine Mercy, envelop the whole world and empty Yourself out upon us.&rdquo;
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <p className="font-semibold text-blue-900 mb-2">On Each Large (Our Father) Bead</p>
+                  <p className="text-blue-800 text-sm italic">
+                    &ldquo;Eternal Father, I offer You the Body and Blood, Soul and Divinity of Your
+                    Dearly Beloved Son, Our Lord, Jesus Christ, in atonement for our sins and
+                    those of the whole world.&rdquo;
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <p className="font-semibold text-purple-900 mb-2">On Each Small (Hail Mary) Bead &mdash; said 10 times per decade</p>
+                  <p className="text-purple-800 text-sm italic">
+                    &ldquo;For the sake of His sorrowful Passion, have mercy on us and on the whole world.&rdquo;
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <p className="font-semibold text-green-900 mb-2">Concluding Doxology &mdash; said three times</p>
+                  <p className="text-green-800 text-sm italic">
+                    &ldquo;Holy God, Holy Mighty One, Holy Immortal One, have mercy on us and on the whole world.&rdquo;
+                  </p>
+                </div>
+
+                <div className="bg-gray-50 p-5 rounded-lg">
+                  <p className="font-semibold text-gray-900 mb-2">Optional Closing Prayer</p>
+                  <p className="text-gray-700 text-sm italic">
+                    &ldquo;Eternal God, in whom mercy is endless and the treasury of compassion
+                    inexhaustible, look kindly upon us and increase Your mercy in us, that in
+                    difficult moments we might not despair nor become despondent, but with great
+                    confidence submit ourselves to Your holy will, which is Love and Mercy itself.&rdquo;
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+            {/* Card 3: The Hour of Mercy and Promises */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Hour of Mercy: 3:00 p.m.</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Christ asked Faustina to observe the Hour of Mercy at three o&rsquo;clock each
+                afternoon &mdash; the hour of His death on the Cross. The <em>Diary</em> records
+                His words:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;At three o&rsquo;clock, implore My mercy, especially for sinners; and, if only
+                  for a brief moment, immerse yourself in My Passion, particularly in My
+                  abandonment at the moment of agony. This is the hour of great mercy for the
+                  whole world. I will allow you to enter into My mortal sorrow. In this hour,
+                  I will refuse nothing to the soul that makes a request of Me in virtue of My
+                  Passion.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Diary</em> &sect;1320</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                At this hour, Christ requested that those who are able pray the Chaplet, meditate
+                briefly on His Passion, or simply make an act of trust. Even a very brief prayer
+                offered at three o&rsquo;clock with awareness of its significance is pleasing to Him.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Promises Associated with the Chaplet
+                </h3>
+                <ul className="text-amber-800 text-sm space-y-3">
+                  <li>
+                    <strong>At the hour of death</strong> (<em>Diary</em> &sect;687): &ldquo;Whoever will
+                    recite it will receive great mercy at the hour of death.&rdquo;
+                  </li>
+                  <li>
+                    <strong>Near the dying</strong> (<em>Diary</em> &sect;811): &ldquo;When they say this
+                    chaplet in the presence of the dying, I will stand between My Father and the
+                    dying person, not as the just Judge but as the merciful Savior.&rdquo;
+                  </li>
+                  <li>
+                    <strong>For hardened sinners</strong> (<em>Diary</em> &sect;687): &ldquo;Even if there
+                    were a sinner most hardened, if he were to recite this chaplet only once, he
+                    would receive grace from My infinite mercy.&rdquo;
+                  </li>
+                  <li>
+                    <strong>For the world</strong>: The chaplet is intercessory in structure &mdash;
+                    prayed not merely for oneself but &ldquo;for us and on the whole world.&rdquo; This
+                    universal scope sets it apart from many devotional prayers.
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: DIVINE MERCY SUNDAY ==================== */}
+        {activeTab === 'divine-mercy-sunday' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Request */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Request for a Feast</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Among Christ&rsquo;s requests to Faustina, one of the most specific was the
+                establishment of a feast of Divine Mercy on the Sunday after Easter. The request
+                appears repeatedly in the <em>Diary</em>, with increasing urgency:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;I desire that the Feast of Mercy be a refuge and shelter for all souls,
+                  and especially for poor sinners. On that day the very depths of My tender
+                  mercy are open. I pour out a whole ocean of graces upon those souls who
+                  approach the Fount of My Mercy. The soul that will go to Confession and
+                  receive Holy Communion shall obtain complete forgiveness of sins and
+                  punishment.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Diary</em> &sect;699</p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Conditions for the Grace of the Feast
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Christ specified three conditions for receiving &ldquo;complete forgiveness of sins
+                  and punishment&rdquo; on Divine Mercy Sunday:
+                </p>
+                <ol className="text-amber-800 text-sm space-y-2 list-decimal list-inside">
+                  <li><strong>Sacramental Confession</strong> &mdash; within eight days before or after the feast (not necessarily on the day itself)</li>
+                  <li><strong>Holy Communion</strong> &mdash; received on Divine Mercy Sunday with trust and contrition</li>
+                  <li><strong>Veneration of the image with trust</strong> &mdash; approaching with a spirit of complete trust in God&rsquo;s mercy, not in one&rsquo;s own merits</li>
+                </ol>
+                <p className="text-amber-700 text-sm mt-3">
+                  Note: The grace promised is not automatic &mdash; it requires genuine trust,
+                  contrition, and the sacramental dispositions the Church has always required.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Christ compared this grace to the grace of Baptism itself &mdash; a complete
+                wiping clean of sin and its temporal punishment. Such a promise, if genuine, is
+                of enormous pastoral significance: it makes Divine Mercy Sunday the greatest
+                feast for sinners in the entire liturgical year, second in significance only to
+                Easter Sunday itself.
+              </p>
+            </div>
+
+            {/* Card 2: JPII Establishes the Feast */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">John Paul II Establishes the Feast</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On April 30, 2000, at the canonization of St. Faustina in St. Peter&rsquo;s Square,
+                Pope John Paul II declared that Divine Mercy Sunday &mdash; the Second Sunday of
+                Easter &mdash; was to be observed throughout the universal Latin Church. His words
+                were unambiguous:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;From now on throughout the Church this Sunday will be called &lsquo;Divine Mercy
+                  Sunday.&rsquo;&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; JPII, Homily at the Canonization of St. Faustina (April 30, 2000)</p>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Divine Mercy! This is the Easter gift that the Church receives from the risen
+                  Christ and offers to humanity at the dawn of the third millennium.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; JPII, ibid.</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The choice of the Second Sunday of Easter was not arbitrary. It was the precise
+                date Christ had requested through Faustina, and it was already the Sunday on
+                which JPII had beatified her in 1993. The timing also carries deep theological
+                resonance: Divine Mercy Sunday falls at the close of Easter Week &mdash; the
+                greatest week in the Christian calendar. Mercy is the fruit of the Paschal Mystery.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Feast in the Liturgical Calendar
+                </h3>
+                <p className="text-green-800 mb-3">
+                  Since 2000, the Second Sunday of Easter is officially titled <em>Second Sunday
+                  of Easter (or Divine Mercy Sunday)</em> in the Latin Church&rsquo;s liturgical books.
+                  Special Masses are celebrated in parishes worldwide. Major observances take place
+                  at the National Shrine of Divine Mercy in Stockbridge, Massachusetts (USA), at
+                  the Divine Mercy Sanctuary in Krak&oacute;w-&#321;agiewniki (Poland), and in churches
+                  throughout the world.
+                </p>
+                <p className="text-green-700 text-sm">
+                  JPII emphasized at the canonization that the feast was not a Polish or Eastern
+                  European devotion but a gift for the whole Church in every nation.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: The Octave of Easter Connection */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Divine Mercy Sunday and the Paschal Mystery</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Divine Mercy Sunday comes at the close of Easter&rsquo;s octave &mdash; the eight
+                days in which the Church celebrates Easter as a continuous feast. This liturgical
+                placement is theologically deliberate. Mercy is not an alternative to the Paschal
+                Mystery but its direct fruit. The Cross is the supreme act of divine mercy; the
+                Resurrection is its vindication. To celebrate mercy at the close of Easter Week
+                is to proclaim that the same love that drove the Incarnation and the Cross is
+                poured out on sinners who come with trust.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                John Paul II explicitly made this connection in his pontificate&rsquo;s central
+                theological project. His first encyclical, <em>Redemptor Hominis</em> (1979),
+                centered on the redemption as an act of divine mercy. His second, <em>Dives in
+                Misericordia</em> (1980), was devoted entirely to the mercy of God. These were
+                not coincidental themes: JPII believed that the modern world, scarred by
+                totalitarianism, war, and the breakdown of the family, needed above all else to
+                hear of God&rsquo;s mercy before it could hear anything else.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Evangelization and the Feast
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Divine Mercy Sunday has become one of the most effective occasions in the
+                  Catholic calendar for drawing lapsed Catholics back to Confession. The specific
+                  promise of &ldquo;complete forgiveness&rdquo; &mdash; comparable to the grace of Baptism
+                  &mdash; provides a concrete, datable occasion for those who have been away from
+                  the sacraments for years or decades. Many parishes organize special confession
+                  schedules in the week before Divine Mercy Sunday precisely for this purpose.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: DIARY PASSAGES ==================== */}
+        {activeTab === 'diary-passages' && (
+          <div className="space-y-8">
+
+            {/* Card 1: About the Diary */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Diary: <em>Divine Mercy in My Soul</em></h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The <em>Diary of St. Faustina</em>, formally titled <em>Divine Mercy in My Soul</em>,
+                consists of six notebooks containing approximately 600 pages of visions, locutions,
+                prayers, reflections, and interior struggles. Faustina wrote it at the direction
+                of Fr. Sopo&#263;ko and her confessor, and completed her last entries weeks before her
+                death in October 1938.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Publication and Approval
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The <em>Diary</em> was published in its complete form by Marian Press (Stockbridge,
+                  Massachusetts) and carries both a <em>nihil obstat</em> and an <em>imprimatur</em>
+                  from the Archdiocese of Krak&oacute;w &mdash; the formal ecclesiastical declaration
+                  that the work is free from doctrinal or moral error.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  <strong>How to read it:</strong> The <em>Diary</em> is spiritual reading, not Scripture
+                  &mdash; it records the experiences and interior locutions of a mystic, interpreted
+                  through her own perception and language. The Church&rsquo;s approval confirms it
+                  is free from doctrinal error; it does not mean every detail is a literal transcript
+                  of divine speech. Approach it with faith and discernment.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The <em>Diary</em> is numbered by paragraph (entries), and these numbers are
+                cited universally across editions. The ten key passages below represent the
+                theological core of the whole work.
+              </p>
+            </div>
+
+            {/* Card 2: Key Passages */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Ten Key Passages</h2>
+              </div>
+
+              <div className="space-y-6">
+
+                <div className="border-l-4 border-amber-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 47&ndash;48 &mdash; The Founding Vision (Płock, 1931)</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    The first vision of the image: Christ appears with two rays of light and commands
+                    Faustina to have the image painted with the inscription &ldquo;Jesus, I trust in You.&rdquo;
+                    He promises that the soul venerating this image will not perish. <em>This is the
+                    foundation of the entire devotion.</em>
+                  </p>
+                  <p className="text-amber-700 text-xs">Theme: The image and the foundational promise</p>
+                </div>
+
+                <div className="border-l-4 border-blue-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 187 &mdash; The Greater the Sinner</p>
+                  <p className="text-gray-700 text-sm mb-2 italic">
+                    &ldquo;The greater the sinner, the greater the right he has to My mercy.&rdquo;
+                  </p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    One of the most quoted passages in the entire <em>Diary</em>. The logic of
+                    divine mercy inverts human calculation: those who are most broken, most guilty,
+                    most aware of their sin are closest to the source of mercy, not furthest from it.
+                  </p>
+                  <p className="text-blue-700 text-xs">Theme: The infinite accessibility of divine mercy</p>
+                </div>
+
+                <div className="border-l-4 border-purple-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 299 &mdash; The Meaning of the Rays</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    Christ explains that the two rays are Blood and Water: the red ray is the Blood
+                    that is the life of souls (Eucharist); the pale ray is the Water that makes souls
+                    righteous (Baptism and Confession). He connects the rays to the moment His Heart
+                    was pierced by the lance on the Cross (John 19:34). Also contains Christ&rsquo;s
+                    request for the feast.
+                  </p>
+                  <p className="text-purple-700 text-xs">Theme: Sacramental theology; the image and the feast</p>
+                </div>
+
+                <div className="border-l-4 border-green-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entries 474&ndash;476 &mdash; Origin of the Chaplet (September 1935)</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    Faustina prays to stop divine punishment from falling upon sinners and receives
+                    the words of the chaplet in a vision. The angel who was about to execute
+                    punishment is unable to do so when the chaplet prayer arises from Faustina&rsquo;s
+                    soul. Christ confirms the chaplet&rsquo;s origin and its intercessory power.
+                  </p>
+                  <p className="text-green-700 text-xs">Theme: Intercession; the chaplet as shield against punishment</p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 570 &mdash; The Image as a Vessel</p>
+                  <p className="text-gray-700 text-sm mb-2 italic">
+                    &ldquo;I am offering people a vessel with which they are to keep coming for graces
+                    to the fountain of mercy. That vessel is this image with the signature:
+                    &lsquo;Jesus, I trust in You.&rsquo;&rdquo;
+                  </p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    The image is not the object of the devotion but the <em>means</em> of accessing
+                    the fountain of mercy. The metaphor is practical and non-magical: a vessel is
+                    a tool for drawing water, not the source itself.
+                  </p>
+                  <p className="text-amber-700 text-xs">Theme: The instrumentality of the image</p>
+                </div>
+
+                <div className="border-l-4 border-red-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 699 &mdash; The Ocean of Grace on the Feast</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    The specific promise for Divine Mercy Sunday: complete forgiveness of sins and
+                    punishment for those who approach with the proper sacramental dispositions.
+                    Christ describes the feast as &ldquo;a refuge and shelter for all souls, and especially
+                    for poor sinners.&rdquo;
+                  </p>
+                  <p className="text-red-700 text-xs">Theme: Divine Mercy Sunday; the specific promise</p>
+                </div>
+
+                <div className="border-l-4 border-blue-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 811 &mdash; Standing at the Hour of Death</p>
+                  <p className="text-gray-700 text-sm mb-2 italic">
+                    &ldquo;When they say this chaplet in the presence of the dying, I will stand between
+                    My Father and the dying person, not as the just Judge but as the merciful Savior.&rdquo;
+                  </p>
+                  <p className="text-blue-700 text-xs">Theme: The chaplet at the hour of death; Christ as advocate</p>
+                </div>
+
+                <div className="border-l-4 border-purple-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 1146 &mdash; Unfathomable Ocean of Mercy</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    One of Faustina&rsquo;s most lyrical passages on the inexhaustibility of divine mercy.
+                    The ocean metaphor runs throughout the <em>Diary</em>: mercy is not a finite
+                    reservoir but an infinite source that cannot be emptied no matter how many souls
+                    draw from it.
+                  </p>
+                  <p className="text-purple-700 text-xs">Theme: The inexhaustibility of divine mercy</p>
+                </div>
+
+                <div className="border-l-4 border-green-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 1320 &mdash; The Hour of Mercy</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    Christ&rsquo;s instruction on the 3 p.m. Hour of Mercy: &ldquo;At three o&rsquo;clock,
+                    implore My mercy, especially for sinners; and, if only for a brief moment,
+                    immerse yourself in My Passion... This is the hour of great mercy for the
+                    whole world.&rdquo;
+                  </p>
+                  <p className="text-green-700 text-xs">Theme: The daily 3 p.m. observance</p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-5">
+                  <p className="font-semibold text-gray-800 mb-1">Entry 1732 &mdash; The Final Entries (October 1938)</p>
+                  <p className="text-gray-700 text-sm mb-2">
+                    Faustina&rsquo;s last diary entries, written weeks before her death from tuberculosis
+                    on October 5, 1938. &ldquo;Today I was brought into the presence of God&rdquo; &mdash;
+                    her final entries are marked by an extraordinary peace and a complete surrender
+                    to God&rsquo;s will. She died at the age of thirty-three.
+                  </p>
+                  <p className="text-amber-700 text-xs">Theme: Faustina&rsquo;s final surrender; the close of the Diary</p>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: THEOLOGY OF MERCY ==================== */}
+        {activeTab === 'theology-of-mercy' && (
+          <div className="space-y-8">
+
+            {/* Card 1: God Is Mercy */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">&ldquo;God Is Mercy&rdquo;</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catholic theology does not say merely that God <em>shows</em> mercy. It says that
+                mercy is God&rsquo;s most fundamental attribute in his relationship with fallen humanity
+                &mdash; the lens through which every other divine attribute (justice, holiness,
+                power) must be understood in the order of salvation. The Catechism is direct:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Gospel is the revelation in Jesus Christ of God&rsquo;s mercy to sinners.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; CCC 1846</p>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;God is the Father Almighty, whose fatherhood and power shed light on one
+                  another: He shows his fatherly omnipotence by the way he takes care of our
+                  needs; by the filial adoption that he gives us; and lastly by his infinite mercy,
+                  for he displays his power at its height by freely forgiving sins.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; CCC 270</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This is not sentimentality. Catholic theology holds that God&rsquo;s mercy is not
+                a softening of His justice but its fulfillment and surpassing. On the Cross, mercy
+                and justice meet: the debt that justice demanded was paid, so that mercy could
+                flow freely. As Psalm 85:10&ndash;11 puts it: &ldquo;Mercy and truth have met; righteousness
+                and peace have kissed.&rdquo; The Cross is the exact point of their meeting.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The biblical Hebrew word <em>hesed</em> (&ldquo;loving-kindness,&rdquo; &ldquo;steadfast love,&rdquo;
+                &ldquo;covenant mercy&rdquo;) and the New Testament Greek <em>eleos</em> (&ldquo;mercy&rdquo;) are
+                the vocabulary of a relationship: mercy in Scripture is always the mercy of a
+                covenant-keeping God toward His people. Divine Mercy, in the tradition of Faustina
+                and the Church, is this same <em>hesed</em> &mdash; not a generic benevolence but
+                the specific, personal, inexhaustible love of the Father for each individual soul.
+              </p>
+            </div>
+
+            {/* Card 2: Dives in Misericordia */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800"><em>Dives in Misericordia</em> &mdash; JPII (1980)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                <em>Dives in Misericordia</em> (&ldquo;Rich in Mercy,&rdquo; November 30, 1980) was Pope
+                John Paul II&rsquo;s second encyclical and the first papal encyclical ever devoted
+                entirely to the mercy of God. It established mercy not merely as a devotional
+                theme but as the theological center of the Christian understanding of God and
+                of the Church&rsquo;s mission in the modern world.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  Three Key Themes of <em>Dives in Misericordia</em>
+                </h3>
+                <div className="space-y-4">
+                  <div>
+                    <p className="font-semibold text-purple-800 mb-1">1. The Prodigal Son (Luke 15:11&ndash;32)</p>
+                    <p className="text-purple-700 text-sm">
+                      JPII reads the Parable of the Prodigal Son as the supreme expression of
+                      mercy in Scripture: the father who runs to meet his son, who restores his
+                      dignity before the son has finished his confession, who celebrates his
+                      return with total lavishness. This is not the God of minimal obligation but
+                      the God of superabundant gift.
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-purple-800 mb-1">2. Mercy Is Not Sentimentality</p>
+                    <p className="text-purple-700 text-sm">
+                      Mercy does not ignore sin or pretend it did not happen. Mercy acknowledges
+                      the full weight of injustice and then surpasses it with love. Justice is not
+                      abolished by mercy; it is fulfilled at a higher level. JPII explicitly
+                      addresses modern objections that mercy is a form of moral laxity.
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-purple-800 mb-1">3. The Contemporary World&rsquo;s Need</p>
+                    <p className="text-purple-700 text-sm">
+                      Written against the backdrop of the Cold War, communist persecution, and the
+                      moral disintegration of the West, JPII argued that a world that had experienced
+                      the Holocaust, the Gulag, and the threat of nuclear annihilation needed mercy
+                      more than anything else. Only mercy could break the cycle of violence and
+                      counter-violence.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Sacrament of Penance as the &ldquo;Tribunal of Mercy&rdquo;
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  In <em>Reconciliatio et Paenitentia</em> (1984), JPII called the confessional
+                  the &ldquo;tribunal of mercy&rdquo; rather than a court of judgment. The CCC amplifies
+                  this: &ldquo;The whole power of the sacrament of Penance consists in restoring us to
+                  God&rsquo;s grace and joining us with him in an intimate friendship&rdquo; (CCC 1468).
+                  The Sacrament of Penance is not a forensic procedure but a personal encounter
+                  with the merciful Christ &mdash; the same Christ who said to Faustina:
+                  &ldquo;The greater the sinner, the greater the right he has to My mercy.&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Misericordiae Vultus and Francis */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800"><em>Misericordiae Vultus</em> &mdash; Pope Francis (2015)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On April 11, 2015, Pope Francis issued <em>Misericordiae Vultus</em> (&ldquo;The Face
+                of Mercy&rdquo;), the Bull of Indiction for the Extraordinary Jubilee of Mercy
+                (December 8, 2015 &ndash; November 20, 2016). The opening line has become one of
+                the defining sentences of Francis&rsquo;s pontificate:
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Jesus Christ is the face of the Father&rsquo;s mercy.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; <em>Misericordiae Vultus</em> &sect;1</p>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Church&rsquo;s very credibility is seen in how she shows merciful and
+                  compassionate love.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Misericordiae Vultus</em> &sect;10</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Francis&rsquo;s theology of mercy builds directly on JPII&rsquo;s <em>Dives in
+                Misericordia</em>, while adding a characteristic pastoral urgency: the Church
+                must be recognizable as an institution of mercy before it can be heard as a
+                voice of truth. The Year of Mercy (2015&ndash;2016) opened special &ldquo;Holy Doors&rdquo;
+                of mercy in cathedrals and pilgrimage churches worldwide, offered special
+                indulgences, and called confessors to extraordinary pastoral gentleness toward
+                those returning after long absences.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Mercy and the New Evangelization
+                </h3>
+                <p className="text-green-800 mb-3">
+                  Both JPII and Francis identify divine mercy as central to the new evangelization.
+                  The diagnosis is that many people have left the Church not because they reject
+                  God but because they encountered judgment before mercy, law before love, demand
+                  before welcome. The pastoral strategy of leading with mercy is not doctrinal
+                  compromise; it is the re-ordering of encounter with the sequence of the Gospel
+                  itself, in which Jesus received sinners before he called them to repentance.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Cross-Links: Related Pages
+                </h3>
+                <ul className="text-amber-800 text-sm space-y-2">
+                  <li>
+                    <ArrowRight className="inline w-4 h-4 mr-1" />
+                    <a href="/prayer/way-of-the-cross" className="underline hover:text-amber-900">Way of the Cross</a>
+                    &mdash; The Passion from which the rays of mercy flow (John 19:34)
+                  </li>
+                  <li>
+                    <ArrowRight className="inline w-4 h-4 mr-1" />
+                    <a href="/mysteries/public-revelation" className="underline hover:text-amber-900">Public Revelation</a>
+                    &mdash; How private revelation (Faustina) relates to public revelation (Scripture and Tradition)
+                  </li>
+                  <li>
+                    <ArrowRight className="inline w-4 h-4 mr-1" />
+                    <a href="/prayer/overview" className="underline hover:text-amber-900">What Is Prayer?</a>
+                    &mdash; The chaplet and the Hour of Mercy in the context of Christian prayer
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Card 4: Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sources &amp; Further Reading</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The following primary sources and scholarly works underlie this page.
+                Readers who wish to go deeper will find these indispensable.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6">
+
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">Primary Sources &mdash; Faustina</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>St. Faustina Kowalska, <em>Divine Mercy in My Soul</em> (Diary; Marian Press, Stockbridge, MA) &mdash; with <em>nihil obstat</em> and <em>imprimatur</em></li>
+                    <li>Key entries: &sect;&sect;47&ndash;48, 187, 299, 474&ndash;476, 570, 687, 699, 811, 1146, 1320, 1732</li>
+                    <li>Fr. George Kosicki, C.S.B., <em>Trust His Mercy</em> (Marian Press) &mdash; pastoral guide to the Diary</li>
+                  </ul>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Magisterial Documents</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;270, 1422&ndash;1498 (Sacrament of Penance)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;1846&ndash;1848 (Mercy and sin)</li>
+                    <li>Second Vatican Council, <em>Lumen Gentium</em> (1964)</li>
+                    <li>Congregation for the Doctrine of the Faith, Notification on St. Faustina&rsquo;s writings, reversal (1978)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-3">Papal Documents</h3>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>Pope John Paul II, <em>Dives in Misericordia</em> (November 30, 1980)</li>
+                    <li>Pope John Paul II, <em>Reconciliatio et Paenitentia</em> (December 2, 1984)</li>
+                    <li>Pope John Paul II, Homily at the Canonization of St. Faustina Kowalska (April 30, 2000)</li>
+                    <li>Pope Francis, <em>Misericordiae Vultus</em> (April 11, 2015) &mdash; Bull of Indiction for the Jubilee of Mercy</li>
+                  </ul>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-3">Scholarly &amp; Devotional</h3>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>Fr. Seraphim Michalenko, M.I.C., <em>The Life of Faustina Kowalska</em> (Servant Books) &mdash; standard English-language biography</li>
+                    <li>Fr. Ignacy R&oacute;&#380;ycki, theological evaluation of Faustina&rsquo;s writings submitted to the Holy See (1967, published posthumously)</li>
+                    <li>Fr. Micha&#322; Sopo&#263;ko, <em>God Is Mercy</em> &mdash; theological work by Faustina&rsquo;s spiritual director</li>
+                    <li>Marian Fathers of the Immaculate Conception (Marian Press), multiple study guides to <em>Divine Mercy</em> devotion</li>
+                  </ul>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/layout.tsx
+++ b/src/app/prayer/layout.tsx
@@ -1,0 +1,14 @@
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import HistoryNavigation from '@/components/HistoryNavigation'
+
+export default function PrayerLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-primary-cream">
+      <Header />
+      <HistoryNavigation />
+      <main className="pb-12">{children}</main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/prayer/liturgy-of-hours/page.tsx
+++ b/src/app/prayer/liturgy-of-hours/page.tsx
@@ -1,0 +1,1068 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Clock,
+  Sun,
+  Moon,
+  Star,
+  Users,
+  Calendar,
+  Heart,
+  Music,
+  Scroll,
+  Church,
+  Globe,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-is-it'
+  | 'history'
+  | 'the-seven-hours'
+  | 'structure'
+  | 'obligation-and-laity'
+  | 'liturgical-year-connection'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-is-it', label: 'What Is the LOTH?' },
+  { id: 'history', label: 'History' },
+  { id: 'the-seven-hours', label: 'The Seven Hours' },
+  { id: 'structure', label: 'Structure of the Office' },
+  { id: 'obligation-and-laity', label: 'Obligation & Laity' },
+  { id: 'liturgical-year-connection', label: 'The Liturgical Year' },
+]
+
+export default function LiturgyOfHoursPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('what-is-it')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Liturgy of the Hours
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The Divine Office &mdash; the Church&rsquo;s unceasing prayer sanctifying every hour of the day,
+            from the Desert Fathers to Vatican II, from monasteries to smartphones.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: WHAT IS THE LOTH? ==================== */}
+        {activeTab === 'what-is-it' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Basic Definition */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Church&rsquo;s Official Daily Prayer</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Liturgy of the Hours (<em>Liturgia Horarum</em>, also called the Divine Office or
+                <em> Officium Divinum</em>) is the official prayer of the Church sanctifying the hours of
+                the day. It is not private prayer but the public, communal prayer of the Church herself
+                &mdash; second only to the Eucharist in liturgical dignity.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catechism of the Catholic Church &mdash; CCC 1174
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The mystery of Christ, his Incarnation and Passover, which we celebrate in the
+                  Eucharist especially at the Sunday assembly, permeates and transfigures the time of
+                  each day, through the celebration of the Liturgy of the Hours, &lsquo;the divine
+                  office.&rsquo;&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catechism of the Catholic Church &mdash; CCC 1175
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Liturgy of the Hours is intended to become the prayer of the whole People of
+                  God. In it Christ himself &lsquo;continues his priestly work through his Church.&rsquo;&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The primary purpose of the LOTH is the <strong>sanctification of time</strong> itself
+                &mdash; to consecrate time to God. By praying at fixed hours throughout the day, the
+                Church transforms ordinary human time into sacred time, making the whole day a continuous
+                act of worship. This is not a new idea: it is the ancient instinct of every culture that
+                has known God, expressed now in the fullness of Christian revelation.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                Even when prayed alone (as most laypeople do), the LOTH is always the prayer of the
+                universal Church. The priest praying Morning Prayer in his rectory, the religious in her
+                chapel, and the layperson on the subway are all praying the same words at the same hours,
+                united with the whole Church worldwide. It is this universality that distinguishes the
+                Liturgy of the Hours from personal devotional prayer.
+              </p>
+            </div>
+
+            {/* Card 2: The Opus Dei */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Church className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The <em>Opus Dei</em> &mdash; the Work of God</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                St. Benedict of Nursia (480&ndash;547) called the Divine Office the <em>Opus Dei</em>
+                &mdash; the &ldquo;Work of God.&rdquo; In his <em>Rule</em>, nothing was to be preferred to
+                it. For Benedictine monks, the Office is the center around which all other activity
+                revolves. Manual labor, study, and hospitality exist in service of the Opus Dei, not the
+                other way around. This Benedictine insight shaped the entire medieval Western Church and
+                remains the proper ordering of any Christian life.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The LOTH and the Eucharist are the two pillars of the Church&rsquo;s official prayer.
+                <em> Sacrosanctum Concilium</em> (Vatican II, 1963) &sect;&sect;83&ndash;101 treats them
+                together. The Mass is the summit; the LOTH extends the Eucharistic grace throughout the
+                day. Many monasteries celebrate the full Office culminating in a daily Mass &mdash; the
+                two forming a single integrated prayer life, morning to night.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  St. Pius X on the Prayer of Christ
+                </h3>
+                <p className="text-amber-800 italic mb-3">
+                  &ldquo;The Liturgy of the Hours is the prayer of Christ continued in time by the
+                  Church.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  When we pray the Hours, we join the 24-hour unceasing prayer that rises from the Church
+                  across all time zones, offering perpetual praise to the Father through the Son in the
+                  Holy Spirit. The sun never sets on the Church at prayer.
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center">
+                  <Scroll className="w-6 h-6 text-gray-600" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Sources & Further Reading</h2>
+              </div>
+              <ul className="space-y-2 text-gray-700">
+                <li><strong>CCC 1174&ndash;1178</strong> &mdash; The Liturgy of the Hours in the Catechism</li>
+                <li><strong>CCC 2768&ndash;2772</strong> &mdash; The Lord&rsquo;s Prayer and the Hours</li>
+                <li><strong><em>Sacrosanctum Concilium</em> &sect;&sect;83&ndash;101</strong> (Vatican II, 1963) &mdash; The Divine Office</li>
+                <li><strong>GILH</strong> &mdash; General Instruction of the Liturgy of the Hours (Paul VI, 1971)</li>
+                <li><strong><em>Laudis Canticum</em></strong> (Paul VI, 1971) &mdash; Apostolic Constitution promulgating the reformed Office</li>
+                <li><strong>Robert Taft SJ</strong>, <em>The Liturgy of the Hours in East and West</em></li>
+                <li><strong>Aelred Squire OP</strong>, <em>Asking the Fathers</em></li>
+                <li><strong>William Storey</strong>, <em>The Complete Liturgy of the Hours</em></li>
+                <li><strong>Canon 276 &sect;2</strong>, 1983 Code of Canon Law &mdash; Obligation of clergy</li>
+                <li><a href="https://universalis.com" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Universalis.com</a> &mdash; Full LOTH online and app</li>
+                <li><a href="https://divineoffice.org" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">DivineOffice.org</a> &mdash; Free audio recordings of the Hours</li>
+              </ul>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: HISTORY ==================== */}
+        {activeTab === 'history' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Old Testament Roots */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Old Testament & Temple Roots</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Liturgy of the Hours did not begin with Christianity. Its roots reach deep into the
+                Old Testament. Psalm 119:164 establishes the pattern: <em>&ldquo;Seven times a day I praise
+                you.&rdquo;</em> The Temple in Jerusalem had morning and evening sacrifices (<em>tamid</em>)
+                accompanied by psalms and prayer. The daily synagogue prayers &mdash; <em>Shacharit</em>
+                (morning), <em>Mincha</em> (afternoon), and <em>Maariv</em> (evening) &mdash; continued
+                this tradition after the Temple&rsquo;s destruction.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Qumran community (Dead Sea Scrolls, 2nd century BC &ndash; 1st century AD) prayed
+                at fixed hours with extraordinary discipline. Their scrolls reveal a community organized
+                entirely around the rhythm of prayer &mdash; anticipating in remarkable ways the later
+                monastic movement. Fixed-hour prayer was not a Christian innovation; it was the
+                inheritance of a tradition that understood time as belonging to God.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The New Testament Witness</h3>
+                <ul className="space-y-2 text-amber-800 text-sm">
+                  <li><strong>Acts 2:15</strong> &mdash; Peter and John at the Temple at the 9th hour (3 p.m.) for prayer</li>
+                  <li><strong>Acts 3:1</strong> &mdash; &ldquo;They were going up to the Temple at the hour of prayer, the ninth hour&rdquo;</li>
+                  <li><strong>Acts 10:9</strong> &mdash; Peter prays at the 6th hour (noon) on the rooftop &mdash; the hour of his vision</li>
+                  <li><strong>Acts 16:25</strong> &mdash; Paul and Silas pray and sing hymns at midnight in prison</li>
+                  <li><strong>The Didache</strong> (c. 100 AD) &mdash; prescribes saying the Lord&rsquo;s Prayer three times daily</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Card 2: Desert Fathers and Benedict */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Desert Fathers & St. Benedict</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The monks of Egypt and Syria (3rd&ndash;4th centuries) developed extensive prayer schedules
+                &mdash; vigil prayer at night, rising for Matins, praying at the set hours through the
+                day. John Cassian (<em>Conferences</em>, early 5th century) transmitted the Eastern monastic
+                practice to the West, becoming the great bridge between the Desert and the Latin Church.
+                Through Cassian, the practice of the canonical hours entered every Western monastery.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Benedict of Nursia (480&ndash;547) codified the Office in his <em>Rule</em> &mdash; eight
+                Offices per day: Vigils (Matins), Lauds, Prime, Terce, Sext, None, Vespers, Compline. He
+                established the four-week psalter cycle and the norms for how many psalms were sung at
+                each Hour. The <em>Rule</em> governed thousands of monasteries and shaped the entire
+                Western Church&rsquo;s prayer life for over a millennium. Wherever Benedictine monasticism
+                went, the Divine Office went with it.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">The Breviary</h3>
+                <p className="text-blue-800 mb-3">
+                  By the high Middle Ages, the Breviary &mdash; a portable single-volume compilation
+                  of all Office texts &mdash; allowed clergy to pray the Office privately without
+                  requiring choir. This democratized the Office but also individualized it. The
+                  cathedral offices (especially Vespers and Matins) maintained their communal character,
+                  while clerics discharged their obligation alone. Polyphonic choral settings of Vespers
+                  &mdash; Monteverdi (1610), Mozart, Handel &mdash; mark the Office&rsquo;s high cultural
+                  impact on Western music.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                <em>Sacrosanctum Concilium</em> (1963) &sect;&sect;83&ndash;101 called for thorough reform:
+                adapting the Office to modern life, making it accessible to laypeople, and restoring a
+                genuine prayer of the hours rather than an obligation hastily discharged. Paul VI issued
+                the reformed <em>Liturgia Horarum</em> in 1971 (<em>Laudis Canticum</em>), abolishing
+                Prime, reducing the required Nocturns, and creating a four-week psalter cycle. The
+                reformed LOTH is shorter and more manageable without sacrificing the tradition&rsquo;s
+                depth.
+              </p>
+            </div>
+
+            {/* Highlight Box */}
+            <div className="bg-amber-50 border-l-4 border-amber-500 rounded-lg p-8">
+              <h3 className="text-xl font-bold text-amber-900 mb-4">The Indestructible Prayer</h3>
+              <p className="text-amber-800 leading-relaxed">
+                The Office survived the most dramatic cultural and political upheavals of Western history
+                &mdash; the Roman collapse, the medieval crisis, the Reformation, the French Revolution
+                &mdash; because it is not a human institution but the voice of the Church praying through
+                Christ to the Father. Every attempt to extinguish it has failed. It will outlast whatever
+                comes next.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE SEVEN HOURS ==================== */}
+        {activeTab === 'the-seven-hours' && (
+          <div className="space-y-8">
+
+            {/* Intro */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Seven Canonical Hours</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed">
+                The reformed LOTH has seven canonical Hours. Together they sanctify the entire arc of the
+                day &mdash; from the first light of morning through the silence of night. Each Hour has
+                its own theological character, its own dominant scriptural canticle, and its own place in
+                the rhythm of prayer.
+              </p>
+            </div>
+
+            {/* Office of Readings */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">1. Office of Readings</h2>
+                <span className="text-sm text-gray-500 italic">(<em>Officium Lectionis</em>, formerly Matins)</span>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                May be prayed at any hour of the day or even anticipated the night before as a Vigil.
+                This flexibility reflects the Hour&rsquo;s contemplative character &mdash; it is primarily
+                an act of deep listening rather than a time-specific ritual.
+              </p>
+
+              <div className="bg-purple-50 p-5 rounded-lg mb-4">
+                <h3 className="font-semibold text-purple-900 mb-2">Contents:</h3>
+                <ul className="text-purple-800 text-sm space-y-1">
+                  <li>Opening verse &bull; Hymn &bull; Three psalms with antiphons</li>
+                  <li>Versicle and response</li>
+                  <li><strong>Two long readings</strong>: one from Scripture, one from the Fathers/saints</li>
+                  <li>Responsory &bull; Closing prayer</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The richest Hour for reading and meditation. Over four years of readings, the Office of
+                Readings presents the entire treasury of patristic, medieval, and modern Catholic thought
+                &mdash; Augustine, Aquinas, Bernard, Teresa of Avila, Newman, and hundreds more.
+              </p>
+            </div>
+
+            {/* Morning Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-yellow-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-yellow-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">2. Morning Prayer (Lauds)</h2>
+                <span className="text-sm text-gray-500 italic">(<em>Laudes Matutinae</em>)</span>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Prayed at sunrise or first light &mdash; historically the most important of the daytime
+                Hours alongside Vespers. <em>Lauds</em> means &ldquo;praise.&rdquo; The morning is the
+                hour of the Resurrection; Lauds consecrates the new day to God.
+              </p>
+
+              <div className="bg-yellow-50 p-5 rounded-lg mb-4">
+                <h3 className="font-semibold text-yellow-900 mb-2">Contents:</h3>
+                <ul className="text-yellow-800 text-sm space-y-1">
+                  <li>Opening verse &bull; Hymn</li>
+                  <li>Psalms: always including a morning psalm and an OT canticle</li>
+                  <li>Short reading &bull; Responsory</li>
+                  <li><strong>The Benedictus</strong> (Canticle of Zechariah, Luke 1:68&ndash;79)</li>
+                  <li>Intercessions &bull; Lord&rsquo;s Prayer &bull; Closing prayer and blessing</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The <strong>Benedictus</strong> is the great morning canticle of the Latin Church:
+                <em> &ldquo;Blessed be the Lord God of Israel, for he has visited and ransomed his
+                people&hellip;&rdquo;</em> (Luke 1:68). Zechariah&rsquo;s song of praise at the birth of
+                John the Baptist has opened the Christian day for fifteen centuries.
+              </p>
+            </div>
+
+            {/* Daytime Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-orange-100 rounded-full flex items-center justify-center">
+                  <Clock className="w-6 h-6 text-orange-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">3. Daytime Prayer (Terce, Sext, None)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                Three optional Hours, any one of which satisfies the obligation of daytime prayer. Each
+                is short &mdash; a hymn, three psalms, a short reading, versicle, and prayer &mdash;
+                taking approximately five to ten minutes.
+              </p>
+
+              <div className="grid md:grid-cols-3 gap-4 mb-4">
+                <div className="bg-orange-50 p-4 rounded-lg">
+                  <h3 className="font-semibold text-orange-900 mb-2">Terce (9 a.m.)</h3>
+                  <p className="text-orange-800 text-sm">
+                    Midmorning. The hour of Pentecost (Acts 2:15) and the beginning of Christ&rsquo;s
+                    trial before Pilate.
+                  </p>
+                </div>
+                <div className="bg-orange-50 p-4 rounded-lg">
+                  <h3 className="font-semibold text-orange-900 mb-2">Sext (Noon)</h3>
+                  <p className="text-orange-800 text-sm">
+                    Midday. The hour of Peter&rsquo;s vision on the rooftop (Acts 10:9) and the hour
+                    the Crucifixion began.
+                  </p>
+                </div>
+                <div className="bg-orange-50 p-4 rounded-lg">
+                  <h3 className="font-semibold text-orange-900 mb-2">None (3 p.m.)</h3>
+                  <p className="text-orange-800 text-sm">
+                    Midafternoon &mdash; the &ldquo;Hour of Mercy,&rdquo; the hour Christ died
+                    (Matt 27:46). The Divine Mercy chaplet echoes this ancient practice.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Evening Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-indigo-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-indigo-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">4. Evening Prayer (Vespers)</h2>
+                <span className="text-sm text-gray-500 italic">(<em>Vesperae</em>)</span>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The &ldquo;hinge&rdquo; Hour of the day alongside Lauds &mdash; the most solemn daytime
+                Hour. Vespers is the Sunday celebration par excellence in the Eastern tradition, and
+                <em> Sacrosanctum Concilium</em> called for its restoration as a communal celebration
+                in the Western Church.
+              </p>
+
+              <div className="bg-indigo-50 p-5 rounded-lg mb-4">
+                <h3 className="font-semibold text-indigo-900 mb-2">Contents:</h3>
+                <ul className="text-indigo-800 text-sm space-y-1">
+                  <li>Opening verse &bull; Hymn</li>
+                  <li>Two psalms and a NT canticle</li>
+                  <li>Short reading &bull; Responsory</li>
+                  <li><strong>The Magnificat</strong> (Luke 1:46&ndash;55, Mary&rsquo;s canticle)</li>
+                  <li>Intercessions (evening; oriented toward the living and the dead)</li>
+                  <li>Lord&rsquo;s Prayer &bull; Prayer and blessing</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The <strong>Magnificat</strong> is the great evening canticle:
+                <em> &ldquo;My soul proclaims the greatness of the Lord&hellip;&rdquo;</em> (Luke 1:46).
+                Mary&rsquo;s song of total self-gift and praise has closed the Christian afternoon for
+                fifteen hundred years. The evening intercessions are richer and more developed than the
+                morning ones, encompassing the Church, the world, the dead, and particular needs.
+              </p>
+            </div>
+
+            {/* Night Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Moon className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">5. Night Prayer (Compline)</h2>
+                <span className="text-sm text-gray-500 italic">(<em>Completorium</em>)</span>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The last prayer before sleep. Night Prayer is short &mdash; roughly ten minutes &mdash;
+                and its texts rotate only within a single week, making it easy to learn. It is the ideal
+                first step for anyone new to the Office.
+              </p>
+
+              <div className="bg-blue-50 p-5 rounded-lg mb-4">
+                <h3 className="font-semibold text-blue-900 mb-2">Contents:</h3>
+                <ul className="text-blue-800 text-sm space-y-1">
+                  <li>Brief examination of conscience &bull; Hymn &bull; One or two psalms &bull; Short reading &bull; Responsory</li>
+                  <li><strong>The Nunc Dimittis</strong> (Simeon&rsquo;s canticle, Luke 2:29&ndash;32)</li>
+                  <li>Antiphon of Our Lady (varies by season: <em>Salve Regina</em> / <em>Alma Redemptoris</em> / <em>Ave Regina Caelorum</em> / <em>Regina Caeli</em>)</li>
+                  <li>Closing blessing</li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The <strong>Nunc Dimittis</strong> &mdash; <em>&ldquo;Lord, now you let your servant go in
+                peace&hellip;&rdquo;</em> (Luke 2:29) &mdash; is Simeon&rsquo;s prayer of readiness to die having
+                seen the Messiah. To end each day with this prayer is to practice the art of dying well:
+                surrendering the day, and ultimately one&rsquo;s life, into the hands of God.
+              </p>
+            </div>
+
+            {/* Highlight Box: Three Canticles */}
+            <div className="bg-amber-50 border-l-4 border-amber-500 rounded-lg p-8">
+              <h3 className="text-xl font-bold text-amber-900 mb-4">The Three Great Canticles</h3>
+              <p className="text-amber-800 leading-relaxed mb-4">
+                The three Gospel canticles mark the three great moments of Christian life:
+              </p>
+              <div className="space-y-3">
+                <p className="text-amber-800">
+                  <strong>Benedictus (dawn)</strong> &mdash; Zechariah&rsquo;s song at the new day,
+                  like the Incarnation breaking into history.
+                </p>
+                <p className="text-amber-800">
+                  <strong>Magnificat (evening)</strong> &mdash; Mary&rsquo;s praise of total
+                  self-gift, the posture of every Christian soul before God.
+                </p>
+                <p className="text-amber-800">
+                  <strong>Nunc Dimittis (night)</strong> &mdash; Simeon&rsquo;s readiness to die
+                  in peace, having seen the Salvation of God.
+                </p>
+              </div>
+              <p className="text-amber-700 mt-4 text-sm italic">
+                The entire arc of Christian life &mdash; Incarnation, self-gift, and peaceful death
+                &mdash; is contained in these three songs prayed each day.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: STRUCTURE OF THE OFFICE ==================== */}
+        {activeTab === 'structure' && (
+          <div className="space-y-8">
+
+            {/* Opening */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Music className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Anatomy of an Hour</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Each Hour shares a common skeleton with variation by season, feast, and weekday. Once
+                you learn the structure, praying any Hour in any season becomes intuitive. Here is the
+                anatomy, element by element.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">The Opening Verse</h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;O God, come to my assistance. O Lord, make haste to help me.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm italic mb-2">
+                  (<em>Deus, in adiutorium meum intende. Domine, ad adiuvandum me festina.</em>)
+                </p>
+                <p className="text-amber-700 text-sm">
+                  Psalm 69:2 &mdash; used since Cassian&rsquo;s time as the opening of every canonical
+                  Hour. This single verse acknowledges our complete dependence on God before every
+                  prayer. Followed by the Glory Be: <em>&ldquo;Glory to the Father and to the Son and to
+                  the Holy Spirit. As it was in the beginning&hellip;&rdquo;</em>
+                </p>
+              </div>
+
+              <div className="space-y-6">
+
+                <div className="border-l-4 border-amber-300 pl-5">
+                  <h3 className="font-semibold text-gray-800 mb-2">The Hymn</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    A brief metrically structured hymn, varying by Hour, day, and season. The ancient
+                    Latin hymns of the breviary &mdash; many written by St. Ambrose of Milan (4th c.)
+                    &mdash; are among the oldest liturgical poetry of the Western Church. These
+                    Ambrosian hymns shaped the entire tradition of Christian hymnody.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-300 pl-5">
+                  <h3 className="font-semibold text-gray-800 mb-2">Psalms and Canticles</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed mb-3">
+                    The heart of the Office. The 150 Psalms are distributed across a four-week psalter
+                    cycle &mdash; no psalm is repeated within a single week. A person praying all Hours
+                    daily prays the entire Psalter in four weeks.
+                  </p>
+                  <p className="text-gray-700 text-sm leading-relaxed mb-3">
+                    <strong>Antiphons</strong>: Short phrases sung before and after each psalm or
+                    canticle, often drawn from the psalm itself or the liturgical feast. They frame the
+                    psalm&rsquo;s meaning for the day, showing how the Church reads the Psalter
+                    christologically.
+                  </p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    <strong>NT Canticles</strong>: The LOTH includes canticles from other OT books (at
+                    Morning Prayer) and from the NT (at Evening Prayer): the Canticle of the Lamb
+                    (Rev 19:1&ndash;7), Ephesians 1:3&ndash;10, Colossians 1:12&ndash;20, and others.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-300 pl-5">
+                  <h3 className="font-semibold text-gray-800 mb-2">The Reading (<em>Lectio Brevis</em>)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    A short Scripture passage (a few verses), varying daily and seasonally. At the Office
+                    of Readings, two longer readings: first from Scripture, second from the Fathers of
+                    the Church, saints&rsquo; writings, or Church documents &mdash; an inexhaustible
+                    treasury spanning two thousand years.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-300 pl-5">
+                  <h3 className="font-semibold text-gray-800 mb-2">The Responsory (<em>Responsorium Breve</em>)</h3>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    A short verse and response, sung or recited, meditating on the reading just
+                    proclaimed. In the monastic tradition, the responsory was chanted at length; in the
+                    reformed Office it is brief but retains its contemplative function.
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+            {/* Gospel Canticles */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">The Gospel Canticles</h2>
+              </div>
+
+              <div className="grid md:grid-cols-3 gap-6">
+                <div className="bg-yellow-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-yellow-900 mb-2">Morning &mdash; Benedictus</h3>
+                  <p className="text-yellow-800 text-sm mb-2">Zechariah (Luke 1:68&ndash;79)</p>
+                  <p className="text-yellow-700 text-sm italic">
+                    &ldquo;Blessed be the Lord God of Israel, for he has visited and ransomed his
+                    people&hellip;&rdquo;
+                  </p>
+                </div>
+                <div className="bg-indigo-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-indigo-900 mb-2">Evening &mdash; Magnificat</h3>
+                  <p className="text-indigo-800 text-sm mb-2">Mary (Luke 1:46&ndash;55)</p>
+                  <p className="text-indigo-700 text-sm italic">
+                    &ldquo;My soul proclaims the greatness of the Lord, my spirit rejoices in God my
+                    savior&hellip;&rdquo;
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Night &mdash; Nunc Dimittis</h3>
+                  <p className="text-blue-800 text-sm mb-2">Simeon (Luke 2:29&ndash;32)</p>
+                  <p className="text-blue-700 text-sm italic">
+                    &ldquo;Lord, now you let your servant go in peace; your word has been
+                    fulfilled&hellip;&rdquo;
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Intercessions and Lord's Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Intercessions, Lord&rsquo;s Prayer & Collect</h2>
+              </div>
+
+              <div className="space-y-4">
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">Morning Intercessions</h3>
+                  <p className="text-green-800 text-sm">
+                    Petitions for the day ahead, the work we will do, those we will encounter. The
+                    morning intercessions consecrate the coming hours to God.
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">Evening Intercessions</h3>
+                  <p className="text-green-800 text-sm">
+                    Richer and more developed &mdash; petitions for the Church, the world, the dead, and
+                    specific needs. Evening prayer carries the accumulated weight of the day and offers
+                    it all to God.
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">The Lord&rsquo;s Prayer</h3>
+                  <p className="text-green-800 text-sm">
+                    Prayed at Morning and Evening Prayer &mdash; the summit of all intercession, as
+                    Christ himself taught it (Matt 6:9&ndash;13; Luke 11:2&ndash;4).
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">Collect (Closing Prayer)</h3>
+                  <p className="text-green-800 text-sm">
+                    The presidential prayer, drawn from the sacramentary, varying daily and seasonally.
+                    It &ldquo;collects&rdquo; the prayers of all who have prayed this Hour and presents
+                    them to the Father through the Son.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Highlight: Patristic Treasury */}
+            <div className="bg-amber-50 border-l-4 border-amber-500 rounded-lg p-8">
+              <h3 className="text-xl font-bold text-amber-900 mb-4">The Patristic Treasury</h3>
+              <p className="text-amber-800 leading-relaxed">
+                The Office of Readings includes texts from the Apostolic Fathers (Clement of Rome,
+                Ignatius, Polycarp), great medieval theologians (Bernard, Aquinas, Bonaventure),
+                Reformation-era saints (Thomas More, Teresa of Avila, John of the Cross), and modern
+                writers (Newman, Th&eacute;r&egrave;se, Edith Stein). Over four years of readings, you
+                encounter the entire tradition of Catholic thought &mdash; not as a historical curiosity
+                but as a living voice addressing you today.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: OBLIGATION & LAITY ==================== */}
+        {activeTab === 'obligation-and-laity' && (
+          <div className="space-y-8">
+
+            {/* Who Is Bound */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Who Is Required to Pray the LOTH</h2>
+              </div>
+
+              <div className="space-y-4">
+                <div className="bg-red-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-red-900 mb-2">Ordained Priests</h3>
+                  <p className="text-red-800 text-sm mb-2">
+                    Bound to pray the full LOTH daily &mdash; all five major Hours (Office of Readings,
+                    Lauds, one daytime Hour, Vespers, Compline) &mdash; by universal law. This obligation
+                    dates to at least the Council of Trent and has been maintained in the 1983 Code of
+                    Canon Law.
+                  </p>
+                  <p className="text-red-700 text-xs italic">Canon 276 &sect;2; GILH &sect;29</p>
+                </div>
+
+                <div className="bg-orange-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-orange-900 mb-2">Permanent Deacons</h3>
+                  <p className="text-orange-800 text-sm mb-2">
+                    Bound to pray Lauds and Vespers daily.
+                  </p>
+                  <p className="text-orange-700 text-xs italic">GILH &sect;29</p>
+                </div>
+
+                <div className="bg-yellow-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-yellow-900 mb-2">Religious (Clergy and Vowed Religious)</h3>
+                  <p className="text-yellow-800 text-sm">
+                    According to their Rule and constitutions. Some are bound to the full Office in
+                    choir; others to certain Hours. The Benedictine tradition binds its members to the
+                    full daily Office &mdash; the Opus Dei &mdash; in community.
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">Laity</h3>
+                  <p className="text-green-800 text-sm mb-2">
+                    <strong>NOT bound by law</strong>; strongly encouraged.
+                  </p>
+                  <p className="text-green-800 text-sm italic mb-2">
+                    <em>Sacrosanctum Concilium</em> &sect;100: &ldquo;Pastors of souls should see to it that
+                    the chief Hours, especially Vespers, are celebrated in common in church on Sundays
+                    and on the more solemn feasts.&rdquo;
+                  </p>
+                  <p className="text-green-800 text-sm italic">
+                    GILH &sect;27: &ldquo;Lay people&hellip; are encouraged to celebrate the Liturgy of
+                    the Hours.&rdquo;
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* How Laypeople Can Pray */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">How Laypeople Can Pray the LOTH</h2>
+              </div>
+
+              <div className="space-y-4 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Start with Night Prayer (Compline)</h3>
+                  <p className="text-blue-800 text-sm">
+                    Very short (&sim;10 minutes). The texts rotate only within a single week &mdash; easy
+                    to learn by heart. Ending the day in the Church&rsquo;s prayer is itself
+                    transformative and is the most widely recommended first step.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Morning and Evening Prayer Minimum</h3>
+                  <p className="text-blue-800 text-sm">
+                    Starting with just Lauds and Vespers is the classic recommendation for those new to
+                    the Office. These two &ldquo;hinge&rdquo; Hours are the most important and most
+                    ancient, and together give the day a clear sacred structure.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">Office of Readings at Any Time</h3>
+                  <p className="text-blue-800 text-sm">
+                    Can be done any time of day &mdash; morning, midday, or before sleep as a Vigil.
+                    Excellent for spiritual reading; the patristic texts alone justify daily prayer of
+                    this Hour.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Physical Forms of the LOTH</h3>
+                <ul className="space-y-2 text-amber-800 text-sm">
+                  <li><strong>4-volume <em>Liturgia Horarum</em></strong> &mdash; The complete Latin edition</li>
+                  <li><strong>4-volume <em>Liturgy of the Hours</em></strong> &mdash; ICEL English translation (1974&ndash;1975); standard for clergy and religious; beautiful but expensive</li>
+                  <li><strong>1-volume <em>Christian Prayer</em></strong> &mdash; Abbreviated form with Lauds, Vespers, Compline, and some Office of Readings; excellent for laypeople; affordable</li>
+                </ul>
+              </div>
+
+              <div className="bg-gray-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-gray-800 mb-3">Digital Resources</h3>
+                <ul className="space-y-2 text-gray-700 text-sm">
+                  <li><strong>iBreviary</strong> (app) &mdash; Full LOTH in multiple languages; free or paid</li>
+                  <li><strong>Universalis</strong> (app/website) &mdash; Beautiful presentation; full Office with audio; subscription</li>
+                  <li><strong>DivineOffice.org</strong> &mdash; Free audio recordings of the Hours prayed communally; very accessible for beginners</li>
+                  <li><strong>Hallow app</strong> &mdash; Includes guided versions of some Hours; popular among younger Catholics</li>
+                  <li><strong>LiturgyoftheHours.app</strong> &mdash; Simple, clean interface; good for those starting out</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Indulgence */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Plenary Indulgence</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed">
+                A plenary indulgence is attached to the communal celebration of Lauds or Vespers (with
+                at least one other person present), with the usual conditions: sacramental Confession,
+                Eucharistic Communion, prayer for the Holy Father&rsquo;s intentions, and detachment from
+                all sin. This is the Church&rsquo;s way of signaling the extraordinary spiritual value
+                she places on the communal prayer of the Hours.
+              </p>
+            </div>
+
+            {/* Highlight */}
+            <div className="bg-amber-50 border-l-4 border-amber-500 rounded-lg p-8">
+              <h3 className="text-xl font-bold text-amber-900 mb-4">Don&rsquo;t Let Complexity Intimidate You</h3>
+              <p className="text-amber-800 leading-relaxed">
+                Start with Night Prayer (Compline) &mdash; it takes 10 minutes, the texts rotate only
+                within a single week, and ending the day in the Church&rsquo;s prayer is itself
+                transformative. Millions of Catholics have discovered the LOTH late in life and wish
+                they had started sooner. The Office is not a spiritual achievement; it is a gift waiting
+                to be received.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: THE LITURGICAL YEAR ==================== */}
+        {activeTab === 'liturgical-year-connection' && (
+          <div className="space-y-8">
+
+            {/* Intro */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Calendar className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The LOTH & the Liturgical Year</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed">
+                The LOTH and the Mass share the same calendar. Every day of the liturgical year &mdash;
+                from Advent through Ordinary Time &mdash; shapes both the Mass readings and the Office.
+                The antiphons, responsories, readings, and hymns of the LOTH all reflect the season.
+                To pray the Office is to live inside the liturgical year with extraordinary intensity.
+              </p>
+            </div>
+
+            {/* Advent and Christmas */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Advent & Christmas</h2>
+              </div>
+
+              <div className="mb-6">
+                <h3 className="font-semibold text-gray-800 mb-3">The O Antiphons (December 17&ndash;23)</h3>
+                <p className="text-gray-700 leading-relaxed mb-4">
+                  The great <em>O Antiphons</em> &mdash; sung before the Magnificat at Vespers on the
+                  seven days before Christmas Eve &mdash; are among the most beautiful texts in the
+                  entire Office. Each begins with &ldquo;O&rdquo; and addresses the Messiah under a
+                  title drawn from the Old Testament:
+                </p>
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <ul className="text-purple-800 text-sm space-y-1">
+                    <li>Dec 17 &mdash; <em>O Sapientia</em> &mdash; O Wisdom</li>
+                    <li>Dec 18 &mdash; <em>O Adonai</em> &mdash; O Lord</li>
+                    <li>Dec 19 &mdash; <em>O Radix Jesse</em> &mdash; O Root of Jesse</li>
+                    <li>Dec 20 &mdash; <em>O Clavis David</em> &mdash; O Key of David</li>
+                    <li>Dec 21 &mdash; <em>O Oriens</em> &mdash; O Rising Sun</li>
+                    <li>Dec 22 &mdash; <em>O Rex Gentium</em> &mdash; O King of Nations</li>
+                    <li>Dec 23 &mdash; <em>O Emmanuel</em> &mdash; O God-with-us, come and save us</li>
+                  </ul>
+                </div>
+                <p className="text-gray-700 text-sm mt-3 italic">
+                  These ancient antiphons are the source of the Advent hymn <em>O Come, O Come
+                  Emmanuel</em>. The initial letters of the titles, read backwards in Latin, spell
+                  &ldquo;ero cras&rdquo; &mdash; &ldquo;I will be there tomorrow.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                At Christmas, the Office of Readings contains both the genealogy from Matthew and the
+                prologue of John (1:1&ndash;18). The Liturgy of the Hours makes Christmas an octave of
+                celebration, not just a single day &mdash; the entire week rings with the mystery of the
+                Incarnation.
+              </p>
+            </div>
+
+            {/* Lent and Holy Week */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-gray-600" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Lent, Holy Week & the Triduum</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                During Lent, the LOTH takes on a penitential character. The <em>Alleluia</em> antiphon
+                is suppressed &mdash; its absence is itself a form of liturgical fasting. The Office of
+                Readings includes patristic meditations on Lenten themes: fasting, baptismal renewal,
+                the slow approach to Easter. Many parishes celebrate Vespers during Lent with the
+                Liturgy of the Hours as communal prayer.
+              </p>
+
+              <div className="bg-gray-50 p-5 rounded-lg mb-4">
+                <h3 className="font-semibold text-gray-800 mb-2">Holy Week & the Triduum</h3>
+                <p className="text-gray-700 text-sm mb-3">
+                  The LOTH in Holy Week is deeply moving. On Good Friday, the Office of Readings
+                  includes Melito of Sardis&rsquo;s <em>Easter Homily</em> (2nd century) &mdash; one of
+                  the most beautiful and theologically rich texts in the entire Office:
+                  <em> &ldquo;He who hung the earth is hanging; he who fixed the heavens has been
+                  fixed&hellip;&rdquo;</em>
+                </p>
+                <p className="text-gray-700 text-sm">
+                  On Holy Saturday morning, Lauds is prayed in the Church&rsquo;s most profound silence
+                  &mdash; the silence of the Tomb, the one day in all history when the Body of Christ lay
+                  still.
+                </p>
+              </div>
+            </div>
+
+            {/* Easter */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-yellow-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-yellow-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Easter, Pentecost & Ordinary Time</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The Easter octave rings with <em>Alleluia</em> suppressed for forty days &mdash; every
+                day is a solemnity. The <em>Regina Caeli</em> (&ldquo;Queen of Heaven, rejoice,
+                Alleluia&rdquo;) replaces the Marian antiphon at Compline throughout the Easter season.
+                At Pentecost, the sequence <em>Veni, Sancte Spiritus</em> is one of the great hymns of
+                the Church; the Office of Readings on Pentecost Sunday includes the full account of
+                Acts 2.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-4">
+                <strong>The Sanctoral Cycle</strong>: Each saint&rsquo;s feast day brings proper
+                antiphons, readings from the saint&rsquo;s writings (or hagiographic texts) in the
+                Office of Readings, and a proper Collect. Over time, praying the LOTH means absorbing
+                the lives and teachings of hundreds of saints &mdash; a continuous apprenticeship in
+                holiness.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                <strong>Sunday Vespers and the Lord&rsquo;s Day</strong>: In the early Church, Sunday
+                Vespers was a major communal celebration &mdash; second only to the Sunday Eucharist.
+                <em> Sacrosanctum Concilium</em> called for its restoration. Where communities celebrate
+                Sunday Vespers, there is a profound sense of the Lord&rsquo;s Day as the
+                &ldquo;eighth day&rdquo; &mdash; a foretaste of eternity, the day that has no evening.
+              </p>
+            </div>
+
+            {/* Cross-links */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Related Topics</h2>
+              </div>
+              <div className="grid sm:grid-cols-3 gap-4">
+                <a
+                  href="/commentary/liturgical-calendar"
+                  className="bg-blue-50 p-4 rounded-lg hover:bg-blue-100 transition-colors"
+                >
+                  <h3 className="font-semibold text-blue-900 mb-1">The Liturgical Calendar</h3>
+                  <p className="text-blue-700 text-sm">Seasons, feasts, and the structure of the Church year</p>
+                </a>
+                <a
+                  href="/history/mass-history"
+                  className="bg-amber-50 p-4 rounded-lg hover:bg-amber-100 transition-colors"
+                >
+                  <h3 className="font-semibold text-amber-900 mb-1">History of the Mass</h3>
+                  <p className="text-amber-700 text-sm">From the Last Supper through the Roman Rite today</p>
+                </a>
+                <a
+                  href="/prayer/overview"
+                  className="bg-green-50 p-4 rounded-lg hover:bg-green-100 transition-colors"
+                >
+                  <h3 className="font-semibold text-green-900 mb-1">What Is Prayer?</h3>
+                  <p className="text-green-700 text-sm">Catholic teaching on the forms and nature of prayer</p>
+                </a>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center">
+                  <Scroll className="w-6 h-6 text-gray-600" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-800">Sources & Further Reading</h2>
+              </div>
+              <ul className="space-y-2 text-gray-700">
+                <li><strong>CCC 1174&ndash;1178</strong> &mdash; The Liturgy of the Hours</li>
+                <li><strong>CCC 2768&ndash;2772</strong> &mdash; The Lord&rsquo;s Prayer in the Hours</li>
+                <li><strong><em>Sacrosanctum Concilium</em> &sect;&sect;83&ndash;101</strong> (Vatican II, 1963)</li>
+                <li><strong>GILH</strong> &mdash; General Instruction of the Liturgy of the Hours</li>
+                <li><strong><em>Laudis Canticum</em></strong> (Paul VI, 1971) &mdash; Apostolic Constitution promulgating the reformed Office</li>
+                <li><strong>Robert Taft SJ</strong>, <em>The Liturgy of the Hours in East and West</em></li>
+                <li><strong>Aelred Squire OP</strong>, <em>Asking the Fathers</em></li>
+                <li><strong>William Storey</strong>, <em>The Complete Liturgy of the Hours</em></li>
+                <li><strong>Canon 276 &sect;2</strong>, 1983 Code of Canon Law</li>
+                <li><a href="https://universalis.com" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Universalis.com</a></li>
+                <li><a href="https://divineoffice.org" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">DivineOffice.org</a></li>
+              </ul>
+            </div>
+
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/marian-devotions/page.tsx
+++ b/src/app/prayer/marian-devotions/page.tsx
@@ -1,0 +1,1004 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Star,
+  Heart,
+  Cross,
+  Sun,
+  Shield,
+  Sparkles,
+  Circle,
+  ArrowRight,
+} from 'lucide-react'
+
+type TabId =
+  | 'angelus'
+  | 'brown-scapular'
+  | 'miraculous-medal'
+  | 'fatima-devotions'
+  | 'ancient-marian-prayers'
+  | 'theology-of-devotion'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'angelus', label: 'The Angelus' },
+  { id: 'brown-scapular', label: 'The Brown Scapular' },
+  { id: 'miraculous-medal', label: 'The Miraculous Medal' },
+  { id: 'fatima-devotions', label: 'Fátima Devotions' },
+  { id: 'ancient-marian-prayers', label: 'Ancient Marian Prayers' },
+  { id: 'theology-of-devotion', label: 'Theology of Marian Devotion' },
+]
+
+export default function MarianDevotionsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('angelus')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Marian Devotions
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The Angelus, Brown Scapular, Miraculous Medal, F&aacute;tima devotions, and the theology
+            behind authentic Catholic devotion to the Mother of God.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: THE ANGELUS ==================== */}
+        {activeTab === 'angelus' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Name and Structure */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Angelus: Name and Structure</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Angelus takes its name from the opening words of the prayer in Latin: <em>Angelus
+                Domini nuntiavit Mariae</em> &mdash; &ldquo;The Angel of the Lord announced to Mary.&rdquo;
+                It is structured as three versicle-and-response pairs (<em>versiculus et responsorium</em>),
+                each followed by a Hail Mary, and concludes with a closing prayer called the
+                <em> collecta</em>. The entire prayer meditates on the Incarnation &mdash; the moment
+                the eternal Son of God became man in Mary&rsquo;s womb.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The three versicle pairs progress through the narrative of the Annunciation: the
+                Angel&rsquo;s announcement, Mary&rsquo;s fiat (her &ldquo;let it be done&rdquo;), and the
+                astounding result &mdash; the Word made flesh. Each pair is a theological proposition
+                answered in assent, punctuated by the Hail Mary as an act of Marian veneration bound
+                to the central mystery. The closing prayer draws out the practical consequence: because
+                God became incarnate, we can be brought through His Passion and Cross to the glory of
+                His Resurrection.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-4">The Prayers of the Angelus</h3>
+
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-amber-800 mb-1">
+                      <strong>V.</strong> The Angel of the Lord declared unto Mary.
+                    </p>
+                    <p className="text-amber-800 mb-2">
+                      <strong>R.</strong> And she conceived of the Holy Spirit.
+                    </p>
+                    <p className="text-amber-700 italic text-sm">Hail Mary&hellip;</p>
+                  </div>
+
+                  <div>
+                    <p className="text-amber-800 mb-1">
+                      <strong>V.</strong> Behold the handmaid of the Lord.
+                    </p>
+                    <p className="text-amber-800 mb-2">
+                      <strong>R.</strong> Be it done unto me according to Thy word.
+                    </p>
+                    <p className="text-amber-700 italic text-sm">Hail Mary&hellip;</p>
+                  </div>
+
+                  <div>
+                    <p className="text-amber-800 mb-1">
+                      <strong>V.</strong> And the Word was made flesh.
+                    </p>
+                    <p className="text-amber-800 mb-2">
+                      <strong>R.</strong> And dwelt among us.
+                    </p>
+                    <p className="text-amber-700 italic text-sm">Hail Mary&hellip;</p>
+                  </div>
+
+                  <div className="border-t border-amber-200 pt-4">
+                    <p className="text-amber-800 mb-1">
+                      <strong>V.</strong> Pray for us, O Holy Mother of God.
+                    </p>
+                    <p className="text-amber-800 mb-4">
+                      <strong>R.</strong> That we may be made worthy of the promises of Christ.
+                    </p>
+                    <p className="text-amber-900 font-medium mb-2">Let us pray:</p>
+                    <p className="text-amber-800 italic">
+                      Pour forth, we beseech Thee, O Lord, Thy grace into our hearts, that we to whom
+                      the Incarnation of Christ Thy Son was made known by the message of an angel, may
+                      by His Passion and Cross be brought to the glory of His resurrection. Through
+                      the same Christ Our Lord. Amen.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  A Daily Memorial of the Incarnation
+                </h3>
+                <p className="text-blue-800">
+                  The Angelus is a daily memorial of the Incarnation &mdash; three times a day, the
+                  Church pauses to recall the moment God became man. It is at once a prayer, a theology
+                  lesson, and an act of worship.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: History */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">History of the Angelus Bell</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The custom of ringing church bells to call the faithful to brief Marian prayer dates
+                to the 12th and 13th centuries. The bell rings three times daily &mdash; at 6 a.m.,
+                noon, and 6 p.m. &mdash; sanctifying the three main parts of the day and weaving the
+                mystery of the Incarnation into the fabric of ordinary time. The practice was gradually
+                codified in the 14th and 15th centuries into the form we know today.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The earliest forms were simpler bell-and-prayer customs associated with the Franciscan
+                and Dominican movements. The full triple versicle structure developed organically as
+                the devotion spread across Europe. Popes from Calixtus III (1456) onward granted
+                indulgences to those who prayed the Angelus, confirming its place in the official
+                devotional life of the Church.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Easter Substitution &mdash; Regina Caeli
+                </h3>
+                <p className="text-amber-800 mb-4">
+                  From Holy Saturday through Pentecost, the Angelus is replaced by the <em>Regina
+                  Caeli</em> (&ldquo;Queen of Heaven&rdquo;), a joyful antiphon that celebrates Christ&rsquo;s
+                  Resurrection: <em>&ldquo;Queen of Heaven, rejoice, alleluia / For He whom you did merit
+                  to bear, alleluia / Has risen as He said, alleluia&hellip;&rdquo;</em> The shift reflects
+                  the liturgical season: during Easter, the Incarnation mystery is celebrated in its
+                  fullest fruit &mdash; the Risen Lord.
+                </p>
+                <p className="text-amber-800">
+                  Pope Francis recites the Regina Caeli (or Angelus during ordinary time) publicly
+                  every Sunday at noon from the window of the Apostolic Palace overlooking St. Peter&rsquo;s
+                  Square, addressing pilgrims and faithful gathered below.
+                </p>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  John Paul II and the Sunday Angelus
+                </h3>
+                <p className="text-green-800">
+                  Pope John Paul II transformed the Sunday Angelus/Regina Caeli into a global catechetical
+                  moment. From the Vatican window, he delivered brief but substantial reflections on
+                  the week&rsquo;s liturgical readings, commenting on world events through a Gospel lens and
+                  greeting pilgrims in dozens of languages. These reflections have been collected in
+                  multiple volumes, representing one of the most accessible bodies of papal teaching
+                  in the modern era.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: THE BROWN SCAPULAR ==================== */}
+        {activeTab === 'brown-scapular' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Vision of St. Simon Stock */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Shield className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Vision of St. Simon Stock</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                According to Carmelite tradition, on July 16, 1251, at Aylesford, England, Our Lady
+                appeared to St. Simon Stock, Prior General of the Carmelite Order. She gave him a
+                scapular &mdash; the distinctive garment of the Carmelite habit &mdash; with a promise
+                that has made this devotion one of the most beloved in Catholic history: <em>&ldquo;Take,
+                beloved son, this scapular of your order as a badge of my confraternity and for you
+                and all Carmelites a special sign of grace; whoever dies in this will not suffer
+                everlasting fire.&rdquo;</em>
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                This promise is known as the <strong>Privilegium Sabbatinum</strong> (Sabbatine
+                Privilege). A further promise, attributed to a papal bull of Pope John XXII in 1322,
+                held that Our Lady would intercede for scapular wearers to be freed from Purgatory
+                on the Saturday following their death. The historical authenticity of the John XXII
+                bull has been questioned by scholars; the Church has treated this particular promise
+                as pious tradition rather than defined doctrinal fact, while affirming the devotion
+                itself as spiritually beneficial.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">What Is a Scapular?</h3>
+                <p className="text-amber-800 mb-3">
+                  Originally, the scapular (<em>scapulare</em>, from <em>scapulae</em>, &ldquo;shoulders&rdquo;)
+                  was a long panel of cloth worn over the habit by Carmelite and other religious,
+                  covering the front and back as a practical work garment and symbol of the yoke of
+                  Christ. The devotional scapular worn by laity is a miniaturized version: two small
+                  pieces of brown wool cloth connected by strings or cords, worn front and back over
+                  the shoulders beneath one&rsquo;s clothing.
+                </p>
+                <p className="text-amber-800">
+                  The wearing of the scapular is an external sign of enrollment in the Confraternity
+                  of Our Lady of Mount Carmel &mdash; a lay association united to the Carmelite Order
+                  and its spiritual charism of prayer, contemplation, and service.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Pope Pius XII on the Scapular</h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Scapular is a habit. Those who wear it become members of the family of Carmel.
+                  Let them, therefore, esteem it as a sign of consecration to the Immaculate Heart
+                  of Mary.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Pope Pius XII (1950)</p>
+              </div>
+            </div>
+
+            {/* Card 2: Conditions and Theology */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Conditions, Theology, and Fátima</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Church has specified four conditions for those who wish to receive the benefits
+                of the scapular devotion: (1) enrollment by a priest in the Confraternity of Our
+                Lady of Mount Carmel; (2) continuous wearing of the scapular (the Church now permits
+                an approved medal as a substitute for those who find the cloth impractical); (3)
+                recitation of the Little Office of Our Lady daily, with provision for substitution
+                of other approved prayers by one&rsquo;s confessor; and (4) observance of chastity
+                according to one&rsquo;s proper state in life.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Critically, the scapular is not a magical charm. The Church classifies it as a
+                <strong> sacramental</strong> (CCC 1667&ndash;1679) &mdash; an external sign that
+                expresses and deepens an interior commitment. The promise of protection is not
+                mechanical; it is conditioned on the sincere living out of the Carmelite spirit:
+                poverty, prayer, and service. Wearing the scapular without interior conversion would
+                be to misunderstand the devotion entirely.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Brown Scapular at F&aacute;tima
+                </h3>
+                <p className="text-amber-800">
+                  Our Lady of F&aacute;tima appeared to the three shepherd children holding a brown
+                  scapular. At the climactic apparition of October 13, 1917 &mdash; the day of the
+                  &ldquo;Miracle of the Sun&rdquo; witnessed by some 70,000 people &mdash; Our Lady appeared
+                  in three forms: Our Lady of the Rosary, Our Lady of Sorrows, and significantly,
+                  Our Lady of Mount Carmel, explicitly linking the Carmelite scapular devotion to
+                  the F&aacute;tima message.
+                </p>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  Sacramental, Not Superstition
+                </h3>
+                <p className="text-purple-800">
+                  The Catechism&rsquo;s teaching on sacramentals (CCC 1677&ndash;1679) is directly
+                  applicable here: sacramentals &ldquo;prepare us to receive grace and dispose us to
+                  cooperate with it.&rdquo; They achieve their effect not <em>ex opere operato</em>
+                  (by the act performed) as sacraments do, but through the devotion of the Church
+                  and of the person using them. The Brown Scapular, understood correctly, is a
+                  wearable consecration to Mary and to the values she embodies.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: THE MIRACULOUS MEDAL ==================== */}
+        {activeTab === 'miraculous-medal' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Catherine Labouré's Visions */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sparkles className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Visions of Catherine Labouré (1830)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Catherine Labour&eacute; (1806&ndash;1876) was a novice with the Daughters of Charity of
+                St. Vincent de Paul at the convent on the rue du Bac in Paris. In 1830 she received
+                three apparitions of Our Lady: on July 18 (the eve of the feast of St. Vincent de
+                Paul), on November 27, and in December 1830. These apparitions would change the
+                devotional life of the Catholic world.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The most significant apparition occurred on November 27, 1830. Our Lady appeared
+                standing on a globe, crushing a serpent underfoot (an image echoing Genesis 3:15 &mdash;
+                the <em>Protoevangelium</em>), with rays of light streaming from rings on her fingers.
+                Our Lady told Catherine that the rays represented the graces she obtained for those
+                who asked for them, and that the darkened stones on some rings were graces not asked
+                for. She then revealed an oval image and said:
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Our Lady&rsquo;s Words</h3>
+                <p className="text-amber-800 italic mb-4">
+                  &ldquo;Have a medal struck after this model. All who wear it will receive great graces;
+                  they should wear it around the neck. Graces will abound for persons who wear it
+                  with confidence.&rdquo;
+                </p>
+                <div className="mt-4">
+                  <p className="text-amber-900 font-semibold mb-2">The Inscription on the Medal:</p>
+                  <p className="text-amber-800 italic text-center text-lg">
+                    &ldquo;O Mary, conceived without sin, pray for us who have recourse to thee.&rdquo;
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Prophecy Before Dogma
+                </h3>
+                <p className="text-blue-800">
+                  The Immaculate Conception was defined as dogma by Pope Pius IX in 1854 &mdash; a full
+                  24 years after Our Lady appeared to Catherine Labouré with the inscription &ldquo;O Mary,
+                  conceived without sin.&rdquo; The apparition preceded and in some sense anticipated the
+                  dogmatic definition. The Church noted this significant sequence when approving the
+                  apparitions.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: The Medal, Conversions, and Catherine's Hidden Life */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Circle className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Medal&rsquo;s Spread and Catherine&rsquo;s Hidden Sanctity</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The reverse of the medal displays a complex Marian iconography: the letter M
+                surmounted by a cross and bar, beneath which are 12 stars encircling the image; two
+                hearts &mdash; the Sacred Heart of Jesus crowned with thorns, and the Immaculate Heart
+                of Mary pierced by a sword (Luke 2:35); and the letter M again. These symbols
+                condensed major Christological and Marian doctrines into a wearable catechism.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Pope Gregory XVI permitted the medal to be struck in 1832. Within four years, over
+                one million medals had been distributed across France and beyond. Reports of cures,
+                conversions, and graces attributed to the medal&rsquo;s intercession began multiplying
+                almost immediately &mdash; leading the faithful to call it the &ldquo;Miraculous Medal,&rdquo;
+                a name that stuck despite it not being the official Church designation.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Conversion of Alphonse Ratisbonne
+                </h3>
+                <p className="text-amber-800">
+                  The most celebrated conversion associated with the medal occurred on January 20,
+                  1842, in Rome. Alphonse Ratisbonne, a secular Jewish man of strong anti-Catholic
+                  views, had agreed to wear the Miraculous Medal at the persistent insistence of a
+                  Catholic acquaintance. While waiting in the church of Sant&rsquo;Andrea delle Fratte,
+                  he experienced a sudden, overwhelming vision of Our Lady. He converted on the spot,
+                  received baptism shortly after, eventually became a Jesuit priest, and founded the
+                  Congregation of Our Lady of Sion. The conversion was investigated by Church authorities
+                  and declared miraculous.
+                </p>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Catherine&rsquo;s Hidden Identity
+                </h3>
+                <p className="text-green-800 mb-3">
+                  Catherine Labour&eacute; never disclosed that she was the recipient of the visions.
+                  She told only her confessor, Father Jean-Marie Aladel, and spent the remaining 46
+                  years of her life in complete obscurity as a carer for elderly men in a Paris hospice,
+                  revealing her identity only weeks before her death in 1876. Her heroic concealment
+                  of the grace she had received is itself considered a mark of the authenticity and
+                  depth of her sanctity.
+                </p>
+                <p className="text-green-800">
+                  She was beatified by Pius XI in 1933 and canonized by Pius XII in 1947. The
+                  shrine at the rue du Bac in Paris &mdash; where the apparitions occurred &mdash;
+                  remains a major Marian pilgrimage site, receiving hundreds of thousands of visitors
+                  annually.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: FÁTIMA DEVOTIONS ==================== */}
+        {activeTab === 'fatima-devotions' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Specific Devotional Requests */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Specific Devotions Requested at F&aacute;tima</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The F&aacute;tima apparitions of 1917 &mdash; to Lucia Santos, Francisco Marto, and Jacinta
+                Marto in the Cova da Iria near F&aacute;tima, Portugal &mdash; were unusual in the specificity
+                of their devotional requests. Our Lady did not ask for generic piety but for concrete,
+                identifiable practices. These have been carefully preserved in the testimonies of
+                Lucia, who lived until 2005 and corresponded extensively with Church authorities.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The F&aacute;tima Decade Prayer
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  At the July 13, 1917 apparition, Our Lady requested that the following prayer be
+                  added to the end of each decade of the Rosary:
+                </p>
+                <p className="text-amber-800 italic text-center text-base mb-3">
+                  &ldquo;O my Jesus, forgive us our sins, save us from the fires of hell, lead all souls
+                  to heaven, especially those most in need of your mercy.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  This prayer is now widely used by Catholics worldwide as a standard addition to
+                  the Rosary, appearing in approved prayer books and digital rosary guides.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Private Revelation and the Faith
+                </h3>
+                <p className="text-blue-800">
+                  The apparitions of F&aacute;tima are classified as &ldquo;private revelations&rdquo; (CCC 67).
+                  Catholics are not required to believe them as articles of faith; but the Church
+                  approves them as worthy of credence and the devotions flowing from them as
+                  spiritually beneficial. They do not add to the deposit of faith but can &ldquo;help
+                  to live the faith more fully in a certain period of history&rdquo; (CCC 67).
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Five First Saturdays and Consecration */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Five First Saturdays and Consecration</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On December 10, 1925, Our Lady appeared to Lucia (then a Dorothean novice) at
+                Pontevedra, Spain, with the Child Jesus beside her, requesting the <strong>Five First
+                Saturdays devotion</strong> of reparation. On five consecutive first Saturdays of
+                the month, the faithful are to: (1) go to Confession; (2) receive Holy Communion;
+                (3) recite five decades of the Rosary; (4) keep Our Lady company for 15 minutes
+                while meditating on the mysteries of the Rosary, with the intention of making
+                reparation to her Immaculate Heart.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">Our Lady&rsquo;s Promise</h3>
+                <p className="text-purple-800 italic">
+                  &ldquo;I promise to assist at the hour of death with the graces necessary for salvation
+                  all those who, on the first Saturday of five consecutive months, shall confess,
+                  receive Holy Communion, recite five decades of the Rosary, and keep me company for
+                  fifteen minutes while meditating on the fifteen mysteries of the Rosary with the
+                  intention of making me reparation.&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Consecration to the Immaculate Heart
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Our Lady requested, at the June and July 1917 apparitions, the consecration of
+                  Russia to her Immaculate Heart. Pope Pius XII consecrated the world to the
+                  Immaculate Heart of Mary in 1942 (renewed 1952). Following extensive consultation
+                  with the world&rsquo;s bishops, Pope John Paul II performed the solemn consecration
+                  of Russia and the world on March 25, 1984. Pope Francis renewed this consecration
+                  on March 25, 2022, in the context of the war in Ukraine.
+                </p>
+                <p className="text-amber-800">
+                  JPII credited Our Lady of F&aacute;tima with saving his life after the assassination
+                  attempt of May 13, 1981 &mdash; which occurred on the 64th anniversary of the first
+                  F&aacute;tima apparition. The bullet that struck him is embedded in the crown of the
+                  statue of Our Lady at F&aacute;tima, placed there by JPII himself.
+                </p>
+              </div>
+
+              <div className="bg-gray-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                  The Third Secret
+                </h3>
+                <p className="text-gray-800">
+                  The Third Secret of F&aacute;tima, entrusted by Our Lady to Lucia at the July 13,
+                  1917 apparition, was revealed in full by the Vatican on June 26, 2000, during the
+                  pontificate of John Paul II. The text describes a vision of a &ldquo;bishop clothed
+                  in white&rdquo; falling under gunfire amid the ruins of a half-destroyed city. The
+                  Church&rsquo;s official interpretation, provided by Cardinal Ratzinger in the accompanying
+                  theological commentary, identified this vision as referring to the persecution of
+                  Christians in the 20th century and, more specifically, to the May 13, 1981
+                  assassination attempt on JPII.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: ANCIENT MARIAN PRAYERS ==================== */}
+        {activeTab === 'ancient-marian-prayers' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Sub Tuum and the Memorare */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sub Tuum Praesidium &amp; The Memorare</h2>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  <em>Sub Tuum Praesidium</em> &mdash; c. AD 250
+                </h3>
+                <p className="text-amber-800 mb-4 italic text-base">
+                  &ldquo;Under your protection we seek refuge, Holy Mother of God. Do not despise our
+                  supplications in our necessities, but deliver us always from all dangers, O glorious
+                  and blessed Virgin.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  This is the oldest known Marian prayer, preserved on Papyrus John Rylands 470, an
+                  Egyptian papyrus dating to approximately AD 250 &mdash; before the Council of Nicaea
+                  (325) and before any formal Marian councils or dogmatic definitions. It demonstrates
+                  that invoking Mary&rsquo;s protection is not a medieval innovation but a practice of
+                  the early Church. The prayer is still prayed in the Roman Rite at Compline
+                  (Night Prayer) during certain liturgical seasons.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The <em>Memorare</em> &mdash; attributed to St. Bernard of Clairvaux, 12th century
+                </h3>
+                <p className="text-blue-800 mb-4 italic">
+                  &ldquo;Remember, O most gracious Virgin Mary, that never was it known that anyone who
+                  fled to your protection, implored your help, or sought your intercession was left
+                  unaided. Inspired with this confidence, I fly to you, O Virgin of virgins, my
+                  Mother. To you I come, before you I stand, sinful and sorrowful. O Mother of the
+                  Word Incarnate, despise not my petitions, but in your mercy hear and answer me.
+                  Amen.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">
+                  The Memorare expresses the boldness of Christian petition to Mary: it begins not
+                  with a cautious &ldquo;please help if it is God&rsquo;s will&rdquo; but with a confident appeal
+                  to the entire history of Mary&rsquo;s intercession. It is a prayer of confident trust.
+                  The attribution to St. Bernard is traditional rather than certainly historical;
+                  the current form may be a 15th-century compilation drawing on earlier Bernardine
+                  texts.
+                </p>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Antiquity of Marian Prayer
+                </h3>
+                <p className="text-green-800">
+                  The sheer antiquity of <em>Sub Tuum Praesidium</em> (AD ~250) shows that Marian
+                  prayer is not a medieval invention &mdash; it predates the Council of Nicaea (325).
+                  Christians have sought Mary&rsquo;s intercession from nearly the beginning of the Church,
+                  long before the great Marian councils and definitions of the 5th century and beyond.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: Salve Regina and the Seasonal Antiphons */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Salve Regina &amp; the Seasonal Antiphons</h2>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  <em>Salve Regina</em> (Hail Holy Queen) &mdash; 11th century
+                </h3>
+                <p className="text-purple-800 mb-4 italic">
+                  &ldquo;Hail, Holy Queen, Mother of Mercy, our life, our sweetness and our hope. To you
+                  do we cry, poor banished children of Eve. To you do we send up our sighs, mourning
+                  and weeping in this valley of tears. Turn, then, most gracious advocate, your eyes
+                  of mercy toward us, and after this, our exile, show unto us the blessed fruit of
+                  your womb, Jesus. O clement, O loving, O sweet Virgin Mary.&rdquo;
+                </p>
+                <p className="text-purple-700 text-sm">
+                  Attributed variously to Adhémar of Monteil or Herman of Reichenau, the Salve Regina
+                  is one of the four Marian antiphons recited at the close of the Liturgy of the
+                  Hours; it is sung from Compline after Pentecost until the beginning of Advent. It
+                  is also prayed at the close of the Rosary.
+                </p>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">
+                    <em>Alma Redemptoris Mater</em>
+                  </h3>
+                  <p className="text-amber-800 text-sm mb-2">
+                    &ldquo;Loving Mother of the Redeemer&rdquo; &mdash; attributed to Herman of Reichenau (d. 1054).
+                  </p>
+                  <p className="text-amber-700 text-sm">
+                    Sung from the First Sunday of Advent through the Feast of the Presentation
+                    (February 2). Celebrates Mary as Mother of both God and man and as the gate of
+                    heaven.
+                  </p>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">
+                    <em>Ave Regina Caelorum</em>
+                  </h3>
+                  <p className="text-blue-800 text-sm mb-2">
+                    &ldquo;Hail, Queen of the Heavens&rdquo; &mdash; one of the four seasonal Marian antiphons.
+                  </p>
+                  <p className="text-blue-700 text-sm">
+                    Sung from the Feast of the Presentation (February 2) through Wednesday of Holy
+                    Week. A compact, exalted praise of Mary as Queen and intercessor.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Litany of Loreto
+                </h3>
+                <p className="text-green-800 mb-3">
+                  The Litany of Loreto is a series of invocations to Mary with over 50 titles,
+                  dating to approximately 1558 at the Loreto shrine in Italy &mdash; the official
+                  litany approved by the Holy See for universal public use. Its titles form a rich
+                  treasury of Marian theology condensed into short, beautiful phrases:
+                </p>
+                <div className="grid sm:grid-cols-3 gap-2">
+                  {[
+                    'Mirror of Justice',
+                    'Seat of Wisdom',
+                    'Tower of David',
+                    'Morning Star',
+                    'Refuge of Sinners',
+                    'Comforter of the Afflicted',
+                    'Health of the Sick',
+                    'Queen of Angels',
+                    'Gate of Heaven',
+                  ].map((title) => (
+                    <div key={title} className="bg-white rounded p-2 text-center">
+                      <span className="text-green-800 text-sm italic">{title}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: THEOLOGY OF MARIAN DEVOTION ==================== */}
+        {activeTab === 'theology-of-devotion' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Lumen Gentium and the Distinctions */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Lumen Gentium, Chapter VIII: The Council&rsquo;s Teaching</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Vatican II&rsquo;s <em>Lumen Gentium</em> (1964), Chapter VIII, is the most authoritative
+                magisterial statement on Mary&rsquo;s place in the Church. Significantly, the Council
+                chose to treat Mary not in a separate document but within the Constitution on the
+                Church itself &mdash; deliberately placing her in ecclesial context, as a member of
+                the Church though in a supremely eminent position.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">Key Passages from Lumen Gentium</h3>
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-amber-800 italic mb-1">
+                      &ldquo;Mary&rsquo;s function as mother of men in no way obscures or diminishes this unique
+                      mediation of Christ, but rather shows its power.&rdquo;
+                    </p>
+                    <p className="text-amber-700 text-sm">&mdash; LG 60</p>
+                  </div>
+                  <div>
+                    <p className="text-amber-800 italic mb-1">
+                      &ldquo;This most Holy Synod deliberately teaches this Catholic doctrine and at the
+                      same time admonishes all the sons of the Church that the cult&hellip; toward the
+                      Blessed Virgin be generously fostered&hellip; But it exhorts theologians and preachers
+                      of the divine word to abstain zealously both from all gross exaggerations as
+                      well as from petty narrow-mindedness.&rdquo;
+                    </p>
+                    <p className="text-amber-700 text-sm">&mdash; LG 66&ndash;67</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Latria, Hyperdulia, Dulia
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Thomas Aquinas&rsquo;s classical distinction resolves the most common misunderstanding
+                  about Catholic Marian devotion:
+                </p>
+                <div className="grid sm:grid-cols-3 gap-4">
+                  <div className="bg-white rounded-lg p-4">
+                    <p className="font-semibold text-blue-900 mb-1">Latria</p>
+                    <p className="text-blue-800 text-sm">
+                      The worship due to God alone. Catholics offer <em>latria</em> only to the Trinity.
+                    </p>
+                  </div>
+                  <div className="bg-white rounded-lg p-4">
+                    <p className="font-semibold text-blue-900 mb-1">Dulia</p>
+                    <p className="text-blue-800 text-sm">
+                      The veneration due to saints, honoring the grace of God at work in them.
+                    </p>
+                  </div>
+                  <div className="bg-white rounded-lg p-4">
+                    <p className="font-semibold text-blue-900 mb-1">Hyperdulia</p>
+                    <p className="text-blue-800 text-sm">
+                      The special veneration due to Mary alone: greater than any saint, yet infinitely
+                      less than the worship due to God.
+                    </p>
+                  </div>
+                </div>
+                <p className="text-blue-800 text-sm mt-4">
+                  Catholics worship God; they venerate Mary. This distinction, often misunderstood
+                  by critics of Catholic devotion, is the precise theological framework within which
+                  all Marian prayers and devotions operate.
+                </p>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Authentic vs. Excessive Devotion
+                </h3>
+                <p className="text-green-800 mb-3">
+                  CCC 971 affirms: &ldquo;The Church&rsquo;s devotion to the Blessed Virgin is intrinsic to
+                  Christian worship.&rdquo; CCC 2678 teaches that &ldquo;we can pray with and to her.&rdquo;
+                  Yet <em>Lumen Gentium</em> 67 issues a double warning: against <em>neglecting</em>
+                  Mary (a Protestant tendency) and against <em>exaggerating</em> her role beyond what
+                  faith and Church teaching warrant. Authentic Marian devotion always leads to Christ;
+                  it is Christocentric by definition.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 2: JPII, De Montfort, and Mary as Model of the Church */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">JPII, De Montfort, and Mary as Model of the Church</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Pope John Paul II&rsquo;s Marian spirituality is inseparable from his theological identity.
+                His episcopal and papal motto &mdash; <em>Totus Tuus</em> (&ldquo;Totally Yours&rdquo;) &mdash; was
+                drawn from St. Louis de Montfort&rsquo;s Marian consecration formula and expressed his
+                complete self-offering to God through Mary. His 1987 encyclical <em>Redemptoris Mater</em>
+                (&ldquo;Mother of the Redeemer&rdquo;) offered a profound theological meditation on Mary as
+                &ldquo;Mother of Mercy&rdquo; and model of the Church on pilgrimage toward the fullness of faith.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  St. Louis de Montfort&rsquo;s <em>True Devotion</em>
+                </h3>
+                <p className="text-purple-800 mb-3">
+                  St. Louis-Marie Grignion de Montfort (1673&ndash;1716) wrote his masterwork <em>True
+                  Devotion to the Blessed Virgin Mary</em> around 1700. Suppressed during the French
+                  Revolution, the manuscript was discovered in 1842 and published in 1843. De Montfort
+                  argues that &ldquo;total consecration&rdquo; &mdash; giving all one&rsquo;s prayers, works, and
+                  merits to Jesus through Mary &mdash; is the &ldquo;surest and shortest&rdquo; path to
+                  holiness and union with Christ.
+                </p>
+                <p className="text-purple-800">
+                  The young Karol Woj&nbsp;ty&l;a read this book as a young man and credited it with
+                  transforming his understanding of Marian devotion from sentimental piety to rigorous
+                  Christocentric theology. The book&rsquo;s core insight &mdash; that going to Jesus through
+                  Mary is the logic of the Incarnation itself &mdash; became the theological foundation
+                  of JPII&rsquo;s entire pontificate.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Mary as Type and Model of the Church
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  <em>Lumen Gentium</em> 53 and 63&ndash;65 present Mary as &ldquo;a type of the Church in
+                  the order of faith, charity, and perfect union with Christ.&rdquo; What the Church is
+                  called to be &mdash; wholly receptive to God, wholly given over to bearing Christ to
+                  the world &mdash; Mary already is, perfectly and completely. Her <em>fiat</em> at the
+                  Annunciation is the model for every act of faith; her faithful perseverance to the
+                  Cross and beyond is the model of the Church&rsquo;s pilgrim journey.
+                </p>
+                <p className="text-amber-800">
+                  This ecclesiological dimension of Marian theology is why devotion to Mary is not
+                  optional piety for Catholics: it is a theological grammar for understanding what
+                  the Church itself is called to be.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Further Exploration
+                </h3>
+                <div className="space-y-2">
+                  <a
+                    href="/prayer/rosary"
+                    className="flex items-center gap-2 text-blue-700 hover:text-blue-900 transition-colors"
+                  >
+                    <ArrowRight className="w-4 h-4" />
+                    <span>The Holy Rosary &rarr;</span>
+                  </a>
+                  <a
+                    href="/mysteries/private-revelations"
+                    className="flex items-center gap-2 text-blue-700 hover:text-blue-900 transition-colors"
+                  >
+                    <ArrowRight className="w-4 h-4" />
+                    <span>Private Revelations &rarr;</span>
+                  </a>
+                  <a
+                    href="/mysteries/public-revelation"
+                    className="flex items-center gap-2 text-blue-700 hover:text-blue-900 transition-colors"
+                  >
+                    <ArrowRight className="w-4 h-4" />
+                    <span>Public Revelation &rarr;</span>
+                  </a>
+                </div>
+              </div>
+
+              {/* Sources */}
+              <div className="bg-white rounded-lg shadow-lg p-8">
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                    <BookOpen className="w-6 h-6 text-amber-700" />
+                  </div>
+                  <h2 className="text-3xl font-bold text-gray-800">Sources &amp; Further Reading</h2>
+                </div>
+
+                <p className="text-gray-700 leading-relaxed mb-6">
+                  The following primary sources and scholarly works underlie this page.
+                  Readers who wish to go deeper will find these indispensable.
+                </p>
+
+                <div className="grid md:grid-cols-2 gap-6">
+                  <div className="bg-amber-50 p-5 rounded-lg">
+                    <h3 className="font-semibold text-amber-900 mb-3">Magisterial &amp; Official</h3>
+                    <ul className="text-amber-800 text-sm space-y-2">
+                      <li><em>Catechism of the Catholic Church</em>, &sect;&sect;484&ndash;511 (Mary in God&rsquo;s plan)</li>
+                      <li><em>Catechism of the Catholic Church</em>, &sect;&sect;963&ndash;975 (Mary, Mother of the Church)</li>
+                      <li><em>Catechism of the Catholic Church</em>, &sect;&sect;2676&ndash;2679 (Marian prayer)</li>
+                      <li><em>Catechism of the Catholic Church</em>, &sect;&sect;1667&ndash;1679 (sacramentals)</li>
+                      <li><em>Catechism of the Catholic Church</em>, &sect;2708 (meditative prayer)</li>
+                      <li>Vatican II, <em>Lumen Gentium</em>, ch. VIII, &sect;&sect;53&ndash;69 (Mary &amp; the Church)</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-blue-50 p-5 rounded-lg">
+                    <h3 className="font-semibold text-blue-900 mb-3">Papal Documents</h3>
+                    <ul className="text-blue-800 text-sm space-y-2">
+                      <li>Pope John Paul II, <em>Redemptoris Mater</em> (1987) &mdash; Mother of the Redeemer</li>
+                      <li>Pope Paul VI, <em>Marialis Cultus</em> (1974) &mdash; For the Right Ordering of Marian Devotion</li>
+                      <li>Pope Pius IX, <em>Ineffabilis Deus</em> (1854) &mdash; definition of the Immaculate Conception</li>
+                      <li>Pope Pius XII, letter on the Brown Scapular (1950)</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-purple-50 p-5 rounded-lg">
+                    <h3 className="font-semibold text-purple-900 mb-3">Spiritual &amp; Scholarly Works</h3>
+                    <ul className="text-purple-800 text-sm space-y-2">
+                      <li>St. Louis de Montfort, <em>True Devotion to the Blessed Virgin Mary</em> (c. 1700, publ. 1843)</li>
+                      <li>Frederick Jelly OP, <em>Madonna: Mary in the Catholic Tradition</em> (Our Sunday Visitor, 1986)</li>
+                      <li>René Laurentin, <em>Bernadette of Lourdes</em> (London, 1979) &mdash; apparition methodology</li>
+                      <li>Thomas Aquinas, <em>Summa Theologiae</em>, IIa IIae, q. 84 (on dulia and hyperdulia)</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-green-50 p-5 rounded-lg">
+                    <h3 className="font-semibold text-green-900 mb-3">Primary Sources on the Devotions</h3>
+                    <ul className="text-green-800 text-sm space-y-2">
+                      <li>Papyrus John Rylands 470 (c. AD 250) &mdash; <em>Sub Tuum Praesidium</em></li>
+                      <li>Sister Lucia, <em>Fatima in Lucia&rsquo;s Own Words</em> (Postulation Centre, F&aacute;tima, 2004)</li>
+                      <li>René Laurentin &amp; Patrick Sbalchiero (eds.), <em>Dictionnaire des &ldquo;apparitions&rdquo; de la Vierge Marie</em> (2007)</li>
+                      <li>Carmelite Institute of Britain and Ireland, documentation on the Brown Scapular tradition</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/overview/page.tsx
+++ b/src/app/prayer/overview/page.tsx
@@ -1,0 +1,1082 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Heart,
+  BookOpen,
+  Mic,
+  CloudRain,
+  GraduationCap,
+  Star,
+  ArrowRight,
+} from 'lucide-react'
+
+type TabId =
+  | 'what-is-prayer'
+  | 'forms-of-prayer'
+  | 'vocal-mental-contemplative'
+  | 'obstacles-distractions'
+  | 'school-of-prayer'
+  | 'the-our-father'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'what-is-prayer', label: 'What Is Prayer?' },
+  { id: 'forms-of-prayer', label: 'Forms of Prayer' },
+  { id: 'vocal-mental-contemplative', label: 'Vocal, Mental & Contemplative' },
+  { id: 'obstacles-distractions', label: 'Obstacles & Distractions' },
+  { id: 'school-of-prayer', label: 'The School of Prayer' },
+  { id: 'the-our-father', label: "The Lord's Prayer" },
+]
+
+export default function PrayerOverviewPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('what-is-prayer')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            What Is Prayer?
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The Catholic understanding of prayer &mdash; its nature, forms, obstacles, and the
+            Lord&rsquo;s own model for how we should pray.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: WHAT IS PRAYER? ==================== */}
+        {activeTab === 'what-is-prayer' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Definition */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Raising of the Heart to God</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Prayer is not merely a religious exercise or a list of requests presented to a distant
+                deity. At its core, Catholic theology understands prayer as a <em>relationship</em>
+                &mdash; a living, personal encounter between the human person and the living God. St.
+                John Damascene, quoted in the Catechism at CCC 2559, defines it with elegant simplicity:
+                &ldquo;Prayer is the raising of one&rsquo;s mind and heart to God or the requesting of
+                good things from God.&rdquo; This raising is not merely intellectual: it is the whole
+                person &mdash; intellect, will, memory, imagination, and desire &mdash; being oriented
+                toward its origin and end.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                St. Th&eacute;r&egrave;se of Lisieux, Doctor of the Church, captures the intimacy of
+                this movement with characteristic simplicity: &ldquo;For me, prayer is a surge of the
+                heart; it is a simple look turned toward heaven, it is a cry of recognition and of
+                love.&rdquo; (<em>Story of a Soul</em>, Ch. 11). Th&eacute;r&egrave;se demystifies
+                prayer: it requires no elaborate technique, no learned vocabulary, no spiritual
+                credential. What it requires is the heart &mdash; turned toward God.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catechism of the Catholic Church
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Prayer is the raising of one&rsquo;s mind and heart to God or the requesting
+                  of good things from God.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; St. John Damascene, cited in CCC 2559</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catechism deepens this definition by grounding prayer in <strong>covenant</strong>.
+                CCC 2560&ndash;2561 reveal a startling reversal: it is <em>God</em> who thirsts for us
+                first. Drawing on John 4:10, where Christ asks the Samaritan woman for a drink, the
+                Catechism notes that the marvel of prayer is that God&rsquo;s thirst meets ours.
+                Prayer is not the human initiative ascending to a reluctant God; it is the human
+                response to a God who has already been calling, already been seeking, already been
+                thirsting.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                CCC 2562 adds a crucial anthropological note: &ldquo;the heart is the place of
+                encounter&rdquo; with God. The &ldquo;heart&rdquo; in biblical and Catholic tradition
+                means something deeper than the emotional center: it is the seat of the whole person,
+                the place where intellect, will, and love converge. When the Catechism says prayer
+                comes from the heart, it means prayer engages the whole person in the act of
+                turning toward God &mdash; not just feelings, not just words, not just duty.
+              </p>
+            </div>
+
+            {/* Card 2: Scripture Foundation */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Scriptural Foundation of Prayer</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The New Testament issues an unqualified call to prayer. In Matthew 7:7&ndash;8,
+                Christ commands: &ldquo;Ask, and it will be given to you; seek, and you will find;
+                knock, and the door will be opened to you.&rdquo; This is not a conditional promise
+                hedged about with qualifications &mdash; it is a direct imperative from the Son of
+                God, who knows the Father&rsquo;s heart perfectly. The threefold parallelism
+                (ask/seek/knock) escalates in intensity: from verbal petition to active searching to
+                persistent, determined knocking.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                St. Paul, writing to the Thessalonians, goes further still: &ldquo;Pray without
+                ceasing&rdquo; (1 Thess 5:17). This is not a call to perpetual verbal prayer but to a
+                continuous interior orientation of life toward God &mdash; what the tradition calls the
+                &ldquo;prayer of the heart&rdquo; or the <em>oratio continua</em> of the Desert
+                Fathers. In Luke 18:1, Christ himself introduces the parable of the persistent widow
+                with an explicit theological gloss: he told the disciples the parable &ldquo;about the
+                necessity of praying always and not losing heart.&rdquo; Perseverance is not
+                optional &mdash; it is of the essence of Christian prayer.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Three Movements of Christian Prayer
+                </h3>
+                <div className="grid sm:grid-cols-3 gap-4">
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Praise</p>
+                    <p className="text-amber-700 text-sm">Glorifying God for who he is &mdash; not for what he gives, but for his own infinite goodness and beauty.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Gratitude</p>
+                    <p className="text-amber-700 text-sm">Acknowledging God as the source of every gift, from existence itself to the particular blessings of our lives.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-800 mb-1">Petition</p>
+                    <p className="text-amber-700 text-sm">Asking God for what we need &mdash; an act of humility and trust, not of distrust or weakness.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Card 3: Communication vs. Communion */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Communication vs. Communion</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A critical distinction in Catholic prayer theology is the difference between prayer as
+                <em>communication</em> and prayer as <em>communion</em>. Communication involves the
+                exchange of information or requests &mdash; telling God what we need, thanking him for
+                what we have received, even praising him in formal phrases. This is real prayer and
+                has genuine value. But the tradition has always insisted that it is not the
+                fullness of what prayer is meant to be.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Communion is something deeper: a mutual indwelling, a resting in God&rsquo;s
+                presence, a union of wills. The mystics &mdash; John of the Cross, Teresa of
+                &Aacute;vila, Thomas Aquinas in his later years &mdash; point to this as the ultimate
+                orientation of all Christian prayer. The goal is not merely to talk to God but to be
+                united with him. This is why contemplative prayer, which may involve no words at all,
+                stands as the highest expression of the impulse that begins in even the simplest
+                petition.
+              </p>
+
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  The Heart of the Matter
+                </h3>
+                <p className="text-green-800 mb-3">
+                  Prayer is not primarily about changing God&rsquo;s mind or obtaining specific
+                  outcomes. It is about aligning our will with his, deepening our knowledge of him,
+                  and being transformed by that encounter. The Catechism&rsquo;s Part IV is devoted
+                  entirely to prayer for precisely this reason: prayer is not an add-on to Christian
+                  life &mdash; it is the <em>breath</em> of Christian life.
+                </p>
+                <p className="text-green-700 text-sm italic">
+                  &ldquo;Seeking the face of God&rdquo; &mdash; CCC 2566 describes prayer as humanity&rsquo;s
+                  most fundamental act, begun in the heart of God&rsquo;s first call and never ceasing.
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  'CCC 2558&ndash;2567 (What is prayer?)',
+                  'CCC 2559&ndash;2561 (Covenant dimension)',
+                  'CCC 2562 (The heart as place of encounter)',
+                  'Matthew 7:7&ndash;8; 1 Thessalonians 5:17; Luke 18:1',
+                  'St. Th&eacute;r&egrave;se of Lisieux, <em>Story of a Soul</em>, Ch. 11',
+                  'St. John Damascene, <em>De Fide Orthodoxa</em> III, 24',
+                ].map((source, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+                    <p className="text-gray-700 text-sm" dangerouslySetInnerHTML={{ __html: source }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: FORMS OF PRAYER ==================== */}
+        {activeTab === 'forms-of-prayer' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Overview */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Six Expressions of Prayer</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Catechism of the Catholic Church (CCC 2626&ndash;2643) identifies six distinct
+                expressions or forms of prayer, each rooted in Scripture and refined by centuries of
+                lived Christian experience. These are not competing approaches to God but facets of
+                a single jewel &mdash; different angles from which the human heart approaches the
+                divine. Most prayer in practice combines several of these forms simultaneously.
+              </p>
+
+              {/* Form 1 */}
+              <div className="border-l-4 border-amber-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">1. Blessing and Adoration</h3>
+                <p className="text-gray-700 leading-relaxed mb-3">
+                  CCC 2626&ndash;2628 explains that blessing is a fundamental movement of Christian
+                  prayer: God blesses the human heart, and the human heart blesses God in return.
+                  <em>Adoration</em> &mdash; from the Latin <em>adoratio</em>, to bow before &mdash;
+                  is the creature&rsquo;s fundamental acknowledgment of its Creator: &ldquo;We are
+                  not our own; we are his.&rdquo; The Psalms are filled with this double movement:
+                  &ldquo;Come, let us worship and bow down; let us kneel before the Lord, our
+                  Maker&rdquo; (Psalm 95:6). The Book of Revelation closes with the heavenly
+                  liturgy of adoration: &ldquo;Blessing and glory and wisdom and thanksgiving and
+                  honor and power and might be to our God&rdquo; (Rev 7:12).
+                </p>
+              </div>
+
+              {/* Form 2 */}
+              <div className="border-l-4 border-blue-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">2. Prayer of Petition</h3>
+                <p className="text-gray-700 leading-relaxed mb-3">
+                  CCC 2629&ndash;2633 grounds petition in the recognition of our radical dependence on
+                  God. Petitionary prayer is not a sign of weak faith &mdash; the Catechism notes
+                  that even Christ himself petitioned the Father (&ldquo;Father, let this cup pass
+                  from me&rdquo; &mdash; Matt 26:39). CCC 2631 identifies the first movement of
+                  petition as asking for forgiveness, because that is the foundational human need
+                  before God. Matthew 7:7 sets the scope: &ldquo;Ask, and it will be given to
+                  you.&rdquo; Petition expresses trust: we ask because we believe the Father
+                  hears and cares.
+                </p>
+              </div>
+
+              {/* Form 3 */}
+              <div className="border-l-4 border-green-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">3. Prayer of Intercession</h3>
+                <p className="text-gray-700 leading-relaxed mb-3">
+                  CCC 2634&ndash;2636 describes intercession as prayer that leads us to pray as
+                  Jesus does &mdash; for others, including enemies. The great biblical models are
+                  Abraham interceding for Sodom (Gen 18), Moses pleading for the people after
+                  the golden calf (&ldquo;Turn from your fierce wrath; relent and do not bring
+                  disaster on your people&rdquo; &mdash; Ex 32:11&ndash;14), and Paul&rsquo;s constant
+                  intercession for his communities (&ldquo;I do not cease to give thanks for
+                  you&rdquo; &mdash; Col 1:3). Intercession is the ultimate school of charity:
+                  when we pray for others, our hearts expand to encompass them.
+                </p>
+              </div>
+
+              {/* Form 4 */}
+              <div className="border-l-4 border-purple-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">4. Prayer of Thanksgiving</h3>
+                <p className="text-gray-700 leading-relaxed mb-3">
+                  CCC 2637&ndash;2638 insists that every event in life can become an occasion for
+                  thanksgiving. The Greek word <em>eucharistia</em> means &ldquo;thanksgiving,&rdquo;
+                  and the Eucharist &mdash; the central act of Catholic worship &mdash; is therefore
+                  the Church&rsquo;s supreme prayer of thanksgiving. Thanksgiving is not passive
+                  contentment; it is the active recognition that everything we have &mdash; being,
+                  breath, grace, redemption &mdash; is pure gift. Paul commands it unconditionally:
+                  &ldquo;Give thanks in all circumstances&rdquo; (1 Thess 5:18).
+                </p>
+              </div>
+
+              {/* Form 5 */}
+              <div className="border-l-4 border-rose-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">5. Prayer of Praise</h3>
+                <p className="text-gray-700 leading-relaxed mb-3">
+                  CCC 2639&ndash;2643 distinguishes praise from thanksgiving: thanksgiving is
+                  gratitude for what God <em>does</em>; praise is glory given to God for who he
+                  <em>is</em>. Praise is the most purely theocentric form of prayer &mdash; it asks
+                  nothing, celebrates nothing particular, expects nothing in return. It simply
+                  glorifies God because God is infinitely worthy of glory. The 150 Psalms, taken
+                  together, form the Church&rsquo;s original school of praise &mdash; covering
+                  every human emotion from lament and desolation to ecstatic joy.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Psalms: The Church&rsquo;s Original Prayer Book
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The 150 Psalms cover every form of prayer: lament, petition, praise, thanksgiving,
+                  intercession, trust, and complaint. Jesus himself prayed the Psalms &mdash; Psalm 22
+                  from the cross, Psalm 31 with his final breath. The Church has structured her
+                  Liturgy of the Hours around the Psalms for over 1,500 years. To pray the Psalms
+                  is to pray with the whole Church, across all time.
+                </p>
+                <p className="text-amber-700 text-sm italic">
+                  &ldquo;Let the Psalter be always in hand: it will be both a source of spiritual
+                  progress and a mirror of the life of the soul.&rdquo; &mdash; St. Ambrose,
+                  <em>Commentary on Psalm 1</em>
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  'CCC 2626&ndash;2643 (Forms of prayer)',
+                  'CCC 2626&ndash;2628 (Blessing and adoration)',
+                  'CCC 2629&ndash;2633 (Petition)',
+                  'CCC 2634&ndash;2636 (Intercession)',
+                  'CCC 2637&ndash;2638 (Thanksgiving)',
+                  'CCC 2639&ndash;2643 (Praise)',
+                  'Psalm 95:6; Revelation 7:12; Matthew 7:7',
+                  'St. Ambrose, <em>Commentary on Psalm 1</em>',
+                ].map((source, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+                    <p className="text-gray-700 text-sm" dangerouslySetInnerHTML={{ __html: source }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: VOCAL, MENTAL & CONTEMPLATIVE ==================== */}
+        {activeTab === 'vocal-mental-contemplative' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Three Expressions */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Mic className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Three Ways the Heart Prays</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 2700 opens with a clarification that matters: the three expressions of
+                prayer &mdash; vocal, mental, and contemplative &mdash; are not three separate
+                categories for three different types of Christians. They are three ways the same
+                prayer finds expression in human beings who are at once embodied, rational, and
+                spiritual. A devout lay person praying the Rosary on a bus may be engaged
+                simultaneously in all three: speaking the vocal formulas, meditating on the
+                mysteries, and resting in the silent presence of Mary&rsquo;s Son.
+              </p>
+
+              {/* Vocal Prayer */}
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-xl font-bold text-blue-900 mb-3">Vocal Prayer (CCC 2700&ndash;2704)</h3>
+                <p className="text-blue-800 leading-relaxed mb-3">
+                  Vocal prayer is prayer expressed in words &mdash; spoken aloud, whispered, or
+                  even voiced interiorly. It encompasses the great liturgical prayers (the Mass, the
+                  Liturgy of the Hours), traditional devotions (the Rosary, the Angelus, litanies),
+                  and spontaneous personal prayer. The incarnational logic of vocal prayer is strong:
+                  because we are embodied beings, our bodies participate in prayer. Jesus himself
+                  prayed aloud &mdash; &ldquo;Father, into your hands I commend my spirit&rdquo;
+                  (Luke 23:46). The Church has never accepted a purely interior, wordless spirituality
+                  that despises vocal expression.
+                </p>
+                <p className="text-blue-700 leading-relaxed">
+                  The danger CCC 2702 warns against is <em>mere recitation</em> without interior
+                  engagement. Christ&rsquo;s rebuke from Isaiah applies here: &ldquo;This people
+                  honors me with their lips, but their hearts are far from me&rdquo; (Mk 7:6).
+                  Vocal prayer without interior attention risks becoming the &ldquo;vain
+                  repetition&rdquo; Jesus warns against (Matt 6:7). The remedy is not to stop
+                  praying vocal prayers but to bring the heart along.
+                </p>
+              </div>
+
+              {/* Meditation */}
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-xl font-bold text-green-900 mb-3">Meditation (CCC 2705&ndash;2708)</h3>
+                <p className="text-green-800 leading-relaxed mb-3">
+                  CCC 2705 defines meditation as &ldquo;a prayerful quest engaging thought,
+                  imagination, emotion, and desire.&rdquo; Unlike casual reading, meditation
+                  re-reads, lingers, questions, savors &mdash; allowing a Scripture passage or
+                  doctrinal truth to penetrate the soul. The goal, per CCC 2708, is to turn the
+                  text toward <em>action</em>: &ldquo;Christian prayer tries above all to meditate
+                  on the mysteries of Christ.&rdquo;
+                </p>
+                <p className="text-green-800 leading-relaxed mb-3">
+                  The Catholic tradition has developed rich methods of meditation. <em>Lectio
+                  Divina</em> (sacred reading) &mdash; the Benedictine method of reading,
+                  meditating, praying, and contemplating a scriptural text &mdash; remains the
+                  primary school of Catholic meditation. The Ignatian method invites the
+                  practitioner to place themselves imaginatively within a Gospel scene. The
+                  Carmelite tradition developed more affective and volitional forms. The Rosary,
+                  properly prayed, is itself a school of meditation on the mysteries of Christ&rsquo;s
+                  life through Mary&rsquo;s eyes.
+                </p>
+              </div>
+
+              {/* Contemplative Prayer */}
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-xl font-bold text-purple-900 mb-3">Contemplative Prayer (CCC 2709&ndash;2724)</h3>
+                <p className="text-purple-800 leading-relaxed mb-3">
+                  CCC 2715 offers the most beautiful description: &ldquo;Contemplative prayer is
+                  the simple expression of the mystery of prayer. It is a gaze of faith fixed on
+                  Jesus, an attentiveness to the Word of God, a silent love.&rdquo; Contemplation
+                  does not mean emptying the mind in an Eastern sense; it is a loving, attentive
+                  gaze toward a Person &mdash; the Person of Christ.
+                </p>
+                <p className="text-purple-800 leading-relaxed mb-3">
+                  The Catholic tradition distinguishes between <em>acquired</em> contemplation
+                  &mdash; the fruit of sustained faithful prayer &mdash; and <em>infused</em>
+                  contemplation, which is a pure gift of grace that God grants without any
+                  technique or merit on our part. The Desert Fathers of the 3rd&ndash;4th centuries
+                  pioneered the pursuit of hesychia (stillness) as the condition for contemplative
+                  union. John of the Cross mapped the progressive deepening of contemplation in his
+                  poetry and theological treatises.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  No Hierarchy of Holiness
+                </h3>
+                <p className="text-amber-800">
+                  The progression from vocal to mental to contemplative prayer is <em>not</em> a
+                  spiritual hierarchy in which contemplatives are holier than Rosary-praying
+                  grandmothers. The Desert Fathers recognized that a simple person praying from
+                  pure faith and love can be more united to God than a technically accomplished
+                  contemplative who harbors pride or self-attachment. What matters is the
+                  sincerity of the heart&rsquo;s turning, not the sophistication of the method.
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  'CCC 2700&ndash;2724 (Three expressions of prayer)',
+                  'CCC 2700&ndash;2704 (Vocal prayer)',
+                  'CCC 2705&ndash;2708 (Meditation)',
+                  'CCC 2709&ndash;2724 (Contemplative prayer)',
+                  'CCC 2715 (&ldquo;A gaze of faith fixed on Jesus&rdquo;)',
+                  'Mark 7:6; Luke 23:46; Matthew 6:7',
+                  'St. John of the Cross, <em>The Ascent of Mount Carmel</em>',
+                  'St. Teresa of &Aacute;vila, <em>The Interior Castle</em>',
+                ].map((source, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+                    <p className="text-gray-700 text-sm" dangerouslySetInnerHTML={{ __html: source }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: OBSTACLES & DISTRACTIONS ==================== */}
+        {activeTab === 'obstacles-distractions' && (
+          <div className="space-y-8">
+
+            {/* Card 1: The Battle */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <CloudRain className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Battle of Prayer</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 2725 begins with a realistic acknowledgment: &ldquo;Prayer is both a gift of
+                grace and a determined response on our part. It always presupposes effort.&rdquo;
+                Anyone who has tried to maintain a regular life of prayer knows this is not
+                poetry &mdash; it is a description of lived experience. The tradition calls the
+                interior struggle of prayer the <em>militia spiritus</em>, the spiritual warfare,
+                in which the human will, wounded by original sin and pulled by distraction and
+                lethargy, must continually be brought back to God.
+              </p>
+
+              {/* Distraction */}
+              <div className="border-l-4 border-yellow-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">Distraction (CCC 2729)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  The most common obstacle: the mind wanders, images and anxieties intrude, the
+                  grocery list surfaces at the Our Father. CCC 2729 offers a key pastoral counsel:
+                  do not pursue each distraction or chase it away with violence, but return
+                  gently to the heart. The Catechism notes that distractions often reveal our
+                  attachments &mdash; what our minds drift to during prayer is itself diagnostic
+                  of what most occupies our hearts. They are not sins; they are invitations to
+                  renewed attention.
+                </p>
+              </div>
+
+              {/* Dryness */}
+              <div className="border-l-4 border-blue-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">Dryness / Aridity (CCC 2731)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  Dryness is when prayer feels empty, God seems absent, and the consolations
+                  that once made prayer easy have vanished. CCC 2731 warns that dryness is not
+                  always caused by negligence or sin &mdash; it can be part of God&rsquo;s own
+                  pedagogy. St. John of the Cross analyzed this as the &ldquo;dark night of
+                  the senses&rdquo;: God is purifying our love by weaning us from the
+                  <em>consolations of prayer</em> so that we learn to seek the <em>God of
+                  consolations</em> rather than the consolations themselves. Persevering in dry
+                  prayer is often more meritorious than praying in spiritual sweetness.
+                </p>
+              </div>
+
+              {/* Acedia */}
+              <div className="border-l-4 border-red-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">Lukewarmness / Acedia (CCC 2733)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  CCC 2733 describes acedia as &ldquo;a form of depression stemming from lax
+                  ascetical practice, decreasing vigilance, carelessness of heart.&rdquo; It is
+                  more than laziness: it is a spiritual despondency that makes God&rsquo;s
+                  demands seem burdensome and prayer feel pointless. Thomas Aquinas treated acedia
+                  as a capital sin in the <em>Summa Theologiae</em> (II&ndash;II, q.35) because it
+                  attacks the very foundation of the spiritual life &mdash; the joy and peace of
+                  knowing God. The remedy is not forced emotional enthusiasm but disciplined
+                  fidelity: showing up even when nothing is felt.
+                </p>
+              </div>
+
+              {/* Difficulties of Faith */}
+              <div className="border-l-4 border-purple-400 pl-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">Difficulties of Faith (CCC 2732)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  CCC 2732 identifies three related temptations: <em>discouragement</em> (&ldquo;my
+                  prayers are not heard&rdquo;), <em>presumption</em> (&ldquo;God must answer in
+                  the way I want&rdquo;), and <em>false humility</em> (&ldquo;I am not holy
+                  enough to pray, so why bother?&rdquo;). All three misunderstand what prayer
+                  is for. Prayer is not a transaction in which sufficient technique or holiness
+                  unlocks divine favor; it is a relationship with a Father who loves his
+                  children unconditionally and answers in ways that are best for them, not
+                  always as they prefer.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  The Remedy: Perseverance
+                </h3>
+                <p className="text-blue-800 leading-relaxed mb-3">
+                  CCC 2742&ndash;2745 returns to the Pauline injunction: &ldquo;Pray constantly&rdquo;
+                  (1 Thess 5:17). The key is not to wait until we feel like praying. CCC 2742
+                  reminds us that &ldquo;the Holy Spirit&hellip; teaches us to pray and intercedes
+                  for us&rdquo; (Rom 8:26&ndash;27): when we cannot pray, the Spirit prays in us.
+                  We are never alone in the struggle.
+                </p>
+                <p className="text-blue-700 text-sm italic">
+                  Bl. Teresa of Calcutta endured over 40 years of spiritual darkness &mdash; praying
+                  without consolation, without felt presence of God &mdash; yet continued to pray,
+                  minister, and smile. Her dark night, revealed only after her death, is one of
+                  the great modern witnesses to perseverance.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  St. Th&eacute;r&egrave;se on Falling Asleep in Prayer
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;I should be distressed about it, but I am not. I bear in mind that little
+                  children are just as pleasing to their parents when they are asleep as when
+                  they are awake.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; St. Th&eacute;r&egrave;se of Lisieux, <em>Story of a Soul</em>
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  'CCC 2725&ndash;2745 (The battle of prayer)',
+                  'CCC 2729 (Distraction)',
+                  'CCC 2731 (Dryness and aridity)',
+                  'CCC 2732 (Difficulties of faith)',
+                  'CCC 2733 (Acedia / lukewarmness)',
+                  'CCC 2742&ndash;2745 (Perseverance)',
+                  '1 Thessalonians 5:17; Romans 8:26&ndash;27',
+                  'Thomas Aquinas, <em>Summa Theologiae</em> II&ndash;II, q.35',
+                  'St. John of the Cross, <em>Dark Night of the Soul</em>',
+                  'St. Th&eacute;r&egrave;se, <em>Story of a Soul</em>',
+                ].map((source, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+                    <p className="text-gray-700 text-sm" dangerouslySetInnerHTML={{ __html: source }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: SCHOOL OF PRAYER ==================== */}
+        {activeTab === 'school-of-prayer' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Who Teaches Us */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <GraduationCap className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Who Teaches Us to Pray?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                CCC 2683&ndash;2696 treats the &ldquo;school of prayer&rdquo; &mdash; the various
+                teachers, communities, and traditions that the Holy Spirit has raised up in the
+                Church to form Christian people in the life of prayer. Prayer is not self-taught.
+                Even solitary mystics were formed within traditions, under spiritual directors,
+                shaped by the liturgy of the Church. The <em>ars orandi</em> (art of prayer) is
+                handed on, just as the <em>ars vivendi</em> (art of living) is.
+              </p>
+
+              {/* The Family */}
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-xl font-bold text-amber-900 mb-3">The Family: First School of Prayer</h3>
+                <p className="text-amber-800 leading-relaxed mb-3">
+                  CCC 2685&ndash;2686 calls the family the first school of prayer and the
+                  &ldquo;domestic church.&rdquo; Parents are the &ldquo;first heralds of
+                  faith&rdquo; (Lumen Gentium 11) and the first teachers of prayer: blessing
+                  children before bed, praying before meals, making the Sign of the Cross, praying
+                  the Rosary together. These seemingly small acts transmit a whole theology &mdash;
+                  that life is lived before God, that God is present at table, that the day is
+                  offered and closed in prayer.
+                </p>
+                <p className="text-amber-700 text-sm italic">
+                  Studies of adult Catholics who maintain a robust prayer life consistently find
+                  that childhood formation in family prayer is the single strongest predictor
+                  of adult faithfulness.
+                </p>
+              </div>
+
+              {/* The Holy Spirit */}
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-xl font-bold text-blue-900 mb-3">The Holy Spirit: Ultimate Teacher</h3>
+                <p className="text-blue-800 leading-relaxed mb-3">
+                  CCC 2680&ndash;2682 insists that the deepest teacher of prayer is the Holy
+                  Spirit himself. Romans 8:26 is the foundational text: &ldquo;The Spirit helps
+                  us in our weakness; for we do not know how to pray as we ought, but the Spirit
+                  himself intercedes for us with sighs too deep for words.&rdquo; This is not
+                  a description of an emergency fallback when our prayer fails; it is a
+                  description of the normal condition of Christian prayer. We never pray alone;
+                  we always pray in and through and with the Spirit who dwells in us.
+                </p>
+              </div>
+
+              {/* Priests, Catechesis, Consecrated Life */}
+              <div className="grid sm:grid-cols-2 gap-6 mb-6">
+                <div className="bg-green-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-bold text-green-900 mb-2">Priests & Deacons</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    CCC 2686 notes that the ordained are called to form their people in prayer
+                    through preaching, liturgy, and personal witness. The priest who prays is
+                    a more powerful teacher than the priest who merely teaches about prayer.
+                    The Liturgy of the Hours &mdash; which the ordained are bound to pray daily
+                    &mdash; is their primary school of prayer.
+                  </p>
+                </div>
+                <div className="bg-purple-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-bold text-purple-900 mb-2">Consecrated Life</h3>
+                  <p className="text-purple-800 text-sm leading-relaxed">
+                    CCC 2687 honors the role of monasteries and religious communities as
+                    &ldquo;schools of prayer for centuries&rdquo; &mdash; Benedictine abbeys,
+                    Carmelite convents, mendicant friars. The contemplative life is not
+                    marginal to the Church&rsquo;s mission; it is its heart, interceding
+                    for the world and embodying the Kingdom that is coming.
+                  </p>
+                </div>
+              </div>
+
+              {/* Saints as Models */}
+              <div className="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-4">Saints as Models of Prayer</h3>
+                <p className="text-gray-700 leading-relaxed mb-4">
+                  CCC 2683 notes: &ldquo;The witnesses who have preceded us into the kingdom,
+                  especially those whom the Church recognizes as saints, share in the living
+                  tradition of prayer.&rdquo; Each saint embodies a particular charism of prayer
+                  that illumines the whole:
+                </p>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div>
+                    <p className="font-semibold text-gray-800 mb-1">St. Francis of Assisi</p>
+                    <p className="text-gray-600 text-sm">Prayer as total poverty before God, rejoicing in creation as God&rsquo;s gift; the Canticle of the Sun as the fruit of contemplation.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-800 mb-1">St. Ignatius of Loyola</p>
+                    <p className="text-gray-600 text-sm">Prayer as discernment of spirits; the <em>Spiritual Exercises</em> as the great Catholic manual of prayer in action.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-800 mb-1">St. Th&eacute;r&egrave;se of Lisieux</p>
+                    <p className="text-gray-600 text-sm">The Little Way: prayer accessible to all, not as heroic asceticism but as childlike trust in the Father&rsquo;s love.</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-800 mb-1">St. John Vianney</p>
+                    <p className="text-gray-600 text-sm">The Cur&eacute; d&rsquo;Ars who spent hours in silent adoration before the Blessed Sacrament; the model of the praying parish priest.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Prayer in Community
+                </h3>
+                <p className="text-amber-800">
+                  From ancient desert monasteries to modern charismatic prayer groups and parish
+                  lectio divina circles, the Church has always recognized that praying together
+                  deepens individual prayer. Jesus promised: &ldquo;Where two or three are gathered
+                  in my name, I am there among them&rdquo; (Matt 18:20). Community prayer does not
+                  replace personal prayer; it feeds and sustains it, and situates the individual
+                  within the great stream of the Church&rsquo;s unceasing prayer.
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  'CCC 2680&ndash;2696 (The school of prayer)',
+                  'CCC 2683 (Saints as teachers of prayer)',
+                  'CCC 2685&ndash;2686 (Family as first school)',
+                  'CCC 2687 (Consecrated life)',
+                  'CCC 2688 (Catechesis and prayer)',
+                  'Lumen Gentium 11 (parents as heralds of faith)',
+                  'Romans 8:26&ndash;27 (Spirit intercedes for us)',
+                  'Matthew 18:20',
+                  'St. Ignatius, <em>Spiritual Exercises</em>',
+                  'St. Francis, <em>Canticle of the Sun</em>',
+                ].map((source, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+                    <p className="text-gray-700 text-sm" dangerouslySetInnerHTML={{ __html: source }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: THE LORD'S PRAYER ==================== */}
+        {activeTab === 'the-our-father' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Introduction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Summary of the Whole Gospel</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Tertullian called the Lord&rsquo;s Prayer &ldquo;the summary of the whole
+                gospel&rdquo; (<em>On Prayer</em>, ch. 1). Thomas Aquinas called it &ldquo;the most
+                perfect of prayers&rdquo; (<em>Summa Theologiae</em> II&ndash;II, q.83, a.9):
+                &ldquo;In it we ask not only for all the things we can rightly desire, but also in the
+                order in which they should be desired.&rdquo; The Catechism devotes CCC 2759&ndash;2865
+                &mdash; over 100 paragraphs &mdash; to the Our Father alone, making it the longest
+                single treatment in Part IV on prayer.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The setting matters: in Luke 11:1&ndash;2, a disciple watches Jesus at prayer and
+                asks, &ldquo;Lord, teach us to pray.&rdquo; Jesus responds not with a treatise on
+                prayer but with a <em>prayer</em>: the Our Father. Matthew&rsquo;s version (6:9&ndash;13)
+                is the longer, liturgical form used in the Church&rsquo;s worship; Luke&rsquo;s is
+                more intimate and condensed. CCC 2759&ndash;2760 notes that the Our Father is at once
+                a revelation of the Father&rsquo;s name, a summary of the Kingdom&rsquo;s demands,
+                and a model for all prayer.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Catechism of the Catholic Church
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Lord&rsquo;s Prayer is truly the summary of the whole gospel.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; Tertullian, cited in CCC 2761</p>
+              </div>
+            </div>
+
+            {/* Card 2: The Petitions */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-3xl font-bold text-gray-800 mb-8">The Seven Petitions</h2>
+
+              {/* Our Father */}
+              <div className="border-l-4 border-amber-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Our Father&rdquo; (CCC 2779&ndash;2785)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  The address is itself a revolution. Not &ldquo;My Father&rdquo; &mdash; but
+                  <em>Our</em> Father: we pray as a body, as a family, as the Church. CCC 2780
+                  explains that we can call God Father only through the Son, in the Spirit &mdash;
+                  this address is possible only for the baptized, who have been adopted as children
+                  in Christ. The Greek word <em>parresia</em> (boldness) captures the audacity of
+                  this address: we approach the Creator of the universe as a child approaches a
+                  loving parent.
+                </p>
+              </div>
+
+              {/* Who art in heaven */}
+              <div className="border-l-4 border-blue-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Who art in heaven&rdquo; (CCC 2794&ndash;2796)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  CCC 2794 notes that &ldquo;heaven&rdquo; here is not a spatial location above
+                  the clouds &mdash; it is a mode of being, a quality of transcendence and glory.
+                  Heaven is where God&rsquo;s will is done perfectly, and this phrase orients the
+                  whole prayer eschatologically: we pray as people whose true home is not yet
+                  fully realized, who live between the first and second comings of Christ.
+                </p>
+              </div>
+
+              {/* Hallowed be thy name */}
+              <div className="border-l-4 border-green-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Hallowed be thy name&rdquo; (CCC 2807&ndash;2815)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  This first petition is a prayer that God&rsquo;s name be recognized as holy &mdash;
+                  not because God needs our acknowledgment to be holy, but because the world
+                  needs to know it. CCC 2814 links this to Ezekiel 36:23 and to the baptismal
+                  vocation: we hallow God&rsquo;s name by holy lives. The petition is both a
+                  prayer and a commitment.
+                </p>
+              </div>
+
+              {/* Thy kingdom come */}
+              <div className="border-l-4 border-purple-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Thy kingdom come&rdquo; (CCC 2816&ndash;2821)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  The Kingdom is already present in Christ but not yet fully manifest &mdash; this
+                  tension defines Christian eschatology. CCC 2818 notes that by the Lord&rsquo;s
+                  Prayer we are &ldquo;detached from temporal attachments to grow in desire for the
+                  Kingdom.&rdquo; The Aramaic <em>Maranatha</em> &mdash; &ldquo;Come, Lord Jesus&rdquo;
+                  (Rev 22:20) &mdash; is the briefest expression of this petition, preserved from
+                  the earliest Christian liturgy.
+                </p>
+              </div>
+
+              {/* Thy will be done */}
+              <div className="border-l-4 border-rose-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Thy will be done&rdquo; (CCC 2822&ndash;2827)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  Not passive resignation but active surrender. CCC 2823 identifies the will of
+                  God as &ldquo;our salvation&rdquo; (citing 1 Tim 2:4) &mdash; this is not an
+                  arbitrary divine demand but the expression of infinite love. The supreme model
+                  is Gethsemane (Matt 26:39): &ldquo;Not as I will, but as you will.&rdquo; Christ&rsquo;s
+                  prayer in the garden teaches us what this petition really costs &mdash; and what
+                  it gives.
+                </p>
+              </div>
+
+              {/* Daily bread */}
+              <div className="border-l-4 border-yellow-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Give us this day our daily bread&rdquo; (CCC 2828&ndash;2837)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  The Greek word <em>epiousios</em> &mdash; translated &ldquo;daily&rdquo; &mdash; is
+                  a uniquely Christian coinage, found nowhere else in Greek literature. Jerome
+                  rendered it <em>supersubstantialis</em> (&ldquo;supersubstantial&rdquo;) in the
+                  Latin Vulgate of Matthew, hinting at the Eucharistic bread that surpasses all
+                  ordinary nourishment. CCC 2837 holds both dimensions together: literal bread
+                  (our dependence on God for physical life) and the Eucharist (our dependence on
+                  God for eternal life).
+                </p>
+              </div>
+
+              {/* Forgive us */}
+              <div className="border-l-4 border-indigo-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;And forgive us our trespasses...&rdquo; (CCC 2838&ndash;2845)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  The sixth petition is the most demanding precisely because it contains a
+                  condition: we ask to be forgiven &ldquo;as we forgive those who trespass against
+                  us.&rdquo; Matt 6:14&ndash;15 and CCC 2840 make the connection explicit and
+                  sobering: our reception of divine forgiveness is linked to our willingness to
+                  extend it. Augustine&rsquo;s <em>Letter 130 to Proba</em> meditates extensively
+                  on this as the heart of Christian moral life: the forgiven must become forgivers.
+                </p>
+              </div>
+
+              {/* Lead us not / deliver us */}
+              <div className="border-l-4 border-gray-400 pl-6 mb-8">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">&ldquo;Lead us not into temptation&hellip; deliver us from evil&rdquo; (CCC 2846&ndash;2865)</h3>
+                <p className="text-gray-700 leading-relaxed">
+                  This petition does not suggest God tempts us &mdash; James 1:13 explicitly
+                  denies it. Rather, we ask not to be led onto the paths that lead to sin, and
+                  to be delivered from the Evil One. CCC 2851 notes that &ldquo;evil&rdquo; in
+                  Matthew 6:13 is <em>tou ponerou</em> (the Evil One, i.e., the devil) in the
+                  original Greek &mdash; a personal opponent, not an abstract force. The doxology
+                  (&ldquo;For thine is the kingdom&hellip;&rdquo;) is not in Luke and was added
+                  liturgically, drawing on 1 Chronicles 29:11&ndash;13.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Scholar highlight */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  Pope Benedict XVI on the Our Father
+                </h3>
+                <p className="text-green-800 leading-relaxed mb-3">
+                  In <em>Jesus of Nazareth</em> Vol. 1, Ch. 5, Pope Benedict XVI offers a sustained
+                  theological meditation on the Lord&rsquo;s Prayer. He argues that the Our Father
+                  is not merely a set of requests but a &ldquo;transformation of ourselves&rdquo;:
+                  in praying it, we allow our desires to be reshaped by God&rsquo;s desires, our
+                  will to be aligned with his. Each petition, Benedict argues, is also a
+                  commitment &mdash; a promise to live in the direction of what we pray.
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  St. Augustine on Praying Well
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;If we pray rightly and fittingly, we can say nothing other than what is
+                  contained in this prayer of the Lord.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Augustine, <em>Letter 130 to Proba</em>
+                </p>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Sources & Further Reading</h2>
+              <div className="grid sm:grid-cols-2 gap-4">
+                {[
+                  'CCC 2759&ndash;2865 (The Lord&rsquo;s Prayer)',
+                  'CCC 2779&ndash;2785 (&ldquo;Our Father&rdquo;)',
+                  'CCC 2816&ndash;2821 (&ldquo;Thy kingdom come&rdquo;)',
+                  'CCC 2828&ndash;2837 (&ldquo;Daily bread&rdquo;)',
+                  'CCC 2838&ndash;2845 (Forgiveness)',
+                  'CCC 2846&ndash;2865 (Temptation and deliverance)',
+                  'Matthew 6:9&ndash;13; Luke 11:1&ndash;2',
+                  'Tertullian, <em>On Prayer</em>, ch. 1',
+                  'Thomas Aquinas, <em>Summa Theologiae</em> II&ndash;II, q.83, a.9',
+                  'Augustine, <em>Letter 130 to Proba</em>',
+                  'Pope Benedict XVI, <em>Jesus of Nazareth</em> Vol. 1, Ch. 5',
+                ].map((source, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+                    <p className="text-gray-700 text-sm" dangerouslySetInnerHTML={{ __html: source }} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== CROSS-LINKS ==================== */}
+        <div className="bg-white rounded-lg shadow-lg p-8 mt-8">
+          <h2 className="text-2xl font-bold text-gray-800 mb-6">Explore Related Topics</h2>
+          <div className="grid sm:grid-cols-3 gap-4">
+            <a
+              href="/prayer/rosary"
+              className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-amber-400 hover:bg-amber-50 transition-colors"
+            >
+              <div className="w-10 h-10 bg-amber-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <Heart className="w-5 h-5 text-amber-700" />
+              </div>
+              <div>
+                <p className="font-semibold text-gray-800">The Holy Rosary</p>
+                <p className="text-gray-500 text-sm flex items-center gap-1">
+                  Learn more <ArrowRight className="w-3 h-3" />
+                </p>
+              </div>
+            </a>
+            <a
+              href="/prayer/contemplative-prayer"
+              className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-amber-400 hover:bg-amber-50 transition-colors"
+            >
+              <div className="w-10 h-10 bg-amber-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <Star className="w-5 h-5 text-amber-700" />
+              </div>
+              <div>
+                <p className="font-semibold text-gray-800">Contemplative Prayer</p>
+                <p className="text-gray-500 text-sm flex items-center gap-1">
+                  Learn more <ArrowRight className="w-3 h-3" />
+                </p>
+              </div>
+            </a>
+            <a
+              href="/mysteries/public-revelation"
+              className="flex items-center gap-3 p-4 rounded-lg border border-gray-200 hover:border-amber-400 hover:bg-amber-50 transition-colors"
+            >
+              <div className="w-10 h-10 bg-amber-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <BookOpen className="w-5 h-5 text-amber-700" />
+              </div>
+              <div>
+                <p className="font-semibold text-gray-800">Public Revelation</p>
+                <p className="text-gray-500 text-sm flex items-center gap-1">
+                  Learn more <ArrowRight className="w-3 h-3" />
+                </p>
+              </div>
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/rosary/page.tsx
+++ b/src/app/prayer/rosary/page.tsx
@@ -1,0 +1,1099 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import {
+  BookOpen,
+  Heart,
+  Star,
+  Sun,
+  Moon,
+  Cross,
+  ArrowRight,
+  Scroll,
+  Globe,
+  Users,
+} from 'lucide-react'
+
+type TabId =
+  | 'origin-history'
+  | 'joyful-mysteries'
+  | 'sorrowful-mysteries'
+  | 'glorious-mysteries'
+  | 'luminous-mysteries'
+  | 'how-to-pray'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'origin-history', label: 'Origin & History' },
+  { id: 'joyful-mysteries', label: 'Joyful Mysteries' },
+  { id: 'sorrowful-mysteries', label: 'Sorrowful Mysteries' },
+  { id: 'glorious-mysteries', label: 'Glorious Mysteries' },
+  { id: 'luminous-mysteries', label: 'Luminous Mysteries' },
+  { id: 'how-to-pray', label: 'How to Pray the Rosary' },
+]
+
+export default function RosaryPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('origin-history')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            The Holy Rosary
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            A compendium of the Gospel &mdash; the history, mysteries, and practice of the Rosary,
+            the most beloved Marian prayer of the Catholic Church.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: ORIGIN & HISTORY ==================== */}
+        {activeTab === 'origin-history' && (
+          <div className="space-y-8">
+
+            {/* Card 1: What Is the Rosary? */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">What Is the Rosary?</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Rosary is a Marian prayer that combines vocal prayer with meditation on the life
+                of Christ, seen through Mary&rsquo;s eyes. It weaves together the <em>Our Father</em>,
+                the <em>Hail Mary</em>, and the <em>Glory Be</em> into a rhythm of contemplation,
+                leading the pray-er through the great mysteries of salvation history &mdash; the
+                Incarnation, the Passion, the Resurrection, and the life of the early Church.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Pope John Paul II, in his apostolic letter <em>Rosarium Virginis Mariae</em> (2002),
+                called the Rosary &ldquo;a compendium of the Gospel.&rdquo; It is not, he insisted, a
+                mechanical repetition of words but a deeply Christocentric meditation: each decade
+                is an invitation to dwell on a specific moment in the life of Christ, with Mary as
+                the model contemplative who &ldquo;kept all these things and pondered them in her
+                heart&rdquo; (Luke 2:19).
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Rosary Is Not Just Repetitive Prayer
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Each decade of Hail Marys is meant to be a meditation on a mystery of Christ&rsquo;s
+                  life. The vocal prayers create a contemplative rhythm that frees the mind and
+                  heart for deeper encounter with God. Pope John Paul II described this rhythm
+                  as &ldquo;a kind of mantra&rdquo; (<em>Rosarium Virginis Mariae</em> &sect;26) &mdash;
+                  not in an Eastern sense but as a repetition that settles and centers the soul,
+                  allowing the imagination to rest on the mystery being contemplated.
+                </p>
+                <p className="text-amber-700 text-sm">
+                  &mdash; Cf. CCC 2708: &ldquo;Meditation engages thought, imagination, emotion, and desire.
+                  This mobilization of faculties is necessary in order to deepen our convictions of
+                  faith, prompt the conversion of our heart, and strengthen our will to follow Christ.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Rosary belongs to a tradition of <em>lectio divina</em> &mdash; prayerful reading
+                and meditation on Scripture &mdash; that runs throughout Catholic spirituality. By
+                meditating on the mysteries, the pray-er enters into the scenes of the Gospel and
+                allows the Holy Spirit to apply their meaning to his or her own life.
+              </p>
+            </div>
+
+            {/* Card 2: Medieval Origins */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Scroll className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Medieval Origins</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The practice of counting prayers on beads is ancient, reaching back to early
+                Christian monasticism. The Desert Fathers used pebbles or knotted cords to count
+                their repetitions of the Jesus Prayer or Psalms. This practice of <em>metered
+                repetition</em> spread through monastic communities as a way to pray continuously
+                (cf. 1 Thess 5:17).
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                By the 12th and 13th centuries, the practice of praying 150 Hail Marys &mdash;
+                one for each of the 150 Psalms &mdash; had developed among lay people who could not
+                recite the Latin Psalter. This &ldquo;Our Lady&rsquo;s Psalter&rdquo; became the direct
+                ancestor of the Rosary as we know it. The practice spread widely in the context
+                of 12th-century Marian devotion.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  St. Dominic and the Dominican Tradition
+                </h3>
+                <p className="text-blue-800 mb-3">
+                  Pious tradition credits St. Dominic de Guzm&aacute;n (1170&ndash;1221) with receiving
+                  the Rosary from Our Lady herself. This is cherished tradition rather than established
+                  historical fact; modern scholarship locates the standardized fifteen-decade Rosary
+                  in the Dominican Confraternity movement of the 15th century. The Catechism and papal
+                  documents present the Dominican connection as tradition rather than proven history.
+                  What is certain is that the Dominicans became the great promoters and evangelizers
+                  of the Rosary throughout Europe.
+                </p>
+                <p className="text-blue-700 text-sm">
+                  &mdash; Cf. CCC 971: &ldquo;The Church&rsquo;s Marian prayer is not in competition with
+                  the prayer addressed to God the Father, but glorifies him, since it comes from
+                  him and leads back to him.&rdquo;
+                </p>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Alain de la Roche (1428&ndash;1475)
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The Flemish Dominican Alain de la Roche (Alanus de Rupe) is largely responsible
+                  for the standardized form of the Rosary we pray today. Around 1470 he founded the
+                  <em> Confraternity of the Most Holy Rosary</em> and promoted the fifteen-mystery,
+                  150-Hail-Mary structure across northern Europe. His confraternities spread rapidly
+                  and helped make the Rosary a universal Catholic devotion.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Historical Milestones */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Globe className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Historical Milestones</h2>
+              </div>
+
+              <div className="space-y-6">
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">
+                    Battle of Lepanto (1571)
+                  </h3>
+                  <p className="text-blue-800 text-sm">
+                    Pope Pius V credited the Christian naval victory over the Ottoman fleet at
+                    Lepanto to the intercession of Our Lady of the Rosary. He had called on all
+                    of Europe to pray the Rosary for the fleet&rsquo;s success. Following the victory,
+                    he established the feast of Our Lady of Victory (October 7), later renamed
+                    Our Lady of the Rosary &mdash; still observed on October 7 to this day.
+                  </p>
+                </div>
+
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">
+                    Pope Leo XIII &mdash; &ldquo;The Pope of the Rosary&rdquo; (1878&ndash;1903)
+                  </h3>
+                  <p className="text-amber-800 text-sm">
+                    Pope Leo XIII wrote eleven encyclicals and apostolic letters dedicated to the
+                    Rosary &mdash; more than any other pope. He made October the official &ldquo;Month of
+                    the Holy Rosary&rdquo; and issued <em>Supremi Apostolatus Officio</em> (1883),
+                    the first of his great Rosary encyclicals. His consistent teaching: the Rosary
+                    is a weapon against evil, a school of Christian life, and a source of social
+                    and family renewal.
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-2">
+                    Our Lady of F&aacute;tima (1917)
+                  </h3>
+                  <p className="text-green-800 text-sm">
+                    In each of the six apparitions at F&aacute;tima (May&ndash;October 1917), Our Lady
+                    asked the shepherd children &mdash; Lucia, Francisco, and Jacinta &mdash; to pray
+                    the Rosary every day &ldquo;for peace in the world and the end of the war.&rdquo; The
+                    F&aacute;tima message gave the Rosary renewed urgency in the 20th century and
+                    introduced the F&aacute;tima Prayer still prayed after the Glory Be at the end
+                    of each decade.
+                  </p>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-2">
+                    Vatican II and Lumen Gentium (1964)
+                  </h3>
+                  <p className="text-purple-800 text-sm">
+                    The Second Vatican Council did not diminish Marian devotion but placed it
+                    within its proper Christological context. Chapter 8 of <em>Lumen Gentium</em>
+                    presents Mary as the pre-eminent member of the Church and model of faith, not
+                    a separate figure above the Church. This Christological grounding was embraced
+                    by Pope John Paul II, who made the Rosary explicitly a &ldquo;Gospel prayer&rdquo;
+                    that meditates on Christ.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-2">
+                    Pope John Paul II &mdash; <em>Rosarium Virginis Mariae</em> (2002)
+                  </h3>
+                  <p className="text-blue-800 text-sm">
+                    In October 2002, John Paul II declared 2002&ndash;2003 the &ldquo;Year of the Rosary&rdquo;
+                    and issued <em>Rosarium Virginis Mariae</em>, one of the most important documents
+                    on the Rosary ever written. He added the five Luminous Mysteries (the Mysteries
+                    of Light), covering Christ&rsquo;s public ministry &mdash; a dimension absent from
+                    the traditional three sets of mysteries. He called the Rosary his
+                    &ldquo;favorite prayer&rdquo; and &ldquo;a compendium of the Gospel.&rdquo;
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: JOYFUL MYSTERIES ==================== */}
+        {activeTab === 'joyful-mysteries' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Introduction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Star className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Joyful Mysteries</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Joyful Mysteries are prayed on <strong>Mondays and Saturdays</strong>. They
+                meditate on the events of the Annunciation, Incarnation, and Christ&rsquo;s hidden
+                life &mdash; the &ldquo;joyful&rdquo; mysteries because they recount the dawn of salvation,
+                the coming of God into the world, and the quiet years in Nazareth. They form a
+                meditation on <em>humility</em> &mdash; God emptying Himself to become a child
+                (Philippians 2:6&ndash;8).
+              </p>
+
+              <div className="space-y-6">
+
+                {/* Mystery 1 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    1. The Annunciation <span className="font-normal text-amber-700">(Luke 1:26&ndash;38)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    The Angel Gabriel announces to the Virgin Mary that she will conceive by the
+                    Holy Spirit and bear the Son of God. Mary&rsquo;s response &mdash; <em>&ldquo;Let it be
+                    done to me according to your word&rdquo;</em> (<em>fiat</em>) &mdash; is the pivotal
+                    moment of human history: the New Eve says &ldquo;yes&rdquo; where the first Eve said
+                    &ldquo;no.&rdquo; The Incarnation &mdash; God becoming flesh &mdash; begins at this
+                    moment of consent.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Humility and faith</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 2 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    2. The Visitation <span className="font-normal text-amber-700">(Luke 1:39&ndash;56)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    Immediately after the Annunciation, Mary travels &ldquo;in haste&rdquo; to the hill
+                    country of Judah to visit her cousin Elizabeth, who is six months pregnant with
+                    John the Baptist. At Mary&rsquo;s greeting, John leaps in the womb and Elizabeth
+                    is filled with the Holy Spirit: &ldquo;Blessed are you among women, and blessed is
+                    the fruit of your womb!&rdquo; Mary responds with the <em>Magnificat</em> (Luke
+                    1:46&ndash;55), the great canticle of the Church prayed every evening at Vespers.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Charity and love of neighbor</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 3 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    3. The Nativity <span className="font-normal text-amber-700">(Luke 2:1&ndash;20)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    The Second Person of the Trinity is born in a stable in Bethlehem, laid in a
+                    manger because there was no room at the inn. Angels proclaim &ldquo;Glory to God in
+                    the highest&rdquo; to shepherds in the fields. The Incarnation reaches its
+                    culmination: Emmanuel, &ldquo;God with us.&rdquo; Meditating on the Nativity invites
+                    a spirit of detachment from material comfort &mdash; God Himself chose poverty
+                    and hiddenness as the setting for His entry into the world.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Poverty of spirit and detachment from worldly things</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 4 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    4. The Presentation <span className="font-normal text-amber-700">(Luke 2:22&ndash;38)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    Forty days after the birth, Mary and Joseph bring the infant Jesus to the Temple
+                    in Jerusalem to fulfill the Law (Lev 12:1&ndash;8; Exod 13:2). The elderly Simeon,
+                    moved by the Holy Spirit, recognizes the child as the &ldquo;light of revelation to
+                    the Gentiles&rdquo; and prophesies that a sword will pierce Mary&rsquo;s own soul
+                    (Luke 2:35) &mdash; the first hint of the Passion. The prophetess Anna also
+                    gives thanks and speaks of the child to all who await the redemption of Jerusalem.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Purity and obedience</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 5 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    5. The Finding in the Temple <span className="font-normal text-amber-700">(Luke 2:41&ndash;52)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    When Jesus is twelve years old, his family travels to Jerusalem for Passover.
+                    On the journey home, Mary and Joseph realize he is not in the caravan. After
+                    three days of searching (a prefigurement of the three days in the tomb), they
+                    find him in the Temple, sitting among the teachers, listening and asking
+                    questions. His response to his anxious parents: &ldquo;Did you not know that I
+                    must be in my Father&rsquo;s house?&rdquo; (Luke 2:49). Luke notes that Mary &ldquo;kept
+                    all these things in her heart&rdquo; (Luke 2:51).
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Zeal for God and fidelity to vocation</strong>
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: SORROWFUL MYSTERIES ==================== */}
+        {activeTab === 'sorrowful-mysteries' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Introduction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-red-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Sorrowful Mysteries</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Sorrowful Mysteries are prayed on <strong>Tuesdays and Fridays</strong>. They
+                meditate on the Passion of Christ &mdash; His agony, arrest, scourging, crowning,
+                the carrying of the cross, and His death on Calvary. These mysteries stand at the
+                heart of Christian faith: the Passion is not a tragedy to be mourned but the
+                supreme act of love by which the world was redeemed. Mary stood at the foot of the
+                cross (John 19:25) and is uniquely qualified to lead us through these mysteries.
+              </p>
+
+              <div className="space-y-6">
+
+                {/* Mystery 1 */}
+                <div className="bg-red-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-red-900 mb-2">
+                    1. The Agony in the Garden
+                    <span className="font-normal text-red-700"> (Luke 22:39&ndash;46; Matt 26:36&ndash;46)</span>
+                  </h3>
+                  <p className="text-red-800 mb-3">
+                    In the Garden of Gethsemane, Jesus prays that &ldquo;this cup&rdquo; might pass from him
+                    &mdash; yet yields completely to the Father&rsquo;s will: &ldquo;Not my will, but yours
+                    be done.&rdquo; Luke records that his sweat became like drops of blood
+                    (<em>hematidrosis</em>), a recognized medical phenomenon under extreme stress.
+                    An angel strengthens him. His disciples, asked to keep watch, fall asleep.
+                    This mystery teaches conformity to God&rsquo;s will in our own dark moments.
+                  </p>
+                  <p className="text-red-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Contrition and conformity to God&rsquo;s will</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 2 */}
+                <div className="bg-red-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-red-900 mb-2">
+                    2. The Scourging at the Pillar
+                    <span className="font-normal text-red-700"> (John 19:1; Isa 53:5)</span>
+                  </h3>
+                  <p className="text-red-800 mb-3">
+                    Pilate orders Jesus flogged. Roman <em>flagellatio</em> was administered with
+                    the <em>flagrum</em> &mdash; a multi-thonged whip with lead balls or bone chips
+                    attached &mdash; and could be lethally brutal. Isaiah had prophesied centuries
+                    earlier: &ldquo;By his stripes we are healed&rdquo; (Isa 53:5). The physical suffering
+                    of the Passion begins. Meditating on this mystery calls the faithful to a spirit
+                    of mortification and purity of heart.
+                  </p>
+                  <p className="text-red-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Purity and mortification</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 3 */}
+                <div className="bg-red-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-red-900 mb-2">
+                    3. The Crowning with Thorns
+                    <span className="font-normal text-red-700"> (Matt 27:27&ndash;31; John 19:2&ndash;3)</span>
+                  </h3>
+                  <p className="text-red-800 mb-3">
+                    The Roman soldiers take Jesus into the praetorium, dress him in a purple robe,
+                    weave a crown of thorns and place it on his head, put a reed in his right hand,
+                    and mockingly kneel before him: &ldquo;Hail, King of the Jews!&rdquo; Then they strike
+                    him, spit on him, and beat the crown deeper into his head. The mockery was meant
+                    to humiliate; in fact it proclaimed the truth &mdash; he is the King. Meditating
+                    on this mystery fosters courage to endure mockery for the faith.
+                  </p>
+                  <p className="text-red-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Moral courage and patience in suffering</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 4 */}
+                <div className="bg-red-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-red-900 mb-2">
+                    4. The Carrying of the Cross
+                    <span className="font-normal text-red-700"> (Luke 23:26&ndash;32; John 19:17)</span>
+                  </h3>
+                  <p className="text-red-800 mb-3">
+                    Jesus carries his cross toward Golgotha, the Place of the Skull. Weakened by the
+                    scourging, he falls; Simon of Cyrene is pressed into service to help carry the
+                    crossbeam. The women of Jerusalem weep for him; he speaks to them (Luke
+                    23:28&ndash;31). He has told his disciples: &ldquo;If any man will come after me,
+                    let him deny himself and take up his cross daily and follow me&rdquo; (Luke 9:23).
+                    The carrying of the cross is not metaphor but literal and historical &mdash; and
+                    the model for every Christian&rsquo;s spiritual life.
+                  </p>
+                  <p className="text-red-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Patience and perseverance</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 5 */}
+                <div className="bg-red-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-red-900 mb-2">
+                    5. The Crucifixion
+                    <span className="font-normal text-red-700"> (John 19:17&ndash;30; Luke 23:33&ndash;46)</span>
+                  </h3>
+                  <p className="text-red-800 mb-3">
+                    At Calvary, Jesus is nailed to the cross and lifted up between two criminals.
+                    The darkness covers the land from noon until three o&rsquo;clock. He speaks
+                    the Seven Last Words. At the ninth hour he cries out and gives up his spirit.
+                    The veil of the Temple is torn in two from top to bottom. A soldier pierces his
+                    side with a lance and blood and water flow out &mdash; a sign of the Eucharist and
+                    Baptism (John 19:34). Mary stands at the foot of the cross. &ldquo;It is finished&rdquo;
+                    (John 19:30). This is the central event of all salvation history.
+                  </p>
+                  <p className="text-red-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Salvation and faith in the Paschal Mystery</strong>
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: GLORIOUS MYSTERIES ==================== */}
+        {activeTab === 'glorious-mysteries' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Introduction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Sun className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Glorious Mysteries</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Glorious Mysteries are prayed on <strong>Wednesdays and Sundays</strong>. They
+                meditate on Christ&rsquo;s triumph over death, His ascent to the Father, the gift of the
+                Holy Spirit at Pentecost, and the final glorification of Mary &mdash; previewing the
+                destiny promised to all who share in the Paschal Mystery. These mysteries are the
+                fruit of the Sorrowful ones: the Resurrection is the answer to the Crucifixion;
+                the Coronation of Mary is the first fruit of what Christ&rsquo;s victory means for
+                redeemed humanity.
+              </p>
+
+              <div className="space-y-6">
+
+                {/* Mystery 1 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    1. The Resurrection
+                    <span className="font-normal text-amber-700"> (Matt 28:1&ndash;10; John 20:1&ndash;18)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    On the first day of the week, the women find the tomb empty and an angel proclaims:
+                    &ldquo;He is not here, for he has risen, as he said&rdquo; (Matt 28:6). Mary Magdalene
+                    encounters the risen Christ in the garden and is sent as the first apostle of
+                    the Resurrection: &ldquo;Go to my brothers and tell them&rdquo; (John 20:17). The
+                    Resurrection is not resuscitation but the entrance of Jesus&rsquo; glorified body
+                    into the New Creation &mdash; the &ldquo;firstfruits of those who have fallen asleep&rdquo;
+                    (1 Cor 15:20).
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Faith in the resurrection of the body</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 2 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    2. The Ascension
+                    <span className="font-normal text-amber-700"> (Acts 1:9&ndash;11; Mark 16:19)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    Forty days after the Resurrection, Jesus leads his disciples to the Mount of
+                    Olives and is taken up into heaven in their sight, a cloud hiding him from their
+                    view. Two men in white garments appear: &ldquo;Men of Galilee, why do you stand
+                    looking up into heaven?&rdquo; Christ ascends not to abandon us but to prepare a
+                    place for us (John 14:2) and to reign at the right hand of the Father as eternal
+                    High Priest (Heb 4:14), interceding for us.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Desire for heaven and hope</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 3 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    3. The Descent of the Holy Spirit
+                    <span className="font-normal text-amber-700"> (Acts 2:1&ndash;13)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    Ten days after the Ascension, on the Jewish feast of Pentecost, the Holy Spirit
+                    descends on the disciples gathered with Mary in the upper room: tongues of fire
+                    rest on each of them and they are filled with the Holy Spirit, speaking in the
+                    languages of all the peoples gathered in Jerusalem. Peter&rsquo;s first sermon results
+                    in three thousand baptisms. The Church is born. This mystery invites meditation
+                    on the gifts of the Spirit in our own lives.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Wisdom and zeal for souls</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 4 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    4. The Assumption of Mary
+                    <span className="font-normal text-amber-700"> (Defined by Pope Pius XII, <em>Munificentissimus Deus</em>, 1950)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    At the end of her earthly life, Mary was taken up body and soul into heavenly
+                    glory. Pope Pius XII defined this as a dogma of faith in 1950. The Assumption
+                    has deep Scriptural types: Revelation 12:1 (&ldquo;a woman clothed with the sun&rdquo;)
+                    and the pattern of Elijah (2 Kings 2:11) and Enoch (Gen 5:24). Mary&rsquo;s bodily
+                    glorification is the first fruits of what the Resurrection promises to all the
+                    redeemed. CCC 966: She is &ldquo;already sharing in the glory of her Son&rsquo;s
+                    Resurrection.&rdquo;
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Grace of a holy death</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 5 */}
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-2">
+                    5. The Coronation of Mary
+                    <span className="font-normal text-amber-700"> (Rev 12:1; CCC 966)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    Mary is crowned Queen of Heaven and Earth, reigning with her Son as intercessor
+                    and mother of all the redeemed. <em>Lumen Gentium</em> 59: she &ldquo;was exalted by
+                    the Lord as Queen of the universe, that she might be the more fully conformed
+                    to her Son, the Lord of lords and the conqueror of sin and death.&rdquo; As Queen,
+                    Mary does not compete with Christ&rsquo;s unique mediation but exercises a
+                    subordinate intercession that flows entirely from his.
+                  </p>
+                  <p className="text-amber-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Trust in Mary&rsquo;s intercession</strong>
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: LUMINOUS MYSTERIES ==================== */}
+        {activeTab === 'luminous-mysteries' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Introduction by JPII */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Moon className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Luminous Mysteries (Mysteries of Light)</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Luminous Mysteries are prayed on <strong>Thursdays</strong>. They were added by
+                Pope John Paul II in his apostolic letter <em>Rosarium Virginis Mariae</em>
+                (&sect;&sect;19&ndash;22, October 2002) to fill a gap in the traditional Rosary: the
+                fifteen classic mysteries moved from the Incarnation (Joyful) directly to the
+                Passion (Sorrowful), skipping Christ&rsquo;s entire public ministry. The five Luminous
+                Mysteries fill this gap by covering the key moments of Christ&rsquo;s mission between
+                the Jordan and the Last Supper.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Pope John Paul II on the Luminous Mysteries
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;Each of these mysteries is a revelation of the Kingdom now present in the very
+                  person of Jesus. It is the Luminous Mystery par excellence. Contemplating these
+                  events together with Mary is the means proposed to us for assimilating the wisdom
+                  of Christ.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Rosarium Virginis Mariae</em> &sect;21</p>
+              </div>
+
+              <div className="space-y-6">
+
+                {/* Mystery 1 */}
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                    1. The Baptism in the Jordan
+                    <span className="font-normal text-blue-700"> (Matt 3:13&ndash;17; Mark 1:9&ndash;11)</span>
+                  </h3>
+                  <p className="text-blue-800 mb-3">
+                    Jesus comes to John at the Jordan and is baptized, even though he has no sin.
+                    The heavens open, the Spirit descends as a dove, and the Father&rsquo;s voice
+                    declares: &ldquo;This is my beloved Son, in whom I am well pleased.&rdquo; The Trinitarian
+                    mystery is fully revealed. The Baptism of Christ inaugurates his public ministry
+                    and hallows water as the instrument of our own baptismal rebirth (CCC 1224).
+                  </p>
+                  <p className="text-blue-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Openness to the Holy Spirit</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 2 */}
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                    2. The Wedding at Cana
+                    <span className="font-normal text-blue-700"> (John 2:1&ndash;12)</span>
+                  </h3>
+                  <p className="text-blue-800 mb-3">
+                    At a wedding feast in Cana of Galilee, Mary notices that the wine has run out
+                    and brings the need to Jesus. Despite his initial response, she tells the servants:
+                    &ldquo;Do whatever he tells you&rdquo; &mdash; words that remain the whole content of
+                    Marian spirituality. Jesus turns six stone jars of water into wine &mdash; his
+                    first sign, revealing his glory and prompting his disciples to believe in him
+                    (John 2:11). Mary&rsquo;s role as mediatrix of intercession is here established.
+                  </p>
+                  <p className="text-blue-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Obedience to Christ; trust in Mary&rsquo;s intercession</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 3 */}
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                    3. The Proclamation of the Kingdom
+                    <span className="font-normal text-blue-700"> (Mark 1:14&ndash;15; Luke 4:16&ndash;21)</span>
+                  </h3>
+                  <p className="text-blue-800 mb-3">
+                    Jesus begins his public preaching: &ldquo;The time is fulfilled, and the kingdom of
+                    God is at hand; repent and believe in the Gospel.&rdquo; In Nazareth he reads Isaiah
+                    61 (&ldquo;The Spirit of the Lord is upon me&rdquo;) and declares it fulfilled in
+                    their hearing. The Sermon on the Mount, the Beatitudes, the parables of the
+                    Kingdom, and the call to discipleship all belong to this mystery. It is an
+                    invitation to continual conversion.
+                  </p>
+                  <p className="text-blue-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Repentance and conversion</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 4 */}
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                    4. The Transfiguration
+                    <span className="font-normal text-blue-700"> (Matt 17:1&ndash;8; Mark 9:2&ndash;8)</span>
+                  </h3>
+                  <p className="text-blue-800 mb-3">
+                    Jesus takes Peter, James, and John up Mount Tabor. Before them he is
+                    transfigured &mdash; his face shines like the sun, his garments become dazzling
+                    white. Moses and Elijah appear and speak with him about his coming &ldquo;departure&rdquo;
+                    (exodus) in Jerusalem. A bright cloud overshadows them and the Father&rsquo;s voice
+                    speaks: &ldquo;This is my beloved Son; listen to him.&rdquo; The Transfiguration is a
+                    foretaste of the Resurrection glory, given to strengthen the disciples before
+                    the Passion.
+                  </p>
+                  <p className="text-blue-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Desire for holiness; spiritual transformation</strong>
+                  </p>
+                </div>
+
+                {/* Mystery 5 */}
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-2">
+                    5. The Institution of the Eucharist
+                    <span className="font-normal text-blue-700"> (Matt 26:26&ndash;29; 1 Cor 11:23&ndash;26)</span>
+                  </h3>
+                  <p className="text-blue-800 mb-3">
+                    At the Last Supper, Jesus takes bread, gives thanks, breaks it and gives it
+                    to his disciples: &ldquo;This is my Body.&rdquo; Then the cup: &ldquo;This is my Blood of the
+                    covenant, which is poured out for many for the forgiveness of sins.&rdquo; He commands:
+                    &ldquo;Do this in memory of me.&rdquo; The Eucharist is the culmination of the Luminous
+                    Mysteries and the center of the Christian life (CCC 1324). John Paul II called
+                    this mystery the heart of the Rosary&rsquo;s entire meditation on Christ.
+                  </p>
+                  <p className="text-blue-700 text-sm font-medium">
+                    Fruit of the mystery: <strong>Eucharistic adoration and love</strong>
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: HOW TO PRAY THE ROSARY ==================== */}
+        {activeTab === 'how-to-pray' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Step-by-Step Guide */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">How to Pray the Rosary</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Rosary can be prayed alone or with others, kneeling or walking, at home or
+                in church. You do not need to understand all the theology to begin. The oral prayers
+                create a contemplative rhythm that gradually forms the soul. Pope John Paul II
+                called this rhythm &ldquo;a kind of mantra&rdquo; (<em>Rosarium Virginis Mariae</em> &sect;26)
+                &mdash; not in an Eastern sense but as a sacred repetition that centers the heart on
+                Christ.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-4">
+                  Step-by-Step Guide
+                </h3>
+                <ol className="text-amber-800 space-y-4">
+                  <li>
+                    <strong>1.</strong> Hold the crucifix and pray the <strong>Apostles&rsquo; Creed</strong>.
+                  </li>
+                  <li>
+                    <strong>2.</strong> On the first large bead (nearest the crucifix), pray the <strong>Our Father</strong>.
+                  </li>
+                  <li>
+                    <strong>3.</strong> On the three small beads, pray the <strong>Hail Mary</strong> three times
+                    &mdash; traditionally for faith, hope, and charity, or for the intentions of the Pope.
+                  </li>
+                  <li>
+                    <strong>4.</strong> Pray the <strong>Glory Be</strong>.
+                  </li>
+                  <li>
+                    <strong>5.</strong> <strong>Announce the first mystery</strong> by name, reflect briefly on it,
+                    and pray the <strong>Our Father</strong> on the large bead.
+                  </li>
+                  <li>
+                    <strong>6.</strong> Pray the <strong>Hail Mary</strong> ten times on the ten small beads,
+                    meditating on the announced mystery throughout.
+                  </li>
+                  <li>
+                    <strong>7.</strong> Pray the <strong>Glory Be</strong>, then the <strong>F&aacute;tima Prayer</strong>:
+                    &ldquo;O my Jesus, forgive us our sins, save us from the fires of hell, lead all souls to
+                    heaven, especially those most in need of your mercy.&rdquo;
+                  </li>
+                  <li>
+                    <strong>8.</strong> Repeat steps 5&ndash;7 for each of the remaining four decades,
+                    announcing a new mystery at the beginning of each decade.
+                  </li>
+                  <li>
+                    <strong>9.</strong> After the fifth decade, close with the <strong>Hail Holy Queen</strong>
+                    (<em>Salve Regina</em>).
+                  </li>
+                  <li>
+                    <strong>10.</strong> A closing prayer may be added: &ldquo;O God, whose only-begotten Son...&rdquo;
+                    (traditional concluding collect).
+                  </li>
+                </ol>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Practical Tips
+                </h3>
+                <ul className="text-blue-800 space-y-2 text-sm">
+                  <li>&bull; The Rosary can be prayed while walking, driving, or during quiet moments &mdash; the beads help maintain your place without mental effort.</li>
+                  <li>&bull; A single decade is better than nothing. If time is short, pray one mystery.</li>
+                  <li>&bull; Announce the mystery aloud, even when alone &mdash; it helps the mind remain focused.</li>
+                  <li>&bull; Begin with the set of mysteries assigned to that day; consistency builds the habit.</li>
+                  <li>&bull; Silence after a Hail Mary can be more fruitful than speed through the words.</li>
+                </ul>
+              </div>
+
+            </div>
+
+            {/* Card 2: The Prayers */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Scroll className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Prayers of the Rosary</h2>
+              </div>
+
+              <div className="space-y-6">
+
+                <div className="bg-amber-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                    The Hail Mary <span className="font-normal text-amber-700">(Luke 1:28, 42 + petition)</span>
+                  </h3>
+                  <p className="text-amber-800 mb-3">
+                    Hail Mary, full of grace, the Lord is with thee. Blessed art thou amongst
+                    women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God,
+                    pray for us sinners, now and at the hour of our death. Amen.
+                  </p>
+                  <p className="text-amber-700 text-sm">
+                    The first part is the Angel&rsquo;s greeting (Luke 1:28) and Elizabeth&rsquo;s greeting
+                    (Luke 1:42); the second part is the Church&rsquo;s petition, added over centuries
+                    of liturgical practice.
+                  </p>
+                </div>
+
+                <div className="bg-blue-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                    The Hail Holy Queen (<em>Salve Regina</em>)
+                  </h3>
+                  <p className="text-blue-800 mb-3">
+                    Hail, Holy Queen, Mother of Mercy, hail our life, our sweetness, and our hope.
+                    To thee do we cry, poor banished children of Eve. To thee do we send up our
+                    sighs, mourning and weeping in this valley of tears. Turn then, most gracious
+                    advocate, thine eyes of mercy toward us, and after this our exile, show unto
+                    us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary.
+                  </p>
+                  <p className="text-blue-800 mb-1">
+                    V. Pray for us, O Holy Mother of God.
+                  </p>
+                  <p className="text-blue-800">
+                    R. That we may be made worthy of the promises of Christ.
+                  </p>
+                  <p className="text-blue-700 text-sm mt-3">
+                    Attributed to Herman of Reichenau (c. 1050); one of the oldest and most beloved
+                    Marian antiphons of the Latin Church.
+                  </p>
+                </div>
+
+                <div className="bg-green-50 p-6 rounded-lg">
+                  <h3 className="text-lg font-semibold text-green-900 mb-3">
+                    The F&aacute;tima Prayer (added 1917)
+                  </h3>
+                  <p className="text-green-800 mb-3">
+                    O my Jesus, forgive us our sins, save us from the fires of hell, lead all souls
+                    to heaven, especially those most in need of your mercy.
+                  </p>
+                  <p className="text-green-700 text-sm">
+                    Requested by Our Lady at F&aacute;tima, prayed after the Glory Be at the end of
+                    each decade.
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+            {/* Card 3: Plenary Indulgence */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Users className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Plenary Indulgence</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A <strong>plenary indulgence</strong> (applicable to souls in Purgatory) is granted
+                when the Rosary is prayed under one of the following conditions, together with the
+                usual requirements (sacramental Confession, Eucharistic Communion, and a prayer for
+                the intentions of the Pope):
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <ul className="text-purple-800 space-y-3 text-sm">
+                  <li>
+                    &bull; <strong>In a church or public oratory</strong>, or in a family group, a religious community,
+                    or pious association, when the five decades are prayed continuously with vocal
+                    and mental prayer (meditation on the mysteries).
+                  </li>
+                  <li>
+                    &bull; <strong>Privately</strong>, when the above conditions of vocal prayer and meditation are
+                    fulfilled, and the pray-er is in a state of grace. A <em>partial</em> indulgence
+                    is granted in other circumstances.
+                  </li>
+                </ul>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The indulgence reflects the Church&rsquo;s ancient conviction that the Rosary is one of
+                the most effective prayers available to the faithful &mdash; a conviction rooted in
+                centuries of saints&rsquo; experience and multiple papal endorsements.
+              </p>
+            </div>
+
+            {/* Card 4: JPII Quote + Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sources &amp; Further Reading</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-8">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Pope John Paul II, <em>Rosarium Virginis Mariae</em> &sect;2 (2002)
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;The Rosary of the Virgin Mary, which gradually took form in the second millennium
+                  under the guidance of the Spirit of God, is a prayer loved by countless Saints and
+                  encouraged by the Magisterium. Simple yet profound, it still remains, at the dawn
+                  of this third millennium, a prayer of great significance, destined to bring forth
+                  a harvest of holiness.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; <em>Rosarium Virginis Mariae</em> &sect;2, Pope John Paul II (2002)</p>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">Magisterial &amp; Official</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>Pope John Paul II, <em>Rosarium Virginis Mariae</em> (2002)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;971 (Marian devotion)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;2678 (Hail Mary)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;2708 (meditation)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;2676&ndash;2678 (Marian prayer)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;963&ndash;972 (Mary in the Church)</li>
+                    <li>Vatican II, <em>Lumen Gentium</em>, &sect;&sect;53&ndash;69 (Mary in the mystery of the Church)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Papal Documents on the Rosary</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Pope Leo XIII, <em>Supremi Apostolatus Officio</em> (1883)</li>
+                    <li>Pope Leo XIII, <em>Octobri Mense</em> (1891)</li>
+                    <li>Pope Leo XIII, <em>Laetitiae Sanctae</em> (1893)</li>
+                    <li>Pope Pius XII, <em>Ingruentium Malorum</em> (1951)</li>
+                    <li>Pope Paul VI, <em>Marialis Cultus</em> (1974)</li>
+                    <li>Pope John Paul II, <em>Rosarium Virginis Mariae</em> (2002)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-3">Historical &amp; Devotional Works</h3>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>St. Louis de Montfort, <em>The Secret of the Rosary</em></li>
+                    <li>St. Alphonsus Liguori, <em>The Glories of Mary</em></li>
+                    <li>Edward Sri, <em>The New Rosary in Scripture</em> (Servant Books, 2003)</li>
+                    <li>Antonio Rum&ograve;, <em>A History of the Rosary</em> &mdash; historical scholarship on Alain de la Roche</li>
+                  </ul>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-3">Scripture References</h3>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>Luke 1:26&ndash;56 (Annunciation and Visitation)</li>
+                    <li>Luke 2:1&ndash;52 (Nativity, Presentation, Finding)</li>
+                    <li>Matt 26&ndash;27; John 18&ndash;19 (Passion)</li>
+                    <li>Matt 28; John 20; Acts 1&ndash;2 (Resurrection, Ascension, Pentecost)</li>
+                    <li>Rev 12:1 (Woman clothed with the sun)</li>
+                    <li>John 2:1&ndash;12; Matt 3:13&ndash;17; Matt 17:1&ndash;8 (Luminous Mysteries)</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== CROSS-LINKS ==================== */}
+        <div className="mt-12 bg-white rounded-lg shadow-lg p-8">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+              <ArrowRight className="w-6 h-6 text-amber-700" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-800">Explore Further</h2>
+          </div>
+          <div className="grid sm:grid-cols-3 gap-4">
+            <Link
+              href="/prayer/marian-devotions"
+              className="block bg-amber-50 hover:bg-amber-100 transition-colors rounded-lg p-5"
+            >
+              <h3 className="font-semibold text-amber-900 mb-1">Marian Devotions</h3>
+              <p className="text-amber-800 text-sm">
+                The broader tradition of Marian devotion in the Catholic Church.
+              </p>
+            </Link>
+            <Link
+              href="/prayer/overview"
+              className="block bg-blue-50 hover:bg-blue-100 transition-colors rounded-lg p-5"
+            >
+              <h3 className="font-semibold text-blue-900 mb-1">What Is Prayer?</h3>
+              <p className="text-blue-800 text-sm">
+                An introduction to Catholic teaching on prayer, contemplation, and the life of faith.
+              </p>
+            </Link>
+            <Link
+              href="/mysteries/public-revelation"
+              className="block bg-green-50 hover:bg-green-100 transition-colors rounded-lg p-5"
+            >
+              <h3 className="font-semibold text-green-900 mb-1">Public Revelation</h3>
+              <p className="text-green-800 text-sm">
+                How God has revealed Himself through Scripture, Tradition, and the Magisterium.
+              </p>
+            </Link>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/prayer/way-of-the-cross/page.tsx
+++ b/src/app/prayer/way-of-the-cross/page.tsx
@@ -1,0 +1,1409 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BookOpen,
+  Heart,
+  Cross,
+  MapPin,
+  ScrollText,
+  Compass,
+  ArrowRight,
+} from 'lucide-react'
+
+type TabId =
+  | 'origin-history'
+  | 'traditional-stations'
+  | 'scriptural-stations'
+  | 'how-to-pray'
+  | 'theology-of-the-cross'
+  | 'carrying-your-cross'
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: 'origin-history', label: 'Origin & History' },
+  { id: 'traditional-stations', label: 'Traditional 14 Stations' },
+  { id: 'scriptural-stations', label: 'The Scriptural Stations' },
+  { id: 'how-to-pray', label: 'How to Pray' },
+  { id: 'theology-of-the-cross', label: 'Theology of the Cross' },
+  { id: 'carrying-your-cross', label: 'Carrying Your Cross' },
+]
+
+export default function WayOfTheCrossPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('origin-history')
+
+  return (
+    <div className="py-8">
+      <div className="container mx-auto px-4">
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-4">
+            Way of the Cross
+          </h1>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            The history, structure, and theology of the Via Crucis &mdash; from the streets of Jerusalem
+            to the churches of the world, tracing Christ&rsquo;s steps from Pilate&rsquo;s court to Calvary.
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex justify-center mb-8">
+          <div className="bg-white rounded-lg shadow-lg p-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-amber-100 text-amber-800 font-semibold'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Content */}
+
+        {/* ==================== TAB 1: ORIGIN & HISTORY ==================== */}
+        {activeTab === 'origin-history' && (
+          <div className="space-y-8">
+
+            {/* Card 1: Pilgrimage to Jerusalem */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <MapPin className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Christian Pilgrimage to Jerusalem</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                From the earliest centuries of the Church, Christians made pilgrimages to the holy sites
+                of the Passion. The route Jesus walked from Pilate&rsquo;s judgment hall to Calvary became
+                the <strong>Via Dolorosa</strong> &mdash; the &ldquo;Way of Suffering&rdquo; &mdash; in
+                Jerusalem. Egeria&rsquo;s <em>Itinerarium</em> (late 4th century) describes processions
+                along this route during Holy Week, with the faithful gathering at sacred sites to hear
+                the Gospel accounts read aloud in the very places where they occurred.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The impulse behind this pilgrimage was not merely archaeological curiosity but a
+                profound desire to pray <em>in loco</em> &mdash; in the actual places where salvation
+                was won. The stones of Jerusalem became sacramental in the minds of early pilgrims:
+                places where the Word made flesh had suffered, wept, and died. Helena, mother of
+                Emperor Constantine, made a famous pilgrimage to Jerusalem around 326 AD and oversaw
+                the identification and veneration of the holy sites, including Golgotha and the Holy
+                Sepulchre. The Church of the Holy Sepulchre, consecrated in 335 AD, became the
+                destination of countless pilgrims from across the known world.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Egeria&rsquo;s Itinerarium (late 4th century)
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  Egeria, a Western pilgrim (possibly a Spanish nun), left one of the most detailed
+                  accounts of liturgical practice in fourth-century Jerusalem. She describes the Holy
+                  Week ceremonies: on Good Friday, the faithful gathered at Golgotha from noon until
+                  three in the afternoon, listening to readings from all the Gospels concerning the
+                  Passion. This communal, site-specific walking and praying of the Passion narrative
+                  is the direct ancestor of the Way of the Cross as it developed in subsequent centuries.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                By the medieval period, the desire to walk in Christ&rsquo;s footsteps had become one of
+                the most powerful forces in Catholic spirituality. Pilgrimage to Jerusalem was the
+                supreme act of devotion &mdash; but it was expensive, dangerous (especially during
+                the Crusades and their aftermath), and impossible for most Christians. The challenge
+                was to find a way to make this transformative journey accessible to ordinary believers
+                who could not travel to the Holy Land.
+              </p>
+            </div>
+
+            {/* Card 2: The Franciscans as Guardians */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Franciscans as Guardians of the Holy Land</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                In 1342, Pope Clement VI entrusted the care of the holy sites in Jerusalem to the
+                Franciscan Order. The Franciscans became the <strong>Custodians of the Holy Land</strong>
+                &mdash; a role they hold to this day. Their presence in Jerusalem gave them an intimate
+                familiarity with the actual route of the Via Dolorosa and a pastoral concern for pilgrims
+                who came to walk it.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                As pilgrimage became increasingly dangerous and expensive &mdash; particularly after
+                the Ottoman conquest of Jerusalem in 1517 &mdash; the Franciscans began promoting
+                &ldquo;spiritual pilgrimages&rdquo;: the practice of praying a structured series of
+                stations in one&rsquo;s local church, meditating on the events of the Passion as if
+                one were physically present in Jerusalem. This democratization of the Passion pilgrimage
+                was one of the most significant acts of pastoral creativity in medieval Catholicism.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Franciscan preachers &mdash; especially St. Leonard of Port Maurice (1676&ndash;1746),
+                who is said to have erected over 500 sets of stations &mdash; became the great apostles
+                of the Way of the Cross throughout Europe. Their mendicant preaching missions invariably
+                included the erection of stations and the teaching of this devotion to ordinary
+                laypeople. St. Francis of Assisi himself had a profound devotion to the Passion of
+                Christ, receiving the stigmata in 1224 &mdash; the wounds of Christ in his own body
+                &mdash; and his order carried this Passion-centered spirituality into every corner
+                of Christendom.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  St. Leonard of Port Maurice
+                </h3>
+                <p className="text-amber-800">
+                  This Franciscan missionary, canonized by Pius IX in 1867, was the greatest promoter
+                  of the Way of the Cross in the 18th century. He erected stations in venues including
+                  the Colosseum in Rome (1749), where the Via Crucis remains a living practice to this
+                  day. Pope John Paul II led the Good Friday Stations of the Cross at the Colosseum
+                  annually throughout his pontificate.
+                </p>
+              </div>
+            </div>
+
+            {/* Card 3: Development of the 14 Stations */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Development of the 14 Stations</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The number of stations was not fixed at 14 from the beginning. Various sets of stations
+                &mdash; 7, 12, 14, and 15 &mdash; were used in different times and places, reflecting
+                different emphases in the Passion narrative and varying pastoral traditions. The
+                seven-station form was common in early Franciscan practice; other traditions used
+                twelve stations corresponding to hours of the day.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The 14-station form was standardized by the Franciscans in the 17th and 18th centuries.
+                The papal history of indulgences attached to the stations reflects the gradual
+                standardization of this form:
+              </p>
+
+              <div className="space-y-3 mb-6">
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <p className="font-semibold text-blue-900">1686 &mdash; Pope Innocent XI</p>
+                  <p className="text-blue-800 text-sm">Approved indulgences for the Franciscan churches
+                  in Jerusalem for those who prayed the stations erected there.</p>
+                </div>
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <p className="font-semibold text-blue-900">1726 &mdash; Pope Benedict XIII</p>
+                  <p className="text-blue-800 text-sm">Extended the indulgences to all churches
+                  with properly erected stations &mdash; a landmark decision that spread the devotion
+                  universally.</p>
+                </div>
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <p className="font-semibold text-blue-900">1731 &mdash; Pope Clement XII</p>
+                  <p className="text-blue-800 text-sm">Confirmed and standardized the earlier grants,
+                  establishing the canonical form of 14 stations with wooden crosses as the basis for
+                  the indulgence &mdash; the form that persists to this day.</p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Art Tradition
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The stations became one of the most important commissions in Catholic church art
+                  &mdash; relief carvings, paintings, frescoes, and stained glass. Great artists
+                  (including followers of El Greco and Caravaggio, and countless anonymous craftsmen)
+                  created station images that both beautified churches and served as visual aids for
+                  the illiterate faithful meditating on the Passion. The <em>Stabat Mater</em>
+                  (&ldquo;The sorrowful mother stood&rdquo;), attributed to Jacopone da Todi (13th
+                  century), became the great medieval hymn accompanying the devotion &mdash; sung
+                  between stations in the communal celebration.
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Many churches, shrines, and retreat centers built outdoor Stations of the Cross
+                &mdash; from the elaborate baroque stations in Bavarian mountain churches to simple
+                wooden crosses in gardens and hillsides. The tradition spread worldwide with Catholic
+                missions: from the Philippines to South America, from sub-Saharan Africa to North
+                America, the Way of the Cross became a universal Catholic practice.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  A Pilgrimage in Miniature
+                </h3>
+                <p className="text-purple-800">
+                  The Way of the Cross combines bodily movement &mdash; walking from station to
+                  station &mdash; with meditation. It is a pilgrimage in miniature. The faithful
+                  literally trace the path of Christ&rsquo;s Passion in their bodies, not just their
+                  minds. This embodied quality &mdash; the procession, the kneeling, the movement
+                  &mdash; distinguishes the Way of the Cross from purely intellectual meditation and
+                  gives it a distinctive sacramental character as prayer involving the whole person.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 2: TRADITIONAL 14 STATIONS ==================== */}
+        {activeTab === 'traditional-stations' && (
+          <div className="space-y-8">
+
+            {/* Intro Card */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Traditional 14 Stations</h2>
+              </div>
+              <p className="text-gray-700 leading-relaxed mb-4">
+                The traditional 14 stations combine events explicitly narrated in the Gospel Passion
+                accounts with events drawn from pious tradition &mdash; particularly the three falls
+                of Jesus under the weight of the cross, and Veronica wiping his face. These traditional
+                stations, while not all directly in Scripture, carry deep theological meaning developed
+                over centuries of meditation on the Passion.
+              </p>
+              <p className="text-gray-700 leading-relaxed">
+                Each station is listed below with its scriptural or traditional basis and a brief
+                note on its theological significance. References cite the NABRE.
+              </p>
+            </div>
+
+            {/* Stations 1-7 */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Stations I &ndash; VII</h2>
+              <div className="space-y-6">
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    I. Jesus is condemned to death
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">Matt 27:24&ndash;26</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Pilate washes his hands; the crowd chooses Barabbas. Jesus is sentenced despite
+                    Pilate finding no guilt in him. The condemnation of the innocent by human authority
+                    fulfills the Servant Songs of Isaiah and reveals the depth of human injustice that
+                    the Son of God chose to enter and redeem.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    II. Jesus takes up the Cross
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">John 19:17</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    &ldquo;Carrying the cross by himself, he went out to what is called The Place of the
+                    Skull.&rdquo; The weight of the world&rsquo;s sin borne on the shoulders of the Lamb.
+                    John&rsquo;s account does not mention Simon of Cyrene &mdash; perhaps a deliberate
+                    theological emphasis on Christ carrying his own cross as the new Isaac carrying
+                    the wood for his own sacrifice (cf. Gen 22:6).
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-300 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    III. Jesus falls the first time
+                  </h3>
+                  <p className="text-sm text-gray-500 font-medium mb-2">Traditional (cf. Isa 53:6)</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Not directly narrated in the Gospels; derived from Isa 53:6 and traditional
+                    accounts of the Via Dolorosa. The physical exhaustion from the scourging, blood
+                    loss, and crown of thorns is medically credible. Spiritually, the three falls of
+                    Jesus mirror the repeated failures of humanity &mdash; and God&rsquo;s patient
+                    willingness to rise again for our sake.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-300 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    IV. Jesus meets his Mother
+                  </h3>
+                  <p className="text-sm text-gray-500 font-medium mb-2">Traditional (cf. John 19:25&ndash;27)</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Not explicitly narrated in the Passion accounts, though John 19:25&ndash;27 places
+                    Mary at Calvary. The meeting along the way is a theological elaboration drawn from
+                    Mary&rsquo;s presence throughout the Passion narrative. Mary the co-sufferer &mdash;
+                    the <em>Mater Dolorosa</em> &mdash; fulfills Simeon&rsquo;s prophecy that a sword
+                    would pierce her own soul (Luke 2:35).
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    V. Simon of Cyrene carries the Cross
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">Luke 23:26; Mark 15:21</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Simon is &ldquo;pressed into service&rdquo; as he comes in from the country. Mark names
+                    his sons Alexander and Rufus &mdash; apparently known to the early Christian community
+                    (cf. Rom 16:13). A model of involuntary discipleship that becomes voluntary: Simon
+                    did not choose to carry the cross, yet in doing so he became the first disciple
+                    literally to take up Christ&rsquo;s cross (cf. Luke 9:23).
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-300 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    VI. Veronica wipes the face of Jesus
+                  </h3>
+                  <p className="text-sm text-gray-500 font-medium mb-2">Traditional</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Not found in the canonical Gospels. The <em>Vera Icon</em> (&ldquo;true image&rdquo;)
+                    &mdash; the cloth bearing Christ&rsquo;s face &mdash; is venerated in St. Peter&rsquo;s
+                    Basilica. The name &ldquo;Veronica&rdquo; may itself be a folk etymology from
+                    <em>vera icon</em>. Theologically, the station meditates on the human desire to
+                    see the face of Christ (Ps 27:8) and the compassionate act of offering small
+                    comforts in the face of great suffering.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-300 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    VII. Jesus falls the second time
+                  </h3>
+                  <p className="text-sm text-gray-500 font-medium mb-2">Traditional</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Traditional; from the weight of the cross and continuing physical deterioration.
+                    The second fall deepens the meditation on Christ&rsquo;s complete embrace of human
+                    weakness &mdash; the all-powerful God choosing to be utterly powerless, that no
+                    human being might ever feel that their weakness places them beyond Christ&rsquo;s
+                    understanding.
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+            {/* Stations 8-14 */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">Stations VIII &ndash; XIV</h2>
+              <div className="space-y-6">
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    VIII. Jesus meets the women of Jerusalem
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">Luke 23:27&ndash;31</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    &ldquo;Daughters of Jerusalem, do not weep for me, weep for yourselves and for your
+                    children.&rdquo; A prophetic saying about the coming destruction of Jerusalem in 70 AD
+                    &mdash; Christ&rsquo;s concern, even in his own suffering, is for those around him.
+                    This station invites meditation on how Christ&rsquo;s Passion is always oriented
+                    outward, toward the salvation of others.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-gray-300 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    IX. Jesus falls the third time
+                  </h3>
+                  <p className="text-sm text-gray-500 font-medium mb-2">Traditional</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Traditional; the final near-complete exhaustion before reaching Golgotha. In many
+                    spiritual interpretations the three falls correspond to the three times Peter
+                    denied Christ &mdash; and the three times Christ rose each time, as an answer
+                    to every human failure and denial.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    X. Jesus is stripped of his garments
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">John 19:23&ndash;24; Ps 22:18</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    &ldquo;They divided my clothes among them and cast lots for my garment.&rdquo; The
+                    humiliation and explicit fulfillment of prophecy (Ps 22:18). Catholic spirituality
+                    reads this station as an invitation to detachment &mdash; the stripping of all
+                    that the world values: dignity, reputation, status &mdash; so that the soul
+                    may be clothed with Christ alone.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    XI. Jesus is nailed to the Cross
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">John 19:18; Luke 23:33&ndash;34</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    &ldquo;Father, forgive them, for they know not what they do.&rdquo; The nailing:
+                    archaeological evidence from the Yohanan ben Hagkol ossuary (discovered 1968)
+                    confirms Roman crucifixion practice &mdash; a nail driven through the heel bones.
+                    Even at the moment of greatest agony, Christ prays for his executioners. The first
+                    word from the cross is forgiveness.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    XII. Jesus dies on the Cross
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">John 19:30; Luke 23:46</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    &ldquo;It is finished&rdquo; (<em>Tetelestai</em> &mdash; the debt paid, the mission
+                    accomplished). &ldquo;Father, into your hands I commend my spirit.&rdquo; The curtain
+                    of the Temple torn in two (Matt 27:51) &mdash; the barrier between God and humanity
+                    rent open. The soldier pierces his side and blood and water flow (John 19:34)
+                    &mdash; read by the Fathers as the birth of the Church in Baptism and Eucharist.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    XIII. Jesus is taken down from the Cross
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">John 19:38&ndash;40</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Joseph of Arimathea and Nicodemus &mdash; both secret disciples who emerge at the
+                    moment of Christ&rsquo;s death &mdash; take down the body with reverence. Mary
+                    holds the body of her Son: the <em>Piet&agrave;</em> tradition, made immortal by
+                    Michelangelo. The urgency of burial before sunset (beginning of Sabbath) underscores
+                    the historical concreteness of the Passion.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-amber-400 pl-6">
+                  <h3 className="text-lg font-bold text-gray-800 mb-1">
+                    XIV. Jesus is laid in the tomb
+                  </h3>
+                  <p className="text-sm text-amber-700 font-medium mb-2">John 19:41&ndash;42; Matt 27:60</p>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Joseph&rsquo;s own new tomb in a garden near Golgotha. The great stone sealed.
+                    &ldquo;The Word was made flesh and dwelt among us&rdquo; &mdash; now he lies in
+                    silence, awaiting the dawn of the third day. The sealed tomb is not the end of
+                    the story; it is the penultimate moment before the definitive act of God&rsquo;s
+                    power in the Resurrection.
+                  </p>
+                </div>
+
+              </div>
+            </div>
+
+            {/* Note on 15th station */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  A Note on the 15th Station
+                </h3>
+                <p className="text-green-800">
+                  Some traditions add a 15th station &mdash; <strong>The Resurrection</strong> &mdash;
+                  to complete the Paschal Mystery rather than end in death. This addition has been
+                  encouraged by several popes as a reminder that the Way of the Cross, rightly
+                  understood, leads not to a sealed tomb but to an empty one. The cross is not the
+                  last word; it is the door through which the last word &mdash; &ldquo;He is risen&rdquo;
+                  &mdash; is spoken.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 3: SCRIPTURAL STATIONS ==================== */}
+        {activeTab === 'scriptural-stations' && (
+          <div className="space-y-8">
+
+            {/* Background Card */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Scriptural Stations of the Cross</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                In 1991, Pope John Paul II introduced a new set of 14 stations for the traditional
+                Good Friday <em>Via Crucis</em> at the Colosseum in Rome. All 14 stations are drawn
+                directly from Scripture &mdash; replacing the three falls and Veronica (which are pious
+                traditions, not scriptural) with explicitly biblical moments from the Passion narrative.
+                These are commonly known as the <strong>Scriptural Stations</strong> or
+                <strong>JPII&rsquo;s Via Crucis</strong>.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                JPII&rsquo;s use of the scriptural stations at the Colosseum reflected his commitment
+                to biblical renewal in Catholic devotional life following Vatican II&rsquo;s
+                <em>Dei Verbum</em>. The scriptural stations are also widely used in ecumenical
+                services: because all 14 stations are taken directly from the canonical Gospels,
+                Protestant communities can participate in the devotion more readily than in a form
+                that includes pious traditions not found in Scripture.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Ecumenical Value
+                </h3>
+                <p className="text-blue-800">
+                  JPII&rsquo;s introduction of the scriptural stations was a fruit of the ecumenical
+                  spirit of Vatican II. Protestant and Anglican communities have used these stations
+                  in joint Good Friday services, finding a common Passion narrative in Scripture
+                  alone. The Congregation for Divine Worship (2007) clarified that the traditional
+                  14 stations remain the normative form for indulgences, but the scriptural stations
+                  are fully licit for parish celebrations and personal devotion.
+                </p>
+              </div>
+            </div>
+
+            {/* The 14 Scriptural Stations */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">The 14 Scriptural Stations</h2>
+              <div className="space-y-5">
+
+                {[
+                  {
+                    num: 'I',
+                    title: 'Jesus in the Garden of Gethsemane',
+                    ref: 'Matt 26:36–41',
+                    desc: 'The agony in the garden: “Not my will, but yours, be done.” The scriptural stations begin before the arrest, at the moment of Christ’s supreme act of surrender to the Father’s will. The disciples sleep; Jesus watches and prays — alone in the darkness, sweating blood (Luke 22:44).',
+                  },
+                  {
+                    num: 'II',
+                    title: 'Jesus, betrayed by Judas, is arrested',
+                    ref: 'Mark 14:43–46',
+                    desc: 'Judas identifies Jesus with a kiss — the ultimate betrayal of friendship. Jesus is handed over by one of the Twelve, fulfilling his own prediction. The arrest in the garden mirrors the first disobedience in a garden (Eden); Christ’s obedience in Gethsemane begins to undo what Adam’s disobedience caused.',
+                  },
+                  {
+                    num: 'III',
+                    title: 'Jesus is condemned by the Sanhedrin',
+                    ref: 'Luke 22:66–71',
+                    desc: 'The high priest asks directly: “Are you the Son of God?” Jesus answers: “You say that I am.” The Sanhedrin condemns him for blasphemy — because he tells the truth. The irony is total: the Son of God is condemned for claiming to be who he is.',
+                  },
+                  {
+                    num: 'IV',
+                    title: 'Jesus is denied by Peter',
+                    ref: 'Matt 26:75',
+                    desc: '“And he went out and wept bitterly.” The first pope denies Christ three times — and is broken by it. This station meditates on human weakness, the sorrow of betrayal from within the inner circle, and Christ’s subsequent restoration of Peter (John 21:15–17): “Do you love me?”',
+                  },
+                  {
+                    num: 'V',
+                    title: 'Jesus is judged by Pilate',
+                    ref: 'Mark 15:1–5, 15',
+                    desc: 'Pilate finds no guilt in Jesus but delivers him to be crucified to satisfy the crowd. Political cowardice confronts divine innocence. Pilate’s question “What is truth?” (John 18:38) becomes history’s most ironic question — posed to the one who is the Truth (John 14:6).',
+                  },
+                  {
+                    num: 'VI',
+                    title: 'Jesus is scourged and crowned with thorns',
+                    ref: 'John 19:1–3',
+                    desc: 'The soldiers mock the King of Kings with purple robe and crown of thorns. The scourging — 39 lashes by Roman custom — fulfills Isaiah 53:5: “By his wounds we are healed.” The mockery of royal insignia reveals the paradox at the heart of the Gospel: the true King comes not in power but in suffering.',
+                  },
+                  {
+                    num: 'VII',
+                    title: 'Jesus takes up his cross',
+                    ref: 'John 19:6b, 15b–17',
+                    desc: '“Carrying the cross himself, he went out.” The voluntary acceptance of the instrument of death is itself a theological statement: no one takes Christ’s life from him; he lays it down of his own accord (John 10:18).',
+                  },
+                  {
+                    num: 'VIII',
+                    title: 'Simon of Cyrene helps Jesus carry the cross',
+                    ref: 'Mark 15:20–21',
+                    desc: 'Pressed into service, Simon becomes the first person to literally fulfill the dominical command: “Take up your cross and follow me.” His sons Alexander and Rufus were apparently known to Mark’s community — a detail that gives this station historical specificity and suggests a family whose faith was shaped by their father’s encounter with Christ.',
+                  },
+                  {
+                    num: 'IX',
+                    title: 'Jesus meets the women of Jerusalem',
+                    ref: 'Luke 23:27–31',
+                    desc: '“Daughters of Jerusalem, do not weep for me; weep for yourselves and for your children.” Even on the way to his death, Christ turns prophet, warning of the coming destruction of Jerusalem. His compassion is for others, not himself.',
+                  },
+                  {
+                    num: 'X',
+                    title: 'Jesus is crucified',
+                    ref: 'Luke 23:33–34',
+                    desc: '“Father, forgive them, for they know not what they do.” The first word from the cross is an intercession for his executioners. The crucifixion at “The Skull” (Golgotha/Calvary) is the center of history: the place where God’s love and human sin meet definitively, and love wins.',
+                  },
+                  {
+                    num: 'XI',
+                    title: 'Jesus promises his kingdom to the good thief',
+                    ref: 'Luke 23:39–43',
+                    desc: '“Today you will be with me in Paradise.” The last person converted by the earthly Christ is a condemned criminal. This station, unique to the scriptural form, is a profound meditation on the mercy of God: no one is too far gone, no death-bed conversion too late.',
+                  },
+                  {
+                    num: 'XII',
+                    title: 'Jesus speaks to his mother and the beloved disciple',
+                    ref: 'John 19:25–27',
+                    desc: '“Woman, behold your son… Behold your mother.” From the cross, Jesus entrusts Mary to John and John to Mary. Catholic tradition reads this as the spiritual motherhood of Mary over all the disciples — the Church is born at the foot of the cross.',
+                  },
+                  {
+                    num: 'XIII',
+                    title: 'Jesus dies on the cross',
+                    ref: 'Luke 23:44–46',
+                    desc: '“Father, into your hands I commend my spirit.” The darkness over the land, the tearing of the Temple curtain, the final commendation of his spirit to the Father: Jesus dies as he lived — in total trust and surrender to God. “It is finished” (John 19:30): the redemption is accomplished.',
+                  },
+                  {
+                    num: 'XIV',
+                    title: 'Jesus is laid in the tomb',
+                    ref: 'Matt 27:57–60',
+                    desc: 'Joseph of Arimathea, a disciple, buries Jesus in his own new tomb. The stone is rolled to the door. Silence. The disciples are scattered and afraid. But the silence of Holy Saturday is not emptiness — it is the silence before the most world-shaking event in history.',
+                  },
+                ].map((station) => (
+                  <div key={station.num} className="border-l-4 border-amber-400 pl-6">
+                    <h3 className="text-base font-bold text-gray-800 mb-1">
+                      {station.num}. {station.title}
+                    </h3>
+                    <p className="text-sm text-amber-700 font-medium mb-2">{station.ref}</p>
+                    <p className="text-gray-700 text-sm leading-relaxed">{station.desc}</p>
+                  </div>
+                ))}
+
+              </div>
+            </div>
+
+            {/* Comparison Card */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Comparing the Two Forms</h2>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">Traditional Stations</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li>Includes three falls (devotionally rich tradition)</li>
+                    <li>Includes Veronica (theologically significant &mdash; the <em>vera icon</em>)</li>
+                    <li>The canonical form for the plenary indulgence</li>
+                    <li>Reflects 700+ years of Catholic Passion piety</li>
+                    <li>Includes meeting of Jesus and Mary</li>
+                  </ul>
+                </div>
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Scriptural Stations (JPII)</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>All 14 stations from the canonical Gospels</li>
+                    <li>Includes Gethsemane, Judas&rsquo; betrayal, Peter&rsquo;s denial</li>
+                    <li>Includes the good thief and John 19:25&ndash;27</li>
+                    <li>Ideal for ecumenical settings</li>
+                    <li>Reflects post-Vatican II biblical renewal</li>
+                  </ul>
+                </div>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                Both forms are fully licit and spiritually fruitful. The traditional stations carry
+                the weight of centuries of Catholic Passion piety; the scriptural stations bring the
+                faithful into direct contact with the Gospel texts. Many spiritual directors recommend
+                alternating between the two forms during Lent, allowing each to illuminate different
+                dimensions of the Passion.
+              </p>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 4: HOW TO PRAY ==================== */}
+        {activeTab === 'how-to-pray' && (
+          <div className="space-y-8">
+
+            {/* Basic Structure */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Basic Structure</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Way of the Cross has no single mandatory form: it is a structured meditation rather
+                than a liturgical rite requiring exact prescribed texts. What is essential is movement
+                from station to station with prayerful attention to Christ&rsquo;s Passion. The following
+                describes the most common form used in Catholic parishes.
+              </p>
+
+              <div className="space-y-4 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">1. Opening</h3>
+                  <p className="text-amber-800 text-sm">
+                    Begin at the first station with an act of contrition or a brief prayer expressing
+                    the intention: to meditate on Christ&rsquo;s Passion for the remission of sins
+                    and the salvation of souls. The leader may begin with the Sign of the Cross and
+                    a short prayer inviting the Holy Spirit to open the heart to the mystery of
+                    Christ&rsquo;s suffering.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">2. At Each Station</h3>
+                  <p className="text-amber-800 text-sm">
+                    The leader announces: &ldquo;The [N]th Station: [Title].&rdquo; A brief Scripture
+                    passage or meditation text is read. A moment of silence is observed. The traditional
+                    versicle and response is prayed: <em>&ldquo;We adore you, O Christ, and we praise
+                    you. Because by your holy cross you have redeemed the world.&rdquo;</em> A short
+                    prayer concludes the station.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">3. Between Stations</h3>
+                  <p className="text-amber-800 text-sm">
+                    The congregation moves to the next station. The <em>Stabat Mater</em> or another
+                    Passion hymn may be sung between stations &mdash; one verse or stanza between
+                    each. In silent individual prayer, the movement itself is the prayer: walking
+                    slowly, holding the intention.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">4. Closing</h3>
+                  <p className="text-amber-800 text-sm">
+                    After the 14th station, a closing prayer is offered. Many forms include a brief
+                    meditation on the Resurrection, reminding the faithful that the Way of the Cross
+                    leads to Easter. A final blessing may be given if led by a priest or deacon.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-purple-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The Traditional Versicle
+                </h3>
+                <p className="text-purple-800 italic text-center text-lg mb-2">
+                  &ldquo;We adore you, O Christ, and we praise you.&rdquo;
+                </p>
+                <p className="text-purple-700 italic text-center text-lg">
+                  &ldquo;Because by your holy cross you have redeemed the world.&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* Individual Prayer */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Individual & Communal Prayer</h2>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-6 mb-6">
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Individual Prayer</h3>
+                  <p className="text-blue-800 text-sm leading-relaxed">
+                    One can walk the stations alone in a church, kneeling briefly at each one. A
+                    prayer booklet guides the meditation &mdash; many approved booklets exist, including
+                    those written by St. Alphonsus Liguori, Cardinal Newman, and Pope John Paul II.
+                    Individual prayer allows a deeper, more personal pace: one may spend five minutes
+                    at a station that particularly speaks to one&rsquo;s own life.
+                  </p>
+                </div>
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-3">Communal Prayer</h3>
+                  <p className="text-green-800 text-sm leading-relaxed">
+                    Led by a priest, deacon, or lay leader. Popular in parishes on the Fridays of
+                    Lent, especially Good Friday. Groups in many cultures walk outdoor stations
+                    carrying a cross &mdash; the Filipino <em>Visita Iglesia</em>, the Latin American
+                    Via Crucis procession, and the Rome Colosseum stations led by the Pope all
+                    demonstrate the universality of this communal form.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Prayer Books for the Way of the Cross
+                </h3>
+                <ul className="text-amber-800 text-sm space-y-2">
+                  <li><strong>St. Alphonsus Liguori</strong> &mdash; <em>The Way of the Cross</em>: The most widely used traditional booklet; rich in acts of contrition and love at each station.</li>
+                  <li><strong>Cardinal Newman</strong> &mdash; <em>Meditations on the Stations of the Cross</em>: Theologically deep; recommended for those who want extended meditation.</li>
+                  <li><strong>Pope John Paul II</strong> &mdash; <em>Via Crucis al Colosseo</em>: The scriptural stations with JPII&rsquo;s own meditations; available in multiple languages.</li>
+                  <li><strong>Pope Francis</strong> &mdash; has written several Good Friday Via Crucis meditations for the Colosseum; often centered on contemporary themes of suffering and mercy.</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Indulgences */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Plenary Indulgence</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                A plenary indulgence is granted for piously walking the Way of the Cross. The
+                <em>Enchiridion Indulgentiarum</em> (the Church&rsquo;s official handbook of indulgences)
+                sets out the conditions:
+              </p>
+
+              <div className="space-y-3 mb-6">
+                {[
+                  { num: '1', text: 'Meditate prayerfully on the Passion and death of Christ while moving from station to station.' },
+                  { num: '2', text: 'Move from station to station in the prescribed order. If physically unable to move, one can gain a partial indulgence by meditating for at least half an hour on the Passion.' },
+                  { num: '3', text: 'The stations must be legitimately erected — 14 crosses (with images optional) installed in a church or oratory with proper ecclesiastical approval.' },
+                  { num: '4', text: 'Be in the state of grace (free from mortal sin).' },
+                  { num: '5', text: 'Receive sacramental Confession within 20 days before or after.' },
+                  { num: '6', text: 'Receive Holy Communion (Eucharist).' },
+                  { num: '7', text: 'Pray for the intentions of the Holy Father.' },
+                ].map((item) => (
+                  <div key={item.num} className="flex gap-3 bg-amber-50 p-4 rounded-lg">
+                    <span className="w-7 h-7 bg-amber-700 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
+                      {item.num}
+                    </span>
+                    <p className="text-amber-800 text-sm">{item.text}</p>
+                  </div>
+                ))}
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Way of the Cross can take as little as 15 minutes or as long as 2 hours depending
+                on the depth of meditation chosen. There is no required format &mdash; what matters
+                is prayerful attention to the suffering of Christ and a willingness to allow his
+                Passion to speak to one&rsquo;s own life.
+              </p>
+            </div>
+
+            {/* Stations in Lent */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Way of the Cross in Lent</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Friday is the traditional day of penance in the Church &mdash; the day of the
+                crucifixion. During Lent, many parishes offer communal Stations of the Cross every
+                Friday evening, often followed by Benediction of the Blessed Sacrament. It is one
+                of the primary ways Catholics enter into the Lenten season of penance and preparation.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Rome&rsquo;s Colosseum stations on Good Friday &mdash; led annually by the Pope &mdash;
+                are a global event, broadcast and watched by millions worldwide. Many pilgrimage
+                sites (F&aacute;tima, Lourdes, Czestochowa) feature prominent outdoor Stations of
+                the Cross, some set in dramatic natural landscapes, integrating the mystery of the
+                Passion with creation.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  Flexibility of Format
+                </h3>
+                <p className="text-amber-800">
+                  The Way of the Cross can be prayed in 15 minutes or 2 hours. It can be led by a
+                  priest at the altar rail, or walked alone in an empty church on a Tuesday afternoon.
+                  It can be prayed as a family around printed images, or on a mountainside shrine in
+                  Bavaria. The essential element is not the format but the intention: to accompany
+                  Christ on the way of his Passion, and to allow his love to transform the one who
+                  prays.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 5: THEOLOGY OF THE CROSS ==================== */}
+        {activeTab === 'theology-of-the-cross' && (
+          <div className="space-y-8">
+
+            {/* The Paschal Mystery */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Paschal Mystery</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Way of the Cross immerses the faithful in the central mystery of the Christian
+                faith: the Paschal Mystery &mdash; Christ&rsquo;s suffering, death, and resurrection
+                as the one act of redemption. The <em>Catechism of the Catholic Church</em> states
+                plainly: &ldquo;The Paschal mystery of Christ&rsquo;s cross and Resurrection stands
+                at the center of the Good News that the apostles, and the Church following them,
+                are to proclaim to the world&rdquo; (CCC 571).
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  CCC 571&ndash;630: The Paschal Mystery
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;The Paschal mystery of Christ&rsquo;s cross and Resurrection stands at the
+                  center of the Good News that the apostles, and the Church following them, are to
+                  proclaim to the world. God&rsquo;s saving plan was accomplished &lsquo;once for all&rsquo;
+                  by the redemptive death of his Son Jesus Christ.&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; CCC 571</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed">
+                The cross is not an unfortunate episode in the life of a good teacher; it is the
+                definitive act of God&rsquo;s love, the moment when the eternal Son of God took upon
+                himself the full weight of human sin, suffering, and death, and transformed them
+                from within by his own divine life. The Way of the Cross is not a meditation on
+                tragedy; it is a meditation on how tragedy becomes triumph through love.
+              </p>
+            </div>
+
+            {/* Scandalon and Foolishness */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Scandalon & Foolishness: Paul&rsquo;s Paradox</h2>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <p className="text-blue-800 italic text-lg mb-2">
+                  &ldquo;We preach Christ crucified, a stumbling block to Jews and foolishness to
+                  Gentiles, but to those who are called, both Jews and Greeks, Christ the power of
+                  God and the wisdom of God.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm">&mdash; 1 Cor 1:23&ndash;24</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Paul&rsquo;s great paradox stands at the heart of Christian theology. The cross is a
+                <em>skandalon</em> &mdash; a stumbling block, an offense &mdash; to those who expect
+                a conquering Messiah (the Jewish expectation) or a wise philosopher (the Greek
+                expectation). A God who suffers and dies on a criminal&rsquo;s instrument of execution
+                looks like defeat.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                But Paul inverts the categories: the cross is not failure but the definitive act of
+                divine wisdom and power. God&rsquo;s &ldquo;weakness&rdquo; (1 Cor 1:25) is stronger
+                than human strength; his &ldquo;foolishness&rdquo; is wiser than human wisdom. This
+                inversion &mdash; the last shall be first, the servant the greatest, the condemned
+                the savior &mdash; is the permanent scandal of the Gospel. The Way of the Cross
+                forces the believer to pray this scandal into their bones, to accept that God&rsquo;s
+                logic is not ours.
+              </p>
+            </div>
+
+            {/* Salvifici Doloris */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800"><em>Salvifici Doloris</em> &mdash; JPII on Redemptive Suffering</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                On February 11, 1984, Pope John Paul II issued <em>Salvifici Doloris</em>
+                (&ldquo;On the Christian Meaning of Human Suffering&rdquo;), his major apostolic
+                letter on the theology of suffering. It remains one of the most profound Catholic
+                documents of the 20th century.
+              </p>
+
+              <div className="space-y-4 mb-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">Key Theme 1: The Universal Human Experience</h3>
+                  <p className="text-amber-800 text-sm">
+                    Suffering is universal and irreducibly human. Every person, in every time and
+                    culture, encounters the mystery of suffering &mdash; physical, psychological,
+                    moral, spiritual. JPII refuses to explain suffering away; he faces it directly
+                    as the central problem of human existence.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">Key Theme 2: Christ&rsquo;s Passion as the Definitive Answer</h3>
+                  <p className="text-amber-800 text-sm">
+                    Christ&rsquo;s Passion does not abolish suffering or explain it philosophically;
+                    it transforms it from within. By entering into the worst suffering that humanity
+                    can endure, the Son of God makes it possible for every human suffering to be
+                    joined to his. Suffering has not been destroyed; it has been redeemed.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">Key Theme 3: Completing What Is Lacking in Christ&rsquo;s Afflictions</h3>
+                  <p className="text-amber-800 text-sm">
+                    Col 1:24: &ldquo;I rejoice in my sufferings for your sake, and in my flesh I am
+                    filling up what is lacking in Christ&rsquo;s afflictions.&rdquo; JPII interprets
+                    this not as Christ&rsquo;s redemption being incomplete but as human beings being
+                    called to enter into the mystery of Christ&rsquo;s suffering &mdash; to allow
+                    their own suffering to become salvific for others when united to his.
+                  </p>
+                </div>
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-2">Key Theme 4: The Dignity of Suffering</h3>
+                  <p className="text-amber-800 text-sm">
+                    Suffering united with Christ is not meaningless or wasted. It has salvific value
+                    &mdash; for the one who suffers and for others. This is the foundation of the
+                    Catholic tradition of &ldquo;offering up&rdquo; suffering as prayer, and of the
+                    Church&rsquo;s accompaniment of the sick and dying as a genuine pastoral and
+                    theological mission.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Cross and Eucharist */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-green-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Cross and the Eucharist</h2>
+              </div>
+
+              <div className="bg-green-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-green-900 mb-3">
+                  CCC 1366&ndash;1367
+                </h3>
+                <p className="text-green-800 italic mb-2">
+                  &ldquo;The sacrifice of Christ and the sacrifice of the Eucharist are one single
+                  sacrifice: &lsquo;The victim is one and the same: the same now offers through the
+                  ministry of priests, who then offered himself on the cross; only the manner of
+                  offering is different.&rsquo;&rdquo;
+                </p>
+                <p className="text-green-700 text-sm">&mdash; CCC 1367, quoting the Council of Trent</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The Eucharist makes present the one sacrifice of the cross &mdash; not a repetition
+                but a re-presentation, rendering present again the one event of Calvary across time.
+                The Way of the Cross, prayed in the context of a parish community on a Friday in
+                Lent, leads naturally to the Sunday Mass as its completion: the community that walks
+                the Stations on Friday gathers at the altar on Sunday to receive the Body and Blood
+                of the one who walked to Calvary.
+              </p>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  The Theology of the Wounds
+                </h3>
+                <p className="text-amber-800 mb-3">
+                  The risen Christ retains his wounds (John 20:27 &mdash; Thomas sees the wounds).
+                  Catholic theology reads these glorified wounds as permanent: they are not erased
+                  by the Resurrection but transformed. The wounds of Christ in his risen body become
+                  sources of grace and mercy rather than signs of defeat. &ldquo;By his wounds you
+                  have been healed&rdquo; (1 Pet 2:24; Isa 53:5) &mdash; past tense, accomplished
+                  once for all, yet perpetually efficacious in the glorified body of the Risen Lord.
+                </p>
+              </div>
+
+              <div className="bg-blue-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  Mary&rsquo;s Role: Co-suffering, Not Co-redemption
+                </h3>
+                <p className="text-blue-800">
+                  The term <em>co-redemptrix</em> has been used by many popes and theologians to
+                  describe Mary&rsquo;s role in the Passion &mdash; she co-suffered with Christ, and
+                  Simeon&rsquo;s sword (Luke 2:35) was fulfilled at Calvary. The title has never been
+                  formally defined as dogma; the Church has not prohibited it but has not elevated
+                  it to dogmatic status. What is clear: Mary&rsquo;s role is entirely subordinate to
+                  Christ&rsquo;s. She does not redeem alongside him on equal footing; she participates
+                  in his redemption as its most perfect recipient and cooperator, by God&rsquo;s
+                  gift, not by her own autonomous merit.
+                </p>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+        {/* ==================== TAB 6: CARRYING YOUR CROSS ==================== */}
+        {activeTab === 'carrying-your-cross' && (
+          <div className="space-y-8">
+
+            {/* The Dominical Command */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Cross className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Dominical Command</h2>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <p className="text-amber-800 italic text-lg mb-2">
+                  &ldquo;Then he said to all, &lsquo;If any want to become my followers, let them deny
+                  themselves and take up their cross daily and follow me.&rsquo;&rdquo;
+                </p>
+                <p className="text-amber-700 text-sm">&mdash; Luke 9:23</p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The word &ldquo;daily&rdquo; is crucial and easily overlooked. Jesus is not speaking
+                only of dramatic martyrdom or heroic self-sacrifice. He is describing the ordinary
+                Christian life &mdash; the daily practice of dying to self, renouncing what is
+                contrary to God, and following Christ through the small deaths that constitute a
+                faithful life: patience in annoyance, fidelity in tedium, love in ingratitude.
+              </p>
+
+              <p className="text-gray-700 leading-relaxed">
+                The Way of the Cross, prayed regularly, trains the believer to see their own life
+                through the lens of the Passion. Each station becomes a mirror: not just a historical
+                scene from first-century Jerusalem but a pattern that repeats in every human life
+                that chooses to follow Christ. The Way of the Cross is ultimately not about Jesus;
+                it is about what it means for us to walk the same way.
+              </p>
+            </div>
+
+            {/* Stations as Examination of Conscience */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+                  <Compass className="w-6 h-6 text-blue-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Stations as Examination of Conscience</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Each station corresponds to interior spiritual realities that the honest believer
+                recognizes in their own life. The following is one classic approach, long used in
+                Lenten retreats:
+              </p>
+
+              <div className="space-y-4 mb-6">
+                {[
+                  {
+                    station: 'Jesus condemned',
+                    reflection: 'Times I was unjustly judged, and how I responded. Times I judged others unfairly or condemned without mercy.',
+                  },
+                  {
+                    station: 'Jesus falls',
+                    reflection: 'My own repeated failures — the same sins I confess again and again. God\'s patient willingness to raise me each time, not because I deserve it but because he loves me.',
+                  },
+                  {
+                    station: 'Meeting his Mother',
+                    reflection: 'The role of family in bearing suffering. Those who have walked beside me in my own Via Dolorosa.',
+                  },
+                  {
+                    station: 'Simon of Cyrene',
+                    reflection: 'The unexpected ways God uses others to bear my burdens — and asks me to help others with theirs, even when I didn\'t volunteer.',
+                  },
+                  {
+                    station: 'The women of Jerusalem',
+                    reflection: 'Compassion in the face of suffering. The times I walked past suffering without stopping.',
+                  },
+                  {
+                    station: 'Stripping of garments',
+                    reflection: 'Detachment from dignity, reputation, status. The things I cling to that prevent full surrender to God.',
+                  },
+                  {
+                    station: 'The Crucifixion',
+                    reflection: 'Complete self-gift. What would it mean for me to say, with Christ: "Not my will, but yours"?',
+                  },
+                ].map((item) => (
+                  <div key={item.station} className="bg-blue-50 p-4 rounded-lg">
+                    <p className="font-semibold text-blue-900 mb-1"><em>{item.station}</em></p>
+                    <p className="text-blue-800 text-sm">{item.reflection}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Uniting Suffering with Christ */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <Heart className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Uniting Suffering with Christ</h2>
+              </div>
+
+              <div className="bg-amber-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-amber-900 mb-3">
+                  <em>Salvifici Doloris</em> &sect;19 (JPII, 1984)
+                </h3>
+                <p className="text-amber-800 italic mb-2">
+                  &ldquo;In the Cross of Christ not only is the Redemption accomplished through
+                  suffering, but also human suffering itself has been redeemed.&rdquo;
+                </p>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Suffering united to Christ&rsquo;s is not wasted. It does not disappear into
+                meaninglessness. In the economy of salvation, it has value &mdash; for the person
+                who suffers and for others. This is the foundation of the ancient Catholic practice
+                of &ldquo;offering up&rdquo; pain, illness, frustration, grief: not as a masochistic
+                indulgence but as a deliberate act of union with the crucified Christ, whose own
+                suffering has been shown to be redemptive.
+              </p>
+
+              <div className="bg-blue-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">
+                  <em>Spe Salvi</em> &sect;&sect;37&ndash;40 (Benedict XVI, 2007)
+                </h3>
+                <p className="text-blue-800 italic mb-2">
+                  &ldquo;It is not by sidestepping or fleeing from suffering that we are healed,
+                  but rather by our capacity for accepting it, maturing through it and finding
+                  meaning through union with Christ, who suffered with infinite love.&rdquo;
+                </p>
+                <p className="text-blue-700 text-sm mb-3">&mdash; <em>Spe Salvi</em>, &sect;37</p>
+                <p className="text-blue-800 text-sm">
+                  Benedict draws on the examples of the Ugandan martyrs and Josephine Bakhita
+                  (a Sudanese slave who endured horrific suffering before converting and becoming
+                  a joyful religious) to illustrate how suffering, when accepted and united with
+                  Christ, is transformed by hope. The key is not stoic endurance but the active
+                  love that gives suffering its meaning.
+                </p>
+              </div>
+            </div>
+
+            {/* Stations in Spiritual Direction */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center">
+                  <ScrollText className="w-6 h-6 text-purple-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">The Stations in Spiritual Direction & The Forward Vision</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                Many spiritual directors use the Stations of the Cross as a framework for reviewing
+                a directed retreat or a period of spiritual dryness. The sequence of events mirrors
+                the classic pattern of the soul&rsquo;s journey in mystical theology: surrender (the
+                condemnation and taking up of the cross), repeated falling and rising (the three falls),
+                unexpected help (Simon), compassionate accompaniment (the women and Mary), stripping
+                away of what is false (the garments), and finally complete self-gift at the
+                crucifixion. Each &ldquo;fall&rdquo; in prayer is not defeat but an occasion for
+                divine mercy and a deeper surrender.
+              </p>
+
+              <div className="bg-purple-50 p-6 rounded-lg mb-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">
+                  The Via Crucis and the Resurrection
+                </h3>
+                <p className="text-purple-800">
+                  The Way of the Cross, properly understood, does not end at the tomb. The 14th
+                  station points forward &mdash; the sealed tomb will be opened on the third day.
+                  Every cross borne in union with Christ contains within it the seed of resurrection.
+                  The Christian does not walk the Via Crucis in despair; they walk it in the certain
+                  hope of Easter. The silence of the sealed tomb is not the final word; it is the
+                  pause before the definitive word that God speaks in the Resurrection.
+                </p>
+              </div>
+
+              <div className="grid md:grid-cols-3 gap-4">
+                <a
+                  href="/prayer/divine-mercy"
+                  className="bg-amber-50 p-5 rounded-lg hover:bg-amber-100 transition-colors group"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <Heart className="w-5 h-5 text-amber-700" />
+                    <h3 className="font-semibold text-amber-900">Divine Mercy</h3>
+                  </div>
+                  <p className="text-amber-800 text-sm mb-2">
+                    The mercy flowing from Christ&rsquo;s wounded side &mdash; the completion of
+                    the Cross&rsquo;s message.
+                  </p>
+                  <span className="text-amber-700 text-sm flex items-center gap-1 group-hover:gap-2 transition-all">
+                    Explore <ArrowRight className="w-4 h-4" />
+                  </span>
+                </a>
+                <a
+                  href="/history/resurrection"
+                  className="bg-blue-50 p-5 rounded-lg hover:bg-blue-100 transition-colors group"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <Cross className="w-5 h-5 text-blue-700" />
+                    <h3 className="font-semibold text-blue-900">The Resurrection</h3>
+                  </div>
+                  <p className="text-blue-800 text-sm mb-2">
+                    The Resurrection as history and theology &mdash; where the Via Crucis leads.
+                  </p>
+                  <span className="text-blue-700 text-sm flex items-center gap-1 group-hover:gap-2 transition-all">
+                    Explore <ArrowRight className="w-4 h-4" />
+                  </span>
+                </a>
+                <a
+                  href="/prayer/overview"
+                  className="bg-green-50 p-5 rounded-lg hover:bg-green-100 transition-colors group"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <BookOpen className="w-5 h-5 text-green-700" />
+                    <h3 className="font-semibold text-green-900">What Is Prayer?</h3>
+                  </div>
+                  <p className="text-green-800 text-sm mb-2">
+                    The foundations of Catholic prayer &mdash; how the Way of the Cross fits the
+                    broader tradition.
+                  </p>
+                  <span className="text-green-700 text-sm flex items-center gap-1 group-hover:gap-2 transition-all">
+                    Explore <ArrowRight className="w-4 h-4" />
+                  </span>
+                </a>
+              </div>
+            </div>
+
+            {/* Sources */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-12 h-12 bg-amber-100 rounded-full flex items-center justify-center">
+                  <BookOpen className="w-6 h-6 text-amber-700" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-800">Sources &amp; Further Reading</h2>
+              </div>
+
+              <p className="text-gray-700 leading-relaxed mb-6">
+                The following primary sources and scholarly works underlie this page.
+                Readers who wish to go deeper will find these indispensable.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="bg-amber-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-amber-900 mb-3">Magisterial &amp; Official</h3>
+                  <ul className="text-amber-800 text-sm space-y-2">
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;571&ndash;630 (The Paschal Mystery)</li>
+                    <li><em>Catechism of the Catholic Church</em>, &sect;&sect;1366&ndash;1367 (Eucharist as Sacrifice)</li>
+                    <li><em>Enchiridion Indulgentiarum</em>, 4th ed. (2004) &mdash; Way of the Cross indulgence conditions</li>
+                    <li>Congregation for Divine Worship, note on the Stations of the Cross (2007)</li>
+                    <li>Vatican II, <em>Dei Verbum</em> &mdash; on biblical renewal in devotional life</li>
+                  </ul>
+                </div>
+
+                <div className="bg-blue-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-blue-900 mb-3">Papal Documents</h3>
+                  <ul className="text-blue-800 text-sm space-y-2">
+                    <li>Pope John Paul II, <em>Salvifici Doloris</em> (February 11, 1984) &mdash; On the Christian Meaning of Human Suffering</li>
+                    <li>Pope Benedict XVI, <em>Spe Salvi</em> (November 2007) &sect;&sect;37&ndash;40 &mdash; on suffering and hope</li>
+                    <li>Pope John Paul II, <em>Via Crucis al Colosseo</em> (1991) &mdash; the scriptural stations text</li>
+                    <li>Pope Clement XII, decree confirming stations indulgences (1731)</li>
+                  </ul>
+                </div>
+
+                <div className="bg-purple-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-purple-900 mb-3">Classic Devotional Sources</h3>
+                  <ul className="text-purple-800 text-sm space-y-2">
+                    <li>St. Alphonsus Liguori, <em>The Way of the Cross</em> (18th c.) &mdash; the most widely used traditional booklet</li>
+                    <li>Cardinal John Henry Newman, <em>Meditations on the Stations of the Cross</em></li>
+                    <li>Egeria, <em>Itinerarium</em> (late 4th c.) &mdash; earliest eyewitness account of Jerusalem Passion processions</li>
+                    <li>Jacopone da Todi (attr.), <em>Stabat Mater</em> (13th c.) &mdash; the classic hymn of the stations</li>
+                  </ul>
+                </div>
+
+                <div className="bg-green-50 p-5 rounded-lg">
+                  <h3 className="font-semibold text-green-900 mb-3">Historical &amp; Scholarly</h3>
+                  <ul className="text-green-800 text-sm space-y-2">
+                    <li>Herbert Thurston, SJ, <em>The Stations of the Cross: An Account of Their History and Devotional Purpose</em> (1906) &mdash; the definitive historical study</li>
+                    <li>Raymond E. Brown, SS, <em>The Death of the Messiah</em>, 2 vols. (Anchor Bible Reference Library, 1994) &mdash; comprehensive exegesis of the Passion narratives</li>
+                    <li>John Dominic Crossan & Jonathan L. Reed, <em>Excavating Jesus</em> (2001) &mdash; on the Yohanan crucifixion ossuary and Roman practice</li>
+                    <li>Servus Gieben, OFM Cap., &ldquo;Historical Survey of the Way of the Cross,&rdquo; <em>Laurentianum</em> (1969) &mdash; scholarly history of the stations&rsquo; development</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -102,6 +102,54 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly' as const,
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/prayer/overview`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/prayer/rosary`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/prayer/marian-devotions`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/prayer/divine-mercy`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/prayer/way-of-the-cross`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/prayer/contemplative-prayer`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/prayer/charismatic-renewal`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/prayer/liturgy-of-hours`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
   ]
 
   // Dynamic pages - posts

--- a/src/components/HistoryNavigation.tsx
+++ b/src/components/HistoryNavigation.tsx
@@ -63,6 +63,20 @@ const categories = [
     ],
   },
   {
+    id: 'prayer',
+    label: 'Prayer & Devotion',
+    tabs: [
+      { href: '/prayer/overview', label: 'What Is Prayer?' },
+      { href: '/prayer/rosary', label: 'The Holy Rosary' },
+      { href: '/prayer/marian-devotions', label: 'Marian Devotions' },
+      { href: '/prayer/divine-mercy', label: 'Divine Mercy' },
+      { href: '/prayer/way-of-the-cross', label: 'Way of the Cross' },
+      { href: '/prayer/contemplative-prayer', label: 'Contemplative Prayer' },
+      { href: '/prayer/charismatic-renewal', label: 'Charismatic Renewal' },
+      { href: '/prayer/liturgy-of-hours', label: 'Liturgy of the Hours' },
+    ],
+  },
+  {
     id: 'eschatology',
     label: 'End Times',
     tabs: [


### PR DESCRIPTION
## Summary

- Adds a new top-level navigation category **Prayer & Devotion** (between Bible Commentary and End Times) with 8 full content pages
- Each page has 6 internal tabs with deep, sourced content from the Catechism, papal documents, and saints' writings
- Resolves the pending CCR page item: Catholic Charismatic Renewal is a movement within the Church, not a denomination

## Pages Added

| Route | Title | Notes |
|-------|-------|-------|
| `/prayer/overview` | What Is Prayer? | CCC 2558-2865, 6 forms, 3 expressions, Lord's Prayer |
| `/prayer/rosary` | The Holy Rosary | History, 4 sets of mysteries, how to pray |
| `/prayer/marian-devotions` | Marian Devotions | Angelus, Brown Scapular, Miraculous Medal, Fátima |
| `/prayer/divine-mercy` | Divine Mercy | St. Faustina, image, chaplet, Divine Mercy Sunday |
| `/prayer/way-of-the-cross` | Way of the Cross | History, 14 stations, JPII scriptural stations, theology |
| `/prayer/contemplative-prayer` | Contemplative Prayer | Lectio Divina, Jesus Prayer, Carmelite, Ignatian, CDF cautions |
| `/prayer/charismatic-renewal` | Catholic Charismatic Renewal | Duquesne 1967, CHARIS 2019, 4 papal endorsements |
| `/prayer/liturgy-of-hours` | Liturgy of the Hours | 7 hours, structure, obligation, laity resources |

## Files Changed

- `src/components/HistoryNavigation.tsx` — added `prayer` category with 8 tabs
- `src/app/prayer/layout.tsx` — new layout (same pattern as mysteries)
- `src/app/prayer/*/page.tsx` — 8 new content pages (~9,370 lines total)
- `src/app/sitemap.ts` — 8 new entries

## Test Plan

- [ ] Navigate to any `/prayer/*` route — page loads with correct header and tabs
- [ ] Clicking each tab switches content correctly
- [ ] "Prayer & Devotion" appears in the nav bar between Bible Commentary and End Times
- [ ] All 8 sub-tabs appear in the nav dropdown/list when Prayer & Devotion is active
- [ ] Cross-links between pages work (e.g. Rosary → Marian Devotions, Way of the Cross → Resurrection)
- [ ] `npx tsc --noEmit` passes with zero errors ✅ (verified before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)